### PR TITLE
PR: Decrease text font-size to 16px

### DIFF
--- a/doc/_static/custom.css
+++ b/doc/_static/custom.css
@@ -4,12 +4,12 @@ cite::before {
 
 cite {
     display: inline;
-    font-size: 16.8px;
+    font-size: 16px;
     color: black;
 }
 
 #doc-content{
-    font-size: 16.8px;
+    font-size: 16px;
 }
 
 .logo {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -146,7 +146,7 @@ html_theme_options = {
     'gray_3': '#EE1C24',
     'font_family': "Raleway, 'Open Sans', Arial, sans-serif",
     'head_font_family': "Raleway, 'Open Sans', Arial, sans-serif",
-    'font_size': '16.8px',
+    'font_size': '16px',
     'link': '#EE1C24',
     'link_hover': '#EE1C24'
     }


### PR DESCRIPTION
I stand corrected again. When using `1.57` for `line-height`, `16px` looks much better than `16.8px`.