### PR TITLE
PR: Build api docs with sphinx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,10 @@ spyder_crash.log
 *.tmp
 *.temp
 *.bak
+
+spyder/
+spyder-repo/
+
+doc/modules.rst
+doc/spyder*
+doc/api*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,55 @@
 # https://travis-ci.org/spyder-ide/spyder-docs
 
 language: python
+
 dist: bionic
 
-python:
-  - 3.7
+services:
+  - xvfb
 
 # Give doctr our deploy key
 env:
   global:
-    secure: "Kyk5NrwAnxbQoanhqkI/XGMXLzJKaxUiN3j0w1j63r1qJUAntKf9lY7iRupmdc6ZxgoJhtNYFAw+wVGaWQ6aoqWLZOGJ03GX+UVfWNtB+kKhsSWzVxdjxoup/jsRJquIZ2TxSKTNcXSrqIPMQbtTPDFWkmpn8pZR7ply3OBFRQY2ZVAIVkE2pl16rNw/vChfs3QA/duNWFwhRVNr/O5u/Af0Lmm7gjPPfjZOObg/hPLklH7KOMSf0Br0pwBatG1Ld60DQp49piMSsEty0xlGVBs1Dh5y8hd4HIzWOPW9cdd4klSljH37sxyInlOC2crmC3ey64oPwMqgdfGRDz/CCnTOwW0J/UTJLekNx9cN8Sp2RfKk1qcLaVuODUJiKzFQPZw6dC+cypyVtTS6gmS1D1yDaYXNdtTtYjZc9IY4MH6Z2alzJLq0WLyJJcyyG6bG449KVC523kJY/r/klVwq5zyyaP/pXol0zc8rVh6jN9XLJb8N308ZvN6/5bTIY0qUqICT2vZEmPwjpIpJCrpnrLQ6TQWCsk+htEAYHXNUKm1bA+I1gpCGQVfK6YUGF9SERnao71H2/nB9SPgAdK+TmMGApUAHjQGL6e46SQhHC7Ct+TE52nFlM/tzHxMsPFdgyqNKJVsNwwtMcaA5YvpAan+cDi9h++3+CO3hV4ysUgI="
+    - CI="True"
+    - secure: "Kyk5NrwAnxbQoanhqkI/XGMXLzJKaxUiN3j0w1j63r1qJUAntKf9lY7iRupmdc6ZxgoJhtNYFAw+wVGaWQ6aoqWLZOGJ03GX+UVfWNtB+kKhsSWzVxdjxoup/jsRJquIZ2TxSKTNcXSrqIPMQbtTPDFWkmpn8pZR7ply3OBFRQY2ZVAIVkE2pl16rNw/vChfs3QA/duNWFwhRVNr/O5u/Af0Lmm7gjPPfjZOObg/hPLklH7KOMSf0Br0pwBatG1Ld60DQp49piMSsEty0xlGVBs1Dh5y8hd4HIzWOPW9cdd4klSljH37sxyInlOC2crmC3ey64oPwMqgdfGRDz/CCnTOwW0J/UTJLekNx9cN8Sp2RfKk1qcLaVuODUJiKzFQPZw6dC+cypyVtTS6gmS1D1yDaYXNdtTtYjZc9IY4MH6Z2alzJLq0WLyJJcyyG6bG449KVC523kJY/r/klVwq5zyyaP/pXol0zc8rVh6jN9XLJb8N308ZvN6/5bTIY0qUqICT2vZEmPwjpIpJCrpnrLQ6TQWCsk+htEAYHXNUKm1bA+I1gpCGQVfK6YUGF9SERnao71H2/nB9SPgAdK+TmMGApUAHjQGL6e46SQhHC7Ct+TE52nFlM/tzHxMsPFdgyqNKJVsNwwtMcaA5YvpAan+cDi9h++3+CO3hV4ysUgI="
+
+before_install:
+  - sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libegl1-mesa libgl1-mesa-dri
+  # Here we just install Miniconda, which you shouldn't have to change.
+  - wget http://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda3/bin:$PATH
+  - conda update conda -q -y
+  - eval "$(conda shell.bash hook)"
+  - conda activate base
+  - conda info
+  - conda list
 
 install:
-  - pip install -U pip
-  - pip install sphinx doctr
+  # Clone Spyder repo
+  # - git clone https://github.com/spyder-ide/spyder.git spyder-repo
+  - git clone https://github.com/goanpeca/spyder.git spyder-repo
+  - cd spyder-repo
+  - git checkout enh/updates-for-sphinx-parsing
+  - cd ..
+  # Install spyder requirements
+  - conda create -n spyder python=3.6 --file spyder-repo/requirements/conda.txt -q -y -c spyder-ide/label/alpha
+  - conda install -n spyder --file spyder-repo/requirements/tests.txt -q -y -c spyder-ide
+  - conda activate spyder
+  - conda remove spyder-kernels --force -q -y
+  - conda remove python-language-server --force -q -y
+  - xvfb-run --server-args="-screen 0 1024x768x24" -e /dev/stdout --auto-servernum --server-num=1 python spyder-repo/bootstrap.py -- --reset
+  - pip install git+https://github.com/spyder-ide/spyder-kernels.git 
+  - pip install git+https://github.com/palantir/python-language-server.git 
+  - pip install doctr
+  - conda info
+  - conda list
 
 script:
   - set -e
-  - cd doc
-  - touch *.rst
-  - make html
-  - make linkcheck
-  - cd ..
+  - make autodocs
+  - make docs
   - if [[ "${TRAVIS_BRANCH}" == "master" ]]; then
       doctr deploy develop --built-docs doc/_build/html;
     else

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,50 @@
+.PHONY: clean clean-test clean-pyc clean-build docs help
+.DEFAULT_GOAL := help
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+
+autodocs: ## generate Sphinx HTML documentation, including API docs
+	rm -f doc/spyder.*
+	rm -f doc/modules.rst
+	sphinx-apidoc -o doc/ spyder-repo/spyder/ *tests*
+
+docs: ## generate Sphinx HTML documentation, including API docs
+	$(MAKE) -C doc clean
+	$(MAKE) -C doc html
+
+servedocs: doc ## compile the docs watching for changes
+	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C doc html' -R -D .
+
+install: clean ## install the package to the active Python's site-packages
+	python setup.py install
+
+serve: ## serve documents
+	$(BROWSER) doc/_build/html/index.html
+
+check: ## check links
+	$(MAKE) -C doc linkcheck

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,10 +18,153 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+# Standard library imports
+import os
+import sys
+import importlib
 
+# Third party imports
+from qtpy.QtCore import Qt, QCoreApplication
+from qtpy.QtWidgets import QApplication
+from qtpy import QtWebEngineWidgets
+
+# Constants
+HERE = os.path.abspath(os.path.dirname(__file__))
+REPO = os.path.dirname(HERE)
+SPYDER = os.path.join(REPO, "spyder-repo")
+if not os.path.isdir(SPYDER):
+    raise Exception(
+        'To build docs you need to clone the Spyder repo inside "{}"'.format(SPYDER)
+    )
+
+sys.path.insert(0, SPYDER)
+os.environ['RUNNING_SPHINX'] = 'true'
+
+# Conf handling
+with open("modules.rst", "r") as fh:
+    lines = fh.read().split("\n")
+
+if ":orphan:" not in lines[0]:
+    lines.insert(0, ":orphan:")
+    lines.insert(1, "")
+
+    with open("modules.rst", "w") as fh:
+        fh.write("\n".join(lines))
+
+
+# PyQt handling
+QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
+app = QApplication([])
+
+# Mocks and ignores
+autodoc_mock_imports = [
+    "PyQt5.QtWebEngineWidgets.QWebEnginePage",
+    "PyQt5.QtWebEngineWidgets.QWebEngineView",
+] 
+nitpick_ignore = [
+    ("py:class", "DirCreatedEvent"),
+    ("py:class", "DirDeletedEvent"),
+    ("py:class", "DirModifiedEvent"),
+    ("py:class", "DirMovedEvent"),
+    ("py:class", "FileCreatedEvent"),
+    ("py:class", "FileDeletedEvent"),
+    ("py:class", "FileModifiedEvent"),
+    ("py:class", "FileMovedEvent"),
+    ("py:class", "IPython.core.history.HistoryManager"),
+    ("py:class", "PyQt5.QtCore.QAbstractItemModel"),
+    ("py:class", "PyQt5.QtCore.QAbstractTableModel"),
+    ("py:class", "PyQt5.QtCore.QObject"),
+    ("py:class", "PyQt5.QtCore.QSortFilterProxyModel"),
+    ("py:class", "PyQt5.QtCore.QThread"),
+    ("py:class", "PyQt5.QtGui.QStandardItem"),
+    ("py:class", "PyQt5.QtGui.QSyntaxHighlighter"),
+    ("py:class", "PyQt5.QtGui.QTextBlockUserData"),
+    ("py:class", "PyQt5.QtPrintSupport.QPrinter"),
+    ("py:class", "PyQt5.QtWebEngineWidgets.QWebEnginePage"),
+    ("py:class", "PyQt5.QtWebEngineWidgets.QWebEngineView"),
+    ("py:class", "PyQt5.QtWidgets.ExtraSelection"),
+    ("py:class", "PyQt5.QtWidgets.QAction"),
+    ("py:class", "PyQt5.QtWidgets.QApplication"),
+    ("py:class", "PyQt5.QtWidgets.QComboBox"),
+    ("py:class", "PyQt5.QtWidgets.QDialog"),
+    ("py:class", "PyQt5.QtWidgets.QDockWidget"),
+    ("py:class", "PyQt5.QtWidgets.QFileIconProvider"),
+    ("py:class", "PyQt5.QtWidgets.QFrame"),
+    ("py:class", "PyQt5.QtWidgets.QHBoxLayout"),
+    ("py:class", "PyQt5.QtWidgets.QHeaderView"),
+    ("py:class", "PyQt5.QtWidgets.QItemDelegate"),
+    ("py:class", "PyQt5.QtWidgets.QKeySequenceEdit"),
+    ("py:class", "PyQt5.QtWidgets.QLabel"),
+    ("py:class", "PyQt5.QtWidgets.QLineEdit"),
+    ("py:class", "PyQt5.QtWidgets.QListWidget"),
+    ("py:class", "PyQt5.QtWidgets.QMainWindow"),
+    ("py:class", "PyQt5.QtWidgets.QMenu"),
+    ("py:class", "PyQt5.QtWidgets.QMessageBox"),
+    ("py:class", "PyQt5.QtWidgets.QPlainTextEdit"),
+    ("py:class", "PyQt5.QtWidgets.QProxyStyle"),
+    ("py:class", "PyQt5.QtWidgets.QPushButton"),
+    ("py:class", "PyQt5.QtWidgets.QScrollArea"),
+    ("py:class", "PyQt5.QtWidgets.QSplitter"),
+    ("py:class", "PyQt5.QtWidgets.QStyledItemDelegate"),
+    ("py:class", "PyQt5.QtWidgets.QTabBar"),
+    ("py:class", "PyQt5.QtWidgets.QTabWidget"),
+    ("py:class", "PyQt5.QtWidgets.QTableView"),
+    ("py:class", "PyQt5.QtWidgets.QTableWidget"),
+    ("py:class", "PyQt5.QtWidgets.QTextEdit"),
+    ("py:class", "PyQt5.QtWidgets.QToolBar"),
+    ("py:class", "PyQt5.QtWidgets.QToolButton"),
+    ("py:class", "PyQt5.QtWidgets.QTreeView"),
+    ("py:class", "PyQt5.QtWidgets.QTreeWidget"),
+    ("py:class", "PyQt5.QtWidgets.QTreeWidgetItem"),
+    ("py:class", "PyQt5.QtWidgets.QWidget"),
+    ("py:class", "QAction"),
+    ("py:class", "QColor"),
+    ("py:class", "QFileInfo"),
+    ("py:class", "QFont"),
+    ("py:class", "QIcon"),
+    ("py:class", "QIndex"),
+    ("py:class", "QLayout"),
+    ("py:class", "QMainWidget"),
+    ("py:class", "QMenu"),
+    ("py:class", "QModelIndex"),
+    ("py:class", "QObject"),
+    ("py:class", "QShortcut"),
+    ("py:class", "QSize"),
+    ("py:class", "QTextBlock"),
+    ("py:class", "QTextCursor"),
+    ("py:class", "QToolBar"),
+    ("py:class", "QWebEngineView"),
+    ("py:class", "QWidget"),
+    ("py:class", "Qt.ItemFlags"),
+    ("py:class", "QtGui.QBrush"),
+    ("py:class", "QtGui.QColor"),
+    ("py:class", "QtGui.QTextCursor"),
+    ("py:class", "SRE_Pattern"),
+    ("py:class", "callable"),
+    ("py:class", "code.InteractiveConsole"),
+    ("py:class", "collections.abc.MutableSequence"),
+    ("py:class", "configparser.ConfigParser"),
+    ("py:class", "iter"),
+    ("py:class", "iterable"),
+    ("py:class", "jupyter_client.kernelspec.KernelSpec"),
+    ("py:class", "number"),
+    ("py:class", "objbrowser.treeitem.TreeItem"),
+    ("py:class", "object"),
+    ("py:class", "optional"),
+    ("py:class", "pydoc.Doc"),
+    ("py:class", "pygments.lexer.RegexLexer"),
+    ("py:class", "qtconsole.manager.QtKernelManager"),
+    ("py:class", "qtconsole.rich_jupyter_widget.RichJupyterWidget"),
+    ("py:class", "qtpy.QtWidgets.QComboBox"),
+    ("py:class", "qtpy.QtCore.QUrl"),
+    ("py:class", "sequence"),
+    ("py:class", "spyder.plugins.completion.kite.KiteEndpoints"),
+    ("py:class", "spyder_kernels.comms.commbase.CommBase"),
+    ("py:class", "string"),
+    ("py:class", "threading.Thread"),
+    ("py:class", "watchdog.events.FileSystemEventHandler"),
+    ("py:class", "watchdog.utils.BaseThread"),
+]
 
 # -- General configuration ---------------------------------------------------
 
@@ -32,37 +175,40 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    'sphinx.ext.githubpages',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.githubpages",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
-source_encoding = 'utf-8'
+source_encoding = "utf-8"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'Spyder'
+project = "Spyder"
 copyright = " 2018 Spyder Doc Contributors <a href='https://opensource.org/licenses/MIT' target='_blank'>MIT License</a>"
-author = 'The Spyder Doc Contributors'
+author = "The Spyder Doc Contributors"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
 # The short X.Y version.
-version = '3'
+version = "3"
 # The full version, including alpha/beta/rc tags.
-release = '3'
+release = "3"
 
 # The language for content autogenerated by Sphinx. Refer to documentation
 # for a list of supported languages.
@@ -73,41 +219,46 @@ language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
-#today = ''
+# today = ''
 # Else, today_fmt is used as the format for a strftime call.
-#today_fmt = '%B %d, %Y'
+# today_fmt = '%B %d, %Y'
 
 # List of documents that shouldn't be included in the build.
-#unused_docs = []
+# unused_docs = []
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = [
+    "_build",
+    "Thumbs.db",
+    ".DS_Store",
+    "*tests*",
+]
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.
 exclude_trees = []
 
 # The reST default role (used for this markup: `text`) to use for all docs.
-#default_role = None
+# default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-#add_function_parentheses = True
+# add_function_parentheses = True
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
-#add_module_names = True
+# add_module_names = True
 
 # If true, sectionauthor and moduleauthor directives will be shown in the
 # output. They are ignored by default.
-#show_authors = False
+# show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+# modindex_common_prefix = []
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -115,67 +266,69 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = "alabaster"
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    'body_text_align': 'left',
-    'github_banner': False,
-    'travis_button': False,
-    'codecov_button': False,
-    'extra_nav_links': {
-        'Troubleshooting': ('https://github.com/spyder-ide/spyder/wiki/'
-                            + 'Troubleshooting-Guide-and-FAQ'),
-        'Spyder Wiki': 'https://github.com/spyder-ide/spyder/wiki',
-        },
-    'sidebar_collapse': True,
-    'show_related': True,
-    'page_width': '1000px',
-    'sidebar_width': '250px',
-    'fixed_sidebar': False,
-    'gray_1': '#303030',
-    'gray_2': '#EBEBEB',
-    'gray_3': '#EE1C24',
-    'font_family': "Raleway, 'Open Sans', Arial, sans-serif",
-    'head_font_family': "Raleway, 'Open Sans', Arial, sans-serif",
-    'font_size': '16px',
-    'link': '#EE1C24',
-    'link_hover': '#EE1C24'
-    }
+    "body_text_align": "left",
+    "github_banner": False,
+    "travis_button": False,
+    "codecov_button": False,
+    "extra_nav_links": {
+        "Troubleshooting": (
+            "https://github.com/spyder-ide/spyder/wiki/"
+            + "Troubleshooting-Guide-and-FAQ"
+        ),
+        "Spyder Wiki": "https://github.com/spyder-ide/spyder/wiki",
+    },
+    "sidebar_collapse": True,
+    "show_related": True,
+    "page_width": "1000px",
+    "sidebar_width": "250px",
+    "fixed_sidebar": False,
+    "gray_1": "#303030",
+    "gray_2": "#EBEBEB",
+    "gray_3": "#EE1C24",
+    "font_family": "Raleway, 'Open Sans', Arial, sans-serif",
+    "head_font_family": "Raleway, 'Open Sans', Arial, sans-serif",
+    "font_size": "16px",
+    "link": "#EE1C24",
+    "link_hover": "#EE1C24",
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+# html_theme_path = []
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-#html_title = None
+# html_title = None
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
-#html_short_title = None
+# html_short_title = None
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
-#html_logo = 'spyder_bbg.png'
+# html_logo = 'spyder_bbg.png'
 
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = '_static/favicon.ico'
+html_favicon = "_static/favicon.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+# html_last_updated_fmt = '%b %d, %Y'
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.
-#html_use_smartypants = True
+# html_use_smartypants = True
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -186,78 +339,77 @@ html_static_path = ['_static']
 # 'searchbox.html']``.
 #
 html_sidebars = {
-    '**': [
-        'about.html',
-        'navigation.html',
+    "**": [
+        "about.html",
+        "navigation.html",
         #'relations.html',
-        'searchbox.html',
-        'donate.html',
+        "searchbox.html",
+        "donate.html",
     ]
 }
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
-#html_additional_pages = {}
+# html_additional_pages = {}
 
 # If false, no module index is generated.
-#html_use_modindex = True
+# html_use_modindex = True
 
 # If false, no index is generated.
-#html_use_index = True
+# html_use_index = True
 
 # If true, the index is split into individual pages for each letter.
-#html_split_index = False
+# html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+# html_show_sourcelink = True
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the
 # base URL from which the finished HTML is served.
-#html_use_opensearch = ''
+# html_use_opensearch = ''
 
 # If nonempty, this is the file name suffix for HTML files (e.g. ".xhtml").
-#html_file_suffix = ''
+# html_file_suffix = ''
 
 
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'Spyderdoc'
+htmlhelp_basename = "Spyderdoc"
 
 
 # -- Options for LaTeX output ------------------------------------------------
 
 # The paper size ('letter' or 'a4').
-#latex_paper_size = 'letter'
+# latex_paper_size = 'letter'
 
 # The font size ('10pt', '11pt' or '12pt').
-#latex_font_size = '10pt'
+# latex_font_size = '10pt'
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'Spyder.tex', 'Spyder Documentation',
-   author, 'manual'),
+    ("index", "Spyder.tex", "Spyder Documentation", author, "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = None
+# latex_logo = None
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+# latex_use_parts = False
 
 # Additional stuff for the LaTeX preamble.
-#latex_preamble = ''
+# latex_preamble = ''
 
 # Documents to append as an appendix to all manuals.
-#latex_appendices = []
+# latex_appendices = []
 
 # If false, no module index is generated.
-#latex_use_modindex = True
+# latex_use_modindex = True
 
 
 # -- Options for Texinfo output ----------------------------------------------
@@ -266,13 +418,32 @@ latex_documents = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Spyder', 'Spyder Documentation',
-     author, 'Spyder', 'The Scientific Python Development Environment.',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "Spyder",
+        "Spyder Documentation",
+        author,
+        "Spyder",
+        "The Scientific Python Development Environment.",
+        "Miscellaneous",
+    ),
 ]
 
 # If true, show URL addresses after external links.
-#man_show_urls = False
+# man_show_urls = False
 
 
 # -- Extension configuration -------------------------------------------------
+
+# Napoleon settings
+napoleon_google_docstring = False
+napoleon_numpy_docstring = True
+napoleon_include_init_with_doc = False
+napoleon_include_private_with_doc = False
+napoleon_include_special_with_doc = True
+napoleon_use_admonition_for_examples = False
+napoleon_use_admonition_for_notes = False
+napoleon_use_admonition_for_references = False
+napoleon_use_ivar = False
+napoleon_use_param = True
+napoleon_use_rtype = True

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -51,3 +51,4 @@ Contents
     onlinehelp
     historylog
     internalconsole
+    modules.rst


### PR DESCRIPTION
This enables building ALL Spyder modules docs with sphinx-autodoc, assuming that you make a clone of spyder and place it in a folder called `spyder-repo, so

```
spyder-docs/
  doc
  ...
  spyder-repo/
    bootstrap.py
    ...
```

