### PR TITLE
PR: Remove unnecessary sidebar links

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -191,7 +191,7 @@ html_sidebars = {
     '**': [
         'about.html',
         'navigation.html',
-        'relations.html',
+        #'relations.html',
         'searchbox.html',
         'donate.html',
     ]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -126,15 +126,11 @@ html_theme_options = {
     'travis_button': False,
     'codecov_button': False,
     'extra_nav_links': {
-        'Main Website': 'https://www.spyder-ide.org/',
-        'Download (Anaconda)': 'https://www.anaconda.com/download/',
-        'Spyder Github': 'https://github.com/spyder-ide/spyder',
         'Troubleshooting': ('https://github.com/spyder-ide/spyder/wiki/'
                             + 'Troubleshooting-Guide-and-FAQ'),
         'Dev Wiki': 'https://github.com/spyder-ide/spyder/wiki/Dev:-Index',
         'Gitter Chatroom': 'https://gitter.im/spyder-ide/public',
         'Google Group': 'http://groups.google.com/group/spyderlib',
-        'Donate': 'https://opencollective.com/spyder/'
         },
     'sidebar_collapse': True,
     'show_related': True,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,7 +128,7 @@ html_theme_options = {
     'extra_nav_links': {
         'Troubleshooting': ('https://github.com/spyder-ide/spyder/wiki/'
                             + 'Troubleshooting-Guide-and-FAQ'),
-        'Dev Wiki': 'https://github.com/spyder-ide/spyder/wiki/Dev:-Index',
+        'Wiki': 'https://github.com/spyder-ide/spyder/wiki',
         'Gitter Chatroom': 'https://gitter.im/spyder-ide/public',
         'Google Group': 'http://groups.google.com/group/spyderlib',
         },


### PR DESCRIPTION
The sidebar is currently too crammed. This is my solution to remove unnecessary stuff.

Links removed:

- Main Website: It can be accessed from the top navbar. No need to repeat it.
- Download (Anaconda): Users can go to the Installation section
- Spyder Github: No documentation can be gained by going to it.
- Donate: The Donate button needs to make part of the footer (@dalthviz, please make sure of that).
- Relations: Our docs are pretty flat right now, so I don't see the need of it (it could be reactivated in Spyder 4)-

Links changed:

- Dev Wiki to Wiki: I think it's better to point out our users to our main wiki.