### PR TITLE
Add a temporary CSS fix for hN::before blocking link clicks

### DIFF
--- a/doc/_static/css/custom_styles.css
+++ b/doc/_static/css/custom_styles.css
@@ -354,3 +354,13 @@ a.dropdown-link:focus {
   color: #fff;
   text-decoration: none;
 }
+
+/* Temporary fix for invisible heading :before blocking clicks */
+
+h2::before,
+h3::before,
+h4::before,
+h5::before,
+h6::before {
+  pointer-events: none;
+}


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

<!--- Describe what you've changed and why. --->

As originally reported by #350, an invisible `::before` element on headings from the theme is blocking clicks to some links in sections above. I'm not entirely sure why its there in the first place, but for now I'll do a quick fix so it doesn't intercept clicks to fix the problem for now, before fixing it more permanently by rebasing on the latest PyData-Sphinx-Theme,


### Issue(s) Resolved

<!--- Pull requests should typically resolve at least one—preferably only one— --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line. --->
<!--- However, smaller fixes, maintenance or trivial changes don't need one. --->

Fixes #350 


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
