### PR TITLE
PR: Pin Python version on CIs to 3.9 to fix build failures with 3.10

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9'
     - name: Install dependencies
       shell: bash
       run: ./ci/install.sh

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9'
     - name: Install dependencies
       shell: bash
       run: ./ci/install.sh

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9'
     - name: Install dependencies
       shell: bash
       run: ./ci/install.sh

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9'
     - name: Install dependencies
       shell: bash
       run: ./ci/install.sh


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->
# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed



## Description of Changes

<!--- Describe what you've changed and why. --->

Currently, the CI builds are now failing because the Python `3.x` target shifted to 3.10 in the latest runners. Unfortunately, we're pinned to Sphinx 3.x due to Sphinx-Multiverison, which doesn't support Python 3.10. Accordingly, I've pinned the runners to use Python 3.9, which should fix the builds and at least give us a few years to figure out what we want to do.

Discovered in and currently blocking #301 

<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
