### PR TITLE
Add latest Spyder version in Anaconda to update command

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -240,7 +240,7 @@ In your system terminal (or Anaconda Prompt if on Windows), run:
 .. code-block:: shell
 
    conda update anaconda
-   conda install spyder
+   conda install spyder=5.3.3
 
 .. note::
 


### PR DESCRIPTION
* Otherwise the update process as currently described does nothing because conda simply prints that Spyder is already installed.
* Using a specific version prevents conda from updating the entire environment, which is what happens when you run `conda update spyder`. Instead, this makes conda only update Spyder to the requested version.
* I understand that this would require us to update this command from time to time, but Anaconda takes now from three to six months to update Spyder, so I don't think that's a big issue.
* I noticed this when updating one of our bot messages to close a recurrent bug that shows up in the Spyder version that comes with Anaconda 2022.05. My idea was to point to our docs instead so that more users learn about them.