### PR TITLE
PR: Rename Related Components to Related Panes for clarity

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -41,8 +41,8 @@ Must (not), should (not), recommended, suggested, may, and can generally follow 
 * L2 Headings for section heads: Use ========= with overline; 3 blank lines before them
 * L3 headings for subheads: Use ~~~~~~; 2 blank lines
 * L4 Headings for sub-subheads if truly necessary: Use ---------; 1 blank line; keep to a minimum (consider a flatter structure or breaking into multiple files)
-* Related components at the bottom: L2 heading; bullets; try for 2-4 links if included
-* All files with Related components should contain at least one L2 section; if only one, can be entitled Overview
+* Related panes at the bottom: L2 heading; bullets; try for 2-4 links if included
+* All files with ``Related panes`` should contain at least one L2 section; if only one, can be entitled Overview
 * Typically, for files with multiple sections or longer than one page, a summary section of a few lines length is helpful before the first section, summarizing the functionality discussed in the section and its purpose
 * Name of component/topic should be in first sentence, Title Case, bold on first use
 

--- a/doc/panes/debugging.rst
+++ b/doc/panes/debugging.rst
@@ -116,9 +116,9 @@ To avoid showing plots while debugging, deactivate the :guilabel:`Process execut
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`editor`
 * :doc:`ipythonconsole`

--- a/doc/panes/editor.rst
+++ b/doc/panes/editor.rst
@@ -49,9 +49,9 @@ Note that this only affects how the outline is displayed; it has no impact on th
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`fileexplorer`
 * :doc:`findinfiles`

--- a/doc/panes/fileexplorer.rst
+++ b/doc/panes/fileexplorer.rst
@@ -94,9 +94,9 @@ Additionally, when you right-click a file, you will find an :guilabel:`Open with
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`editor`
 * :doc:`findinfiles`

--- a/doc/panes/findinfiles.rst
+++ b/doc/panes/findinfiles.rst
@@ -60,9 +60,9 @@ Finally, to change the number of matches displayed, select the :guilabel:`Set ma
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`editor`
 * :doc:`fileexplorer`

--- a/doc/panes/help.rst
+++ b/doc/panes/help.rst
@@ -74,9 +74,9 @@ This can be disabled in the :guilabel:`Help` pane's top-right options menu so th
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`editor`
 * :doc:`ipythonconsole`

--- a/doc/panes/historylog.rst
+++ b/doc/panes/historylog.rst
@@ -46,8 +46,8 @@ While there is currently no built-in way to clear history from the Spyder interf
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`ipythonconsole`

--- a/doc/panes/ipythonconsole.rst
+++ b/doc/panes/ipythonconsole.rst
@@ -180,9 +180,9 @@ If desired, you can turn it on or off, and prevent specific modules from being r
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`debugging`
 * :doc:`editor`

--- a/doc/panes/onlinehelp.rst
+++ b/doc/panes/onlinehelp.rst
@@ -81,8 +81,8 @@ To cancel searching or page loading, click the stop button (red square), and to 
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`help`

--- a/doc/panes/plots.rst
+++ b/doc/panes/plots.rst
@@ -80,9 +80,9 @@ Finally, you can use the "remove" and "remove all" buttons in the toolbar to cle
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`ipythonconsole`
 * :doc:`variableexplorer`

--- a/doc/panes/profiler.rst
+++ b/doc/panes/profiler.rst
@@ -94,9 +94,9 @@ For more information, go to the `spyder-memory-profiler git repository`_.
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`ipythonconsole`
 * :doc:`pylint`

--- a/doc/panes/projects.rst
+++ b/doc/panes/projects.rst
@@ -57,9 +57,9 @@ To use this functionality, the :guilabel:`Project` must be located in a ``git`` 
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`editor`
 * :doc:`fileexplorer`

--- a/doc/panes/pylint.rst
+++ b/doc/panes/pylint.rst
@@ -86,9 +86,9 @@ For more details on configuring Pylint, see the `Pylint documentation`_.
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`editor`
 * :doc:`profiler`

--- a/doc/panes/variableexplorer.rst
+++ b/doc/panes/variableexplorer.rst
@@ -181,9 +181,9 @@ Finally, we added a context-menu action to open any object using the new Object 
 
 
 
-==================
-Related components
-==================
+=============
+Related panes
+=============
 
 * :doc:`debugging`
 * :doc:`ipythonconsole`


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

As originally noticed on #322 , the choice of name in the standard "Related components" heading is not ideal—"Related panes" is more clear and specific, shorter, and avoids confusion with any other use of components within the section titles, e.g. as on #322 . Therefore, we should change it. I've updated the style guide accordingly.


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
