### PR TITLE
Update contrib guide link and other minor tweaks to issue/PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,9 +1,12 @@
 <!--- **PLEASE NOTE:** This is the issue tracker for Spyder's documentation, not problems with the Spyder application itself nor general help with Spyder. For that, please see the main Spyder repo: <https://github.com/spyder-ide/spyder> . --->
 
 <!--- Please make sure you fill out this template completely so we can find and fix your issue. Otherwise, it may be closed. Thanks! --->
+
 # Issue Report
 
 ## Issue Description
+
+<!--- Describe the issue you've found with the documentation. --->
 
 
 
@@ -26,10 +29,14 @@
 
 * Is the problem specific to documentation for a particular version of Spyder?
 
+    * [ ] N/A
+    * [ ] Spyder 5 (``master``)
+    * [ ] Spyder 4 (``4.x``)
+    * [ ] Spyder 3 (``3.x``, frozen)
 
 
 * Are you planning on submitting a Github pull request with a suitable change?
 
-
-
-* Anything else you'd like to add?
+    * [ ] Yes
+    * [ ] No
+    * [ ] Maybe so

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,15 @@
 <!--- Before submitting your pull request, --->
 <!--- please complete as much as possible of the following checklist: --->
+
 # Pull Request
 
 ## Pull Request Checklist
 
-* [ ] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
+* [ ] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
 * [ ] Based your PR on the latest version of the correct branch (master or 4.x)
 * [ ] Checked your writing carefully for correct English spelling, grammar, etc
 * [ ] Described your changes and the motivation for them below
 * [ ] Noted what issue(s) this pull request resolves, creating one if needed
-
 
 
 ## Description of Changes
@@ -19,11 +19,12 @@
 
 
 
-## Issue(s) Resolved
+### Issue(s) Resolved
 
-<!--- Pull requests should typically resolve at least one—preferably only one—
-<!--- outstanding issue; create a new one if no relevant issue exists.
-<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->
+<!--- Pull requests should typically resolve at least one—preferably only one— --->
+<!--- outstanding issue; create a new one if no relevant issue exists. --->
+<!--- List the issue(s) below, in the form "Fixes #1234" . One per line. --->
+<!--- However, smaller fixes, maintenance or trivial changes don't need one. --->
 
 Fixes #
 


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->
# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

I noticed, thanks to the note by @JulienPalard in #316 , that the Contributing Guide link in the issue template points to Spyder's version, not the docs-specific one (which was almost certainly a mistake on my part at some point many years ago when I created this repo, copying over our Spyder PR template). [Edit—looks like it was 516bcb10 , resyncing it after I presumably rewrrote the latter].

Here', I've updated it, along with a few other minor changes to the issue and PR template. In the future, we should use the template chooser with a few templates and other options to direct users, and perhaps even with an issue form, but this should fix the immediate issue for now.
