### PR TITLE
PR: Fix margins for iframes

### DIFF
--- a/doc/_static/custom_styles.css
+++ b/doc/_static/custom_styles.css
@@ -50,6 +50,14 @@ div.fasb h3, div.fabb h3 {
   padding-bottom: 0.3em;
 }
 
+/* Center iframes and adjust their bottom margins */
+iframe {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 1.5rem;
+}
+
 /*** Custom colors for specific FA icons in the index page ***/
 
 div.fa-laptop-code::before {

--- a/doc/_static/custom_styles.css
+++ b/doc/_static/custom_styles.css
@@ -56,6 +56,7 @@ iframe {
   margin-left: auto;
   margin-right: auto;
   margin-bottom: 1.5rem;
+  margin-top: 1.0rem;
 }
 
 /*** Custom colors for specific FA icons in the index page ***/

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -369,7 +369,7 @@ class IframeVideo(Directive):
 
 
 class Youtube(IframeVideo):
-    html = ('<iframe src="http://www.youtube.com/embed/%(video_id)s'
+    html = ('<iframe src="https://www.youtube.com/embed/%(video_id)s'
             '?start=%(start)s" '
             'width="%(width)u" height="%(height)u" frameborder="0" '
             'webkitAllowFullScreen mozallowfullscreen allowfullscreen '


### PR DESCRIPTION
This centers our iframes (i.e. the frames that contain our Youtube videos) and fixes their bottom margin to be the same as the one for our images.