### PR TITLE
PR: Make docs URL HTTPS when it wasn't for some reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ your support of the project!
 
 [Download Spyder (with Anaconda)](https://www.anaconda.com/download/)
 
-[Online Documentation](http://docs.spyder-ide.org/)
+[Online Documentation](https://docs.spyder-ide.org/)
 
 [Spyder Github](https://github.com/spyder-ide/spyder)
 


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below



## Description of Changes

<!--- Describe what you've changed and why. --->

For some reason, the URL to our docs site in the readme, https://docs.spyder-ide.org/, wasn't listed as  HTTPS but plain HTTP. This PR fixes that.


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
