### PR TITLE
PR: Only deploy 3.x via doctr for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - "cd doc"
   - "make html"
   - "cd .."
-  - doctr deploy . --no-require-master --built-docs doc/_build/html
+  - "doctr deploy . --no-require-master --built-docs doc/_build/html --branch-whitelist 3.x"
 
 notifications:
   email: false


### PR DESCRIPTION
Setup doctr to only deploy docs from the current 3.x branch for now. Hopefully, we can decide on a longer-term solution soon. Also, test that deployment still works with branch protection.