### PR TITLE
PR: Cleanup a few accumulated formatting issues on rewritten docs

### DIFF
--- a/doc/_static/custom_styles.css
+++ b/doc/_static/custom_styles.css
@@ -27,7 +27,7 @@ div.fasb h3 {
 }
 
 /* Center all images by default */
-.section > img:not([class]) {
+.section > img:not([class]), .section > a > img:not([class]) {
     margin-left: auto;
     margin-right: auto;
     display: block;

--- a/doc/findinfiles.rst
+++ b/doc/findinfiles.rst
@@ -51,7 +51,7 @@ To parse your search string as a `regular expression`_, enable the :guilabel:`.*
 .. image:: images/find_in_files/find-in-files-regex.gif
    :alt: Spyder Find pane showing regular expression search
 
-To exclude certain filenames, extensions or directories from your search, click the :guilabel:`Plus` button to display the advanced options for the pane, and then enter them in the :guilabel:`Exclude` text box. 
+To exclude certain filenames, extensions or directories from your search, click the :guilabel:`Plus` button to display the advanced options for the pane, and then enter them in the :guilabel:`Exclude` text box.
 
 .. image:: images/find_in_files/find-in-files-extensions.gif
    :alt: Spyder Find pane showing search excluding several file-types
@@ -61,9 +61,13 @@ Finally, to change the number of matches displayed, select the :guilabel:`Set ma
 .. image:: images/find_in_files/find-in-files-max-results.png
    :alt: Spyder Find pane showing window with maximum results dialog open
 
+|
 
+
+
+==================
 Related components
-~~~~~~~~~~~~~~~~~~
+==================
 
 * :doc:`editor`
 * :doc:`fileexplorer`

--- a/doc/first-steps-with-spyder.rst
+++ b/doc/first-steps-with-spyder.rst
@@ -5,8 +5,10 @@ First Steps with Spyder
 The videos in this section provide a starting point for new users who have never opened Spyder before.
 You'll get familiar with opening Spyder in different ways, working with the four main panes and customizing the Spyder to your heart's content.
 
+
+
 ===============
-Getting Started
+Getting started
 ===============
 
 Discover the basics of using the Spyder interface and get an introduction to its four main panes, along with a quick look at the others.

--- a/doc/indexpanes.rst
+++ b/doc/indexpanes.rst
@@ -4,7 +4,6 @@ Panes in Depth
 
 .. toctree::
     :maxdepth: 2
-    :glob:
     
     variableexplorer
     help

--- a/doc/indexvideos.rst
+++ b/doc/indexvideos.rst
@@ -4,7 +4,6 @@ Intro Videos
 
 .. toctree::
     :maxdepth: 2
-    :glob:
     
     first-steps-with-spyder
     working-with-spyder

--- a/doc/plots.rst
+++ b/doc/plots.rst
@@ -18,13 +18,12 @@ The figures shown in the Plots pane are those associated with the currently acti
 
 
 ============
-Options Menu
+Options menu
 ============
 
 The options menu in the top right of the :guilabel:`Plots` pane offers several ways to customize how your plots are displayed.
 
 
-~~~~~~~~~~~~~~~~~~~~
 Mute inline plotting
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -35,7 +34,6 @@ If you deactivate this option, figures will display in both the Plots pane and t
    :alt: Spyder's plots pane and console showing plots in the console
 
 
-~~~~~~~~~~~~~~~~~
 Show plot outline
 ~~~~~~~~~~~~~~~~~
 
@@ -45,7 +43,6 @@ The :guilabel:`Show plot outline` option, off by default, shows a thin stroke su
    :alt: Spyder's plots pane showing a plot's outline
 
 
-~~~~~~~~~~~~~~~~~~~
 Fit plots to window
 ~~~~~~~~~~~~~~~~~~~
 
@@ -60,7 +57,7 @@ Disabling it will display plots at their native size, and allow you use the zoom
 
 
 ===============
-Toolbar Options
+Toolbar options
 ===============
 
 The toolbar at the top of the Plots pane provides several useful features that allow you to interact with your figures.

--- a/doc/profiler.rst
+++ b/doc/profiler.rst
@@ -76,7 +76,7 @@ Meanwhile, :guilabel:`Total Time` for ``sleep_wrapper()`` would be 3.66 ms, but 
 
 
 ================
-Profiler Plugins
+Profiler plugins
 ================
 
 There are two additional plugins that you can install to enable other types of profiling in Spyder. 

--- a/doc/variableexplorer.rst
+++ b/doc/variableexplorer.rst
@@ -16,20 +16,19 @@ The Variable Explorer gives you information on the name, size, type and value of
 To modify a scalar variable, like an number, string or boolean, simply double click it in the pane and type its new value.
 
 .. image:: images/variable_explorer/variable-explorer-modifying.gif
-   :alt: Spyder Variable Explorer modifying value of a variable 
+   :alt: Spyder Variable Explorer modifying value of a variable
 
 |
 
 
 
 ==============
-Object Viewers
+Object viewers
 ==============
 
 Spyder's :guilabel:`Variable Explorer` offers built in support for editing lists, strings, dictionaries, NumPy arrays, Pandas DataFrames, Series and more; as well as being able to plot and visualize them with one click.
 
 
-~~~~~~~
 Strings
 ~~~~~~~
 
@@ -40,7 +39,6 @@ When a string variable is longer than forty characters, you can double click it 
    :alt: Variable Explorer text editor, displaying a long string in a window
 
 
-~~~~~~~~~~~~
 Dictionaries
 ~~~~~~~~~~~~
 
@@ -52,7 +50,6 @@ You can double click any of the values to modify them, which will open a new vie
    :alt: Dictionary editor displaying keys and their types, sizes, and values
 
 
-~~~~~
 Lists
 ~~~~~
 
@@ -65,8 +62,7 @@ Just like dictionaries, you can double-click values to edit them.
    :alt: List editor displaying a list, showing one being edited
 
 
-~~~~~~~~~~~~
-Numpy Arrays
+Numpy arrays
 ~~~~~~~~~~~~
 
 Like lists, for Numpy arrays the Variable Explorer shows a preview of their values.
@@ -88,7 +84,6 @@ Clicking the :guilabel:`Resize` button will set it automatically.
    :alt: Array editor with a 2D int array, showing resizing of columns
 
 
-~~~~~~~~~~
 DataFrames
 ~~~~~~~~~~
 
@@ -97,7 +92,7 @@ DataFrames, like Numpy arrays, display in a viewer where you can show or hide "h
 .. image:: images/variable_explorer/variable-explorer-dataframe.png
    :alt: Dataframe editor showing data frame "heatmap"
 
-Additionally, the Variable Explorer in Spyder 4 has MultiIndex support in its DataFrame inspector, including for multi-level and multi-dimensional indices. 
+Additionally, the Variable Explorer in Spyder 4 has MultiIndex support in its DataFrame inspector, including for multi-level and multi-dimensional indices.
 
 
 .. image:: images/variable_explorer/variable-explorer-multi-index.png
@@ -108,10 +103,10 @@ Additionally, the Variable Explorer in Spyder 4 has MultiIndex support in its Da
 
 
 ============
-Options Menu
+Options menu
 ============
 
-The options menu in the top right of the Variable Explorer pane allows you filter the objects shown by a number of different criteria. 
+The options menu in the top right of the Variable Explorer pane allows you filter the objects shown by a number of different criteria.
 
 .. image:: images/variable_explorer/variable-explorer-menu.png
    :alt: Spyder Variable Explorer, with options menu
@@ -127,7 +122,7 @@ It also allows you to display the min and max of Numpy arrays instead of a previ
 
 
 ===============
-Toolbar Buttons
+Toolbar buttons
 ===============
 
 The Variable Explorer's toolbar includes several useful features that affect the entire namespace.
@@ -146,7 +141,7 @@ Finally, there is a button to refresh the Variable Explorer's contents, which wi
 
 
 ======================
-Advanced Functionality
+Advanced functionality
 ======================
 
 The context menu, available by right-clicking any variable, provides numerous additional options to interact with objects of various types.

--- a/doc/working-with-spyder.rst
+++ b/doc/working-with-spyder.rst
@@ -4,6 +4,8 @@ Working with Spyder
 
 In this section, you will learn about Spyder's more advanced functionality, and explore most of the panes. 
 
+
+
 =====================
 Beyond the main panes
 =====================
@@ -20,5 +22,3 @@ Explore how to take advantage of Spyder’s functionality beyond just the four c
 * Quickly navigate within and between files with the Outline pane
 * Search for text or regular expressions across your entire project with the Find pane
 * Discover and explore structured documentation in the Online Help pane
-
-


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below



## Description of Changes

<!--- Describe what you've changed and why. --->

Fixes a few accumulated formatting issues and inconsistencies we've noticed and discussed over the course of the docs project so far that we didn't catch on the first pass. Specifically:

* Two docs that had double h3 headers, 
* A mix of sentence and title case h2 headers
* A missing line break at the end of a section with a photo
* A few h2 headers that didn't have the three line breaks before them
* One "related components" section that was h3, not h2
* A file with a few extra blank lines at the end
* A couple spurious directives in toctrees

I did not, as a rule, eliminate trailing whitespace or compress PNGs (both of which are a consistent issue); I can do that at the end, though in a few instances my editor did the former automatically near lines I have touched.

<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
