### PR TITLE
PR: Remove outdated reference to searching Mercurial repos and test branch protection

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -70,7 +70,7 @@ Key features:
   * documentation may be displayed as an html page thanks to the rich text mode (powered by `sphinx`)
 
 * :doc:`onlinehelp`: automatically generated html documentation on installed Python modules
-* :doc:`findinfiles`: find string occurrences in a directory, a mercurial repository or directly in PYTHONPATH (support for regular expressions and  included/excluded string lists)
+* :doc:`findinfiles`: find string occurrences in a directory, a git repository or directly in PYTHONPATH (support for regular expressions and included/excluded string lists)
 * :doc:`fileexplorer`
 * :doc:`projects`
 


### PR DESCRIPTION
Removes an outdated reference to Find in Files being able to search a Mercurial repo, but main purpose is to prompt a redeploy of the docs with ``doctr`` to test stricter branch protection settings and their impact on deploying the docs to github pages.