### PR TITLE
Fix incorrect reST indents in docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,7 +168,7 @@ repos:
 
 # Lint RST
 - repo: https://github.com/sphinx-contrib/sphinx-lint
-  rev: 'v0.6.1'
+  rev: v0.8.1
   hooks:
   - id: sphinx-lint
     name: Lint RST

--- a/doc/panes/debugging.rst
+++ b/doc/panes/debugging.rst
@@ -61,11 +61,11 @@ To open it, select :menuselection:`Debug --> List breakpoints`, or press :kbd:`C
 
 There are several different ways to set and clear breakpoints:
 
-  * With the :guilabel:`Set/clear breakpoint` option in the Debug menu.
-  * Through pressing the configurable keyboard shortcut (:kbd:`F12` for normal, or :kbd:`Shift-F12` for conditional breakpoints by default).
-  * By clicking to the left of the line number in an open file in the Editor (adding :kbd:`Shift` for a conditional breakpoint).
-  * With the ``breakpoint()`` builtin function in your code.
-  * Interactively, using the ``b`` command in a debugging session.
+* With the :guilabel:`Set/clear breakpoint` option in the Debug menu.
+* Through pressing the configurable keyboard shortcut (:kbd:`F12` for normal, or :kbd:`Shift-F12` for conditional breakpoints by default).
+* By clicking to the left of the line number in an open file in the Editor (adding :kbd:`Shift` for a conditional breakpoint).
+* With the ``breakpoint()`` builtin function in your code.
+* Interactively, using the ``b`` command in a debugging session.
 
 .. image:: /images/debugging/debugging-breakpoints.gif
    :alt: Spyder showing setting conditional breakpoint

--- a/doc/troubleshooting/submit-a-report.rst
+++ b/doc/troubleshooting/submit-a-report.rst
@@ -60,27 +60,27 @@ The key items, in order of priority:
 
 * The full, **complete error message or traceback** copy/pasted or automatically entered exactly as displayed by Spyder:
 
-    - Auto-generated reports directly from the error dialog should include this automatically, but double check to make sure.
-    - You can copy and paste this from the the :guilabel:`Show Details` section of the error dialog.
-    - If not present, or a dialog is not displayed, you can also find it printed to Spyder's :guilabel:`Internal Console`, located under the :guilabel:`View` menu at :menuselection:`Panes --> Internal Console`.
-    - If you prefer, or if Spyder won't start, you can start Spyder from your command line (or Anaconda prompt on windows) with ``spyder`` and copy the output printed there.
+  - Auto-generated reports directly from the error dialog should include this automatically, but double check to make sure.
+  - You can copy and paste this from the the :guilabel:`Show Details` section of the error dialog.
+  - If not present, or a dialog is not displayed, you can also find it printed to Spyder's :guilabel:`Internal Console`, located under the :guilabel:`View` menu at :menuselection:`Panes --> Internal Console`.
+  - If you prefer, or if Spyder won't start, you can start Spyder from your command line (or Anaconda prompt on windows) with ``spyder`` and copy the output printed there.
 
-   .. note::
+  .. note::
 
-      If you are reporting a specific behavior rather than an error, or the message does not fully explain what occurs, please describe in detail what actually happened, and what you expected Spyder to do.
+     If you are reporting a specific behavior rather than an error, or the message does not fully explain what occurs, please describe in detail what actually happened, and what you expected Spyder to do.
 
 * A **detailed, step by step description of exactly what you did** leading up to the error occurring, complete with sample code that triggers it, if applicable.
 
 * **Information about Spyder and its environment** as listed in the error report template, which you can find under :guilabel:`About Spyder` in the :guilabel:`Help` menu; along with its key dependencies, shown in the dialog under :menuselection:`Help --> Dependencies` (there's a button to copy-paste them).
 
-   .. image:: /images/submit-a-report/submit-a-report-spyder-info.png
-      :alt: Spyder showing Spyder's info and dependencies
+  .. image:: /images/submit-a-report/submit-a-report-spyder-info.png
+     :alt: Spyder showing Spyder's info and dependencies
 
-   If Spyder won't launch, paste the output of ``conda list`` from your command line (or Anaconda prompt on Windows) in the :guilabel:`Dependencies` section of the issue template.
+  If Spyder won't launch, paste the output of ``conda list`` from your command line (or Anaconda prompt on Windows) in the :guilabel:`Dependencies` section of the issue template.
 
-   .. image:: /images/submit-a-report/submit-a-report-conda-list.png
-      :alt: Command line showing output of conda list
-      :width: 500px
+  .. image:: /images/submit-a-report/submit-a-report-conda-list.png
+     :alt: Command line showing output of conda list
+     :width: 500px
 
 * **How you installed Spyder** and any other relevant packages, *e.g.* Anaconda, MacPorts or pip and **whether Spyder has worked before** since you installed it.
 

--- a/doc/workshops/scientific-computing.rst
+++ b/doc/workshops/scientific-computing.rst
@@ -19,13 +19,13 @@ You will need to have Spyder installed. Visit our :doc:`installation guide<../in
 
 It is also desirable to have the following prior knowledge:
 
-   * Basic level of Python. You can visit `The Python Tutorial`_ to learn the basics of this programming language.
-   * Some knowledge of Statistics (`hypothesis testing`_ , `ANOVA`_, `p-value`_)
+* Basic level of Python. You can visit `The Python Tutorial`_ to learn the basics of this programming language.
+* Some knowledge of Statistics (`hypothesis testing`_ , `ANOVA`_, `p-value`_)
 
-   .. _The Python Tutorial: https://docs.python.org/3/tutorial/
-   .. _hypothesis testing: https://en.wikipedia.org/wiki/Statistical_hypothesis_testing
-   .. _ANOVA: https://en.wikipedia.org/wiki/Analysis_of_variance
-   .. _p-value: https://en.wikipedia.org/wiki/P-value
+.. _The Python Tutorial: https://docs.python.org/3/tutorial/
+.. _hypothesis testing: https://en.wikipedia.org/wiki/Statistical_hypothesis_testing
+.. _ANOVA: https://en.wikipedia.org/wiki/Analysis_of_variance
+.. _p-value: https://en.wikipedia.org/wiki/P-value
 
 
 


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [ ] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

Fixes markup errors spotted by:
* https://github.com/sphinx-contrib/sphinx-lint/pull/87 (see [these failures](https://github.com/sphinx-contrib/sphinx-lint/actions/runs/6510345052/job/17683828313?pr=87#step:8:531))

cc @CAM-Gerlach 



### Issue(s) Resolved

<!--- Pull requests should typically resolve at least one—preferably only one— --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line. --->
<!--- However, smaller fixes, maintenance or trivial changes don't need one. --->



<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
