### PR TITLE
PR: Uncollapse dropdowns that contain highlighted words (e.g. from search)

### DIFF
--- a/doc/_static/js/custom_scripts.js
+++ b/doc/_static/js/custom_scripts.js
@@ -248,6 +248,16 @@
     };
   };
 
+  // Open all dropdowns that have highlighted words
+  function openHighlightedDropdowns () {
+    var dropdowns = document.getElementsByClassName(dropdownClassName)
+    for (var idx = 0; idx < dropdowns.length; idx++) {
+      if (dropdowns[idx].getElementsByClassName('highlighted').length) {
+        dropdowns[idx].open = true
+      };
+    };
+  };
+
   /* Fire events */
 
   // Initial DOM ready
@@ -274,6 +284,11 @@
     // Start the tour
     if (document.getElementsByClassName('interactive-tour-container').length) {
       startTour()
+    };
+
+    // Open any dropdowns with highlighted words
+    if (document.getElementsByClassName(dropdownClassName).length) {
+      openHighlightedDropdowns()
     };
 
     // Scroll to and open the dropdown direct links


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->
# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed



## Description of Changes

<!--- Describe what you've changed and why. --->

Automatically uncollapses any FAQ questions (or other dropdowns across the pages that use them) that contain the highlighted search term, so it may be more easily found on the page. Previously, when using the site's search function to find a word present on the FAQ page and clicking on the FAQ page in the results, the highlighted term was not visible if it was inside the collapsed FAQ answers. With this PR, any FAQ questions or answers that contain a highlighted term automatically uncollapse themselves when visiting the page.


## Issue(s) Resolved

<!--- Pull requests should typically resolve at least one—preferably only one—
<!--- outstanding issue; create a new one if no relevant issue exists.
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

Fixes #250 


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
