### PR TITLE
Re-instate documentation for lineprofiler and notebook plugins

### DIFF
--- a/doc/plugins/index.rst
+++ b/doc/plugins/index.rst
@@ -5,4 +5,5 @@ Spyder Plugins
 .. toctree::
     :maxdepth: 2
 
+    lineprofiler
     terminal

--- a/doc/plugins/index.rst
+++ b/doc/plugins/index.rst
@@ -4,6 +4,6 @@ Spyder Plugins
 
 .. toctree::
     :maxdepth: 2
+    :glob:
 
-    lineprofiler
-    terminal
+    *

--- a/doc/plugins/lineprofiler.rst
+++ b/doc/plugins/lineprofiler.rst
@@ -1,14 +1,6 @@
-:orphan:
-
 ####################
 Spyder Line Profiler
 ####################
-
-.. warning::
-
-   Currently, this plugin is still being ported to Spyder 5, and will likely not yet work or experience serious issues on this version of Spyder.
-   A compatible version will be released soon.
-   Thanks for your patience!
 
 **Spyder-Line-Profiler** is a plugin to run the Python `line profiler`_.
 This package profiles the time that individual lines of code take to execute.

--- a/doc/plugins/notebook.rst
+++ b/doc/plugins/notebook.rst
@@ -1,14 +1,6 @@
-:orphan:
-
 ###############
 Spyder Notebook
 ###############
-
-.. warning::
-
-   Currently, this plugin is still being ported to Spyder 5, and will likely not yet work or experience serious issues on this version of Spyder.
-   A compatible version is expected soon.
-   Thanks for your patience!
 
 **Spyder-notebook** is a plugin that allows you to open, edit and interact with Jupyter Notebooks right inside Spyder.
 


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

Remove the warning in the documentation for the `spyder-lineprofiler` and `spyder-notebook` plugins that they are incompatible with Spyder 5, because this is no longer the case. Also include them both under "Plugins" in the left sidebar.

This reverts PRs #283 and #305.


### Issue(s) Resolved

<!--- Pull requests should typically resolve at least one—preferably only one— --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line. --->
<!--- However, smaller fixes, maintenance or trivial changes don't need one. --->

Fixes #324


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
