### PR TITLE
PR: Check CI variables to properly detect branch when HEAD detached

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ script:
   - set -e
   - ci/build.sh
   - make linkcheck
-  - if [ "${TRAVIS_BRANCH-}" = "master" ]; then
-      doctr deploy . --built-docs doc/_build/html;
-    fi
+  - doctr deploy . --built-docs doc/_build/html
 
 notifications:
   email: false

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -6,8 +6,8 @@ pip3 install sphinx doctr sphinx-panels sphinx-multiversion
 pip3 install git+https://github.com/spyder-ide/spyder-docs-sphinx-theme.git@develop_spyder
 # Needed to build PR previews using Netlify with the different versions of the docs available
 if [ "${CI-}" = "true" ]; then
-    git config --global user.email "you@example.com"
-    git config --global user.name "Your Name"
+    git config --global user.email "spyder.python@gmail.com"
+    git config --global user.name "Spyder-Docs Deploy Bot"
     git config remote.upstream.url >&- || git remote add upstream https://github.com/spyder-ide/spyder-docs.git
     git fetch --all
     git update-ref -m "reset: Update master to latest commit" refs/heads/master upstream/master


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist


## Description of Changes

<!--- Describe what you've changed and why. --->

Fixes the detection of whether we're on a feature/PR branch or a release branch, and consequently the build filtering, output directory and version naming behavior, to work on CIs in detached HEAD mode. Also, several minor improvements:

* Run doctr deploy regardless of branch (it already has its own builtin filtering)
* Use a more recognizable name and email for the git user commiting the deploy to `gh-pages`
* Improve output logging to make empty branches and match patterns more clear
