### PR TITLE
PR: Add icons to Additional Help section of installation guide

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -257,16 +257,35 @@ For more information, please see the `Contributing Guide`_ included with the Spy
 
 
 
+.. rst-class:: blue-32px
+
 ===============
 Additional help
 ===============
 
-* *Run in to a problem installing or running Spyder?* Read our `Troubleshooting Guide and FAQ`_.
-* *Looking for general information about Spyder and its ecosystem?* See our `main website`_.
-* *Need to submit a bug report or feature request?* Check out our `Github repository`_.
-* *Want development-oriented help and information?* Consult our `Github wiki`_.
-* *Have a help request or discussion topic?* Subscribe to our `Google Group`_.
-* *Asking a quick question or want to chat with the dev team?* Stop by our `Gitter chatroom`_.
+.. rst-class:: fasb fa-first-aid
+
+*Run in to a problem installing or running Spyder?* Read our `Troubleshooting Guide and FAQ`_.
+
+.. rst-class:: fasb fa-globe
+
+*Looking for general information about Spyder and its ecosystem?* See our `main website`_.
+
+.. rst-class:: fasb fa-bug
+
+*Need to submit a bug report or feature request?* Check out our `Github repository`_.
+
+.. rst-class:: fasb fa-code
+
+*Want development-oriented help and information?* Consult our `Github wiki`_.
+
+.. rst-class:: fasb fa-mail-bulk
+
+*Have a help request or discussion topic?* Subscribe to our `Google Group`_.
+
+.. rst-class:: fasb fa-comments
+
+*Asking a quick question or want to chat with the dev team?* Stop by our `Gitter chatroom`_.
 
 .. _Troubleshooting Guide and FAQ: https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ
 .. _main website: https://www.spyder-ide.org/


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

Per previous discussion, this adds icons to the Additional Help section of the installation guide. Ideas welcome if you want me to change the colors.


![image](https://user-images.githubusercontent.com/17051931/89496270-aeb2e700-d77f-11ea-86b4-ea4f68913302.png)



<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
