### PR TITLE
PR: Make navbar have a similar look to the one on the main website

### DIFF
--- a/doc/_static/custom_styles.css
+++ b/doc/_static/custom_styles.css
@@ -46,3 +46,13 @@ div.fa-globe-americas::before {
 div.fa-user-friends::before {
   color: #f6951f;
 }
+
+.navbar-menu {
+  text-transform: uppercase;
+  font-size: 12px;
+  letter-spacing: 2px;
+}
+
+.navbar-light {
+  box-shadow: 0 0 7px 0 rgba(0, 0, 0, 0.589);
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -134,6 +134,10 @@ html_logo = '_static/spyder_logo.png'
 html_theme_options = {
     "external_links": [
         {
+            "url": "https://www.spyder-ide.org",
+            "name": "Home"
+        },
+        {
             "url": "https://www.spyder-ide.org/blog",
             "name": "Blog"
         }


### PR DESCRIPTION
Things look like this now:

![Selección_043](https://user-images.githubusercontent.com/365293/89486674-32ada480-d769-11ea-9b2e-bc119f75abdd.png)

I didn't go for full compatibility with our main website (i.e. same padding around the navbar entries) because that would break responsiveness.

This depends on https://github.com/spyder-ide/spyder-docs-sphinx-theme/pull/11

Fixes #144.