### PR TITLE
PR: Set doctr deploy directory to root per multiversion changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - ci/build.sh
   - make linkcheck
   - if [ "${TRAVIS_BRANCH-}" = "master" ]; then
-      doctr deploy develop --built-docs doc/_build/html;
+      doctr deploy . --built-docs doc/_build/html;
     fi
 
 notifications:


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

## Description of Changes

<!--- Describe what you've changed and why. --->

Doctr was previously deploying `master` to the `develop` subdir of the site, but with the multiversion changes, it needs to deploy to the root.

