### PR TITLE
Install Guide: Update latest available Anaconda version

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -240,7 +240,7 @@ In your system terminal (or Anaconda Prompt if on Windows), run:
 .. code-block:: shell
 
    conda update anaconda
-   conda install spyder=5.3.3
+   conda install spyder=5.4.2
 
 .. note::
 


### PR DESCRIPTION
## Description of Changes

Anaconda updated Spyder to 5.4.2 a couple of weeks ago, so now we can recommend users to update to it.
