### PR TITLE
PR: Update copyright dates to 2021 and automatically update in built docs in the future

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2009-2018 Spyder Doc Contributors (see AUTHORS.txt)
+Copyright (c) 2009-2021 Spyder Doc Contributors (see AUTHORS.txt)
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Spyder Docs — Documentation for the Scientific Python Development Environment](./doc/_static/spyder_readme_banner.png)
 
-*Copyright © 2009–2020 The Spyder Doc Contributors*
+*Copyright © 2009–2021 The Spyder Doc Contributors*
 
 
 [![license](https://img.shields.io/pypi/l/spyder.svg)](./LICENSE.txt)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -23,6 +23,7 @@ from docutils.parsers.rst import Directive, directives
 #
 
 # Standard library imports
+import datetime
 import os
 import subprocess
 
@@ -32,6 +33,7 @@ import subprocess
 # Constants
 CI = os.environ.get("CI")
 TRAVIS_BRANCH = os.environ.get("TRAVIS_BRANCH")
+UTC_DATE = datetime.datetime.now(datetime.timezone.utc)
 
 # -- General configuration ---------------------------------------------------
 
@@ -66,7 +68,12 @@ master_doc = "index"
 
 # General information about the project.
 project = "Spyder"
-copyright = " 2021 Spyder Doc Contributors <a href='https://opensource.org/licenses/MIT' target='_blank'>MIT License</a>"
+copyright = (
+    f" 2009-{UTC_DATE.year} Spyder Doc Contributors "
+    "<span class='pipe-red'>|</span> "
+    "<a href='https://opensource.org/licenses/MIT' "
+    "target='_blank'>MIT License</a>"
+    )
 author = "The Spyder Doc Contributors"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Spyder"
-copyright = " 2020 Spyder Doc Contributors <a href='https://opensource.org/licenses/MIT' target='_blank'>MIT License</a>"
+copyright = " 2021 Spyder Doc Contributors <a href='https://opensource.org/licenses/MIT' target='_blank'>MIT License</a>"
 author = "The Spyder Doc Contributors"
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
Co-authored-by: storm-sergey <77465944+storm-sergey@users.noreply.github.com>

<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed



## Description of Changes

<!--- Describe what you've changed and why. --->

Updates the various copyright dates in the README, LICENSE and the `conf.py`, merging in the former two from #219 and #220 respectively (with co-commit credit) and doing so in one appropriately named and described commit, branch and PR. Thanks @storm-sergey for that, we appreciate the reminder.

Also, implements a change in the `conf.py` to automatically update the displayed year in the docs in the future when they are rebuilt (and thus are subject to copyright in that new year), and adds a missing red pipe between the date/author and the license link to match the other entries in the docs footer and the one on our main website.


### Issue(s) Resolved

<!--- Pull requests should typically resolve at least one—preferably only one—
<!--- outstanding issue; create a new one if no relevant issue exists.
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Closes #219 
Closes #220 


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
