### PR TITLE
Use `require_serial` for `sphinx-lint` in `.pre-commit-config.yaml`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,6 +173,7 @@ repos:
   - id: sphinx-lint
     name: Lint RST
     args: [--enable, all, --disable, line-too-long]
+    require_serial: true  # sphinx-lint already uses multiprocessing
 
 # Check TOML and XML
 - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [ ] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

<!--- Describe what you've changed and why. --->
`sphinx-lint` already uses multiprocessing internally, and this might interfere with `precommit`, since it will try to use multiple processes too.  By setting `require_serial` we prevent `precommit` from doing that.

See:
* https://github.com/sphinx-contrib/sphinx-lint/pull/95
