### PR TITLE
PR: Change description of CAM Gerlach

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -2,7 +2,7 @@ The Spyder Doc Contributors are composed of:
 
 * Pierre Raybaut <pierre.raybaut@gmail.com> (Original Spyder author).
 * Carlos Cordoba <ccordoba12@gmail.com> (Current Spyder maintainer).
-* C.A.M. Gerlach <CAM.Gerlach@Gerlach.CAM> (Current docs maintainer).
+* C.A.M. Gerlach <CAM.Gerlach@Gerlach.CAM> (Former docs maintainer).
 * All other developers who have committed to the spyder-docs repository:
   <https://github.com/spyder-ide/spyder-docs/graphs/contributors>
   and contributors to the original documentation in the main spyder repository:

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -2,7 +2,6 @@ The Spyder Doc Contributors are composed of:
 
 * Pierre Raybaut <pierre.raybaut@gmail.com> (Original Spyder author).
 * Carlos Cordoba <ccordoba12@gmail.com> (Current Spyder maintainer).
-* C.A.M. Gerlach <CAM.Gerlach@Gerlach.CAM> (Former docs maintainer).
 * All other developers who have committed to the spyder-docs repository:
   <https://github.com/spyder-ide/spyder-docs/graphs/contributors>
   and contributors to the original documentation in the main spyder repository:


### PR DESCRIPTION
CAM Gerlach is now listed as *former* docs maintainer.
Feel free to add whoever is currently the maintainer.

Fixes #98
