### PR TITLE
Add/update links to separate M1 and Intel macOS installers

### DIFF
--- a/doc/_static/css/custom_styles.css
+++ b/doc/_static/css/custom_styles.css
@@ -318,7 +318,8 @@ table.installer-table tbody td:nth-child(1) p::before {
   vertical-align: middle;
 }
 
-table.installer-table tbody td:nth-child(2) p::before {
+table.installer-table tbody td:nth-child(2) p::before,
+table.installer-table tbody td:nth-child(3) p::before {
   content: "\f179";
   font-size: 2em;
   padding-right: 0.5em;

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -75,12 +75,13 @@ On macOS, open the disk image and drag Spyder to your :guilabel:`Applications` f
 
 .. table::
 
-   ========================================== ==========================================
-   `Windows Installer`_                       `macOS Installer`_
-   ========================================== ==========================================
+   ================ ================ ================
+   `Windows`_       `macOS M1`_      `macOS Intel`_
+   ================ ================ ================
 
-.. _Windows Installer: https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_64bit_full.exe
-.. _macOS Installer: https://github.com/spyder-ide/spyder/releases/latest/download/Spyder.dmg
+.. _Windows: https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_64bit_full.exe
+.. _macOS M1: https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_arm64.dmg
+.. _macOS Intel: https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_x86_64.dmg
 
 .. note::
 


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

<!--- Describe what you've changed and why. --->

As fixed for the Spyder website in spyder-ide/website-spyder#223 , the download link for macOS now 404s (as correctly detected by `sphinx linkcheck` due to the Mac installers being renamed with the 5.5.1 release recently and split into x86-64 (Intel) and ARM64 (M1) versions. The simplest fix for now was to just split the existing macOS download button into two, which is exactly what this PR does.

Merging this will fix the linkcheck failure first seen on PR #358 .
