### PR TITLE
PR: Add mention of kernel ID number in description of connect to kernel dialog

### DIFF
--- a/doc/ipythonconsole.rst
+++ b/doc/ipythonconsole.rst
@@ -39,6 +39,7 @@ Connect to an external kernel
 To connect to an external kernel,
 
 #. Launch an IPython kernel on the local or remote host if one is not already running.
+
    If using Spyder 3.3.0 or later, you'll need to do so with ``python -m spyder_kernels.console`` (after you've first installed ``spyder-kernels`` on the host with ``<conda/pip> install spyder-kernels``).
    If using a version of Spyder before 3.3.0, ``ipython kernel`` should work to launch the kernel, albeit without certain Spyder-specific features.
 
@@ -54,9 +55,9 @@ To connect to an external kernel,
    As a convenience, kernel ID numbers (e.g. ``20345``) entered in the connection file path field will be expanded to :file:`{jupter_runtime_dir}/kernal-{id}.json` on your local machine.
 
 #. If connecting to a remote kernel over ``ssh``, check the appropriate box and type the full hostname you're connecting to (in the form :file:`{username}@{hostname}:{port-number}`).
-   The port number is the one on which the SSH daemon (``sshd``) is running, typically 22 unless you or your administrator has configured it otherwise.
    Then, enter *either* :file:`{username}` 's password on the remote machine, or your user SSH keyfile (typically :file:`.perm`) (only one is needed to connect), and press :guilabel:`Ok`.
 
+   The port number is the one on which the SSH daemon (``sshd``) is running, typically 22 unless you or your administrator has configured it otherwise.
 
 .. image:: images/console/console_dialog_connect.png
    :align: center

--- a/doc/ipythonconsole.rst
+++ b/doc/ipythonconsole.rst
@@ -51,6 +51,8 @@ To connect to an external kernel,
 #. Browse for or enter the path to the connection file from the previous step.
    If you're connecting to a local kernel, click :guilabel:`Ok` and Spyder should connect to the kernel; if a remote kernel, proceed to the final step.
 
+   As a convenience, kernel ID numbers (e.g. ``20345``) entered in the connection file path field will be expanded to :file:`{jupter_runtime_dir}/kernal-{id}.json` on your local machine.
+
 #. If connecting to a remote kernel over ``ssh``, check the appropriate box and type the full hostname you're connecting to (in the form :file:`{username}@{hostname}:{port-number}`).
    The port number is the one on which the SSH daemon (``sshd``) is running, typically 22 unless you or your administrator has configured it otherwise.
    Then, enter *either* :file:`{username}` 's password on the remote machine, or your user SSH keyfile (typically :file:`.perm`) (only one is needed to connect), and press :guilabel:`Ok`.


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below



## Description of Changes

<!--- Describe what you've changed and why. --->

As suggested by @bcolsen in spyder-ide/spyder#7914 , I've added a mention of the use of the kernel ID in the connect to kernel dialog for the connection field. Also did a bit of minor cleanup/consistency conformance to the line spacing in that lists, to make it easier to follow.


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
