### PR TITLE
PR: Remove Spyder badges from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 *Copyright © 2009–2020 The Spyder Doc Contributors*
 
+
+[![license](https://img.shields.io/pypi/l/spyder.svg)](./LICENSE.txt)
 [![Travis status](https://travis-ci.org/spyder-ide/spyder-docs.svg?branch=master)](https://travis-ci.org/spyder-ide/spyder-docs)
 [![OpenCollective Backers](https://opencollective.com/spyder/backers/badge.svg?color=blue)](#backers)
 [![Join the chat at https://gitter.im/spyder-ide/public](https://badges.gitter.im/spyder-ide/spyder.svg)](https://gitter.im/spyder-ide/public)
+
+
+![Screenshot of documentation index page](./doc/_static/index_screenshot.png)
 
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -2,18 +2,9 @@
 
 *Copyright © 2009–2020 The Spyder Doc Contributors*
 
-
-[![license](https://img.shields.io/pypi/l/spyder.svg)](./LICENSE.txt)
-[![PyPI status](https://img.shields.io/pypi/status/spyder.svg)](https://github.com/spyder-ide/spyder)
-[![pypi version](https://img.shields.io/pypi/v/spyder.svg)](https://pypi.org/project/spyder)
-[![conda version](https://img.shields.io/conda/vn/conda-forge/spyder.svg)](https://www.anaconda.com/download/)
-[![download count](https://img.shields.io/conda/dn/conda-forge/spyder.svg)](https://www.anaconda.com/download/)
 [![Travis status](https://travis-ci.org/spyder-ide/spyder-docs.svg?branch=master)](https://travis-ci.org/spyder-ide/spyder-docs)
 [![OpenCollective Backers](https://opencollective.com/spyder/backers/badge.svg?color=blue)](#backers)
 [![Join the chat at https://gitter.im/spyder-ide/public](https://badges.gitter.im/spyder-ide/spyder.svg)](https://gitter.im/spyder-ide/public)
-
-
-![Screenshot of documentation index page](./doc/_static/index_screenshot.png)
 
 
 ## Overview


### PR DESCRIPTION
My rationale for these changes:

* Since we're going to have several versions of our docs (Spyder 3, 4, etc), I think it makes little sense to have a screenshot for a specific version.
* I also think that since this is a development repo, our Readme should be focused on giving instructions to new contributors on how to get started. And the screenshot doesn't really help with that.
* Finally, about removing most of the Spyder badges, I think they are kind of distracting for new contributors too. Also, in my humble opinion, I think they belong in the Spyder repo, not here.