### PR TITLE
PR: Fix docs still deploying on master due to ambiguous command argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ script:
   - "cd doc"
   - "make html"
   - "cd .."
-  - "doctr deploy . --no-require-master --built-docs doc/_build/html --branch-whitelist 3.x"
+  - "doctr deploy . --built-docs doc/_build/html --branch-whitelist 3.x"
 
 notifications:
   email: false


### PR DESCRIPTION
Thanks to use of an unclearly-document argument, docs were still deploying on master (and presumably other branches) despite not being on the explicit whitelist which should have prevented that. This PR fixes that.

My apologies for the flurry of small PRs; its just been difficult when there isn't a reliable way to test the internal interactions between github, doctr and the code in a PR alone.