### PR TITLE
Update macOS Intel install link again back to original

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -81,7 +81,7 @@ On macOS, open the disk image and drag Spyder to your :guilabel:`Applications` f
 
 .. _Windows: https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_64bit_full.exe
 .. _macOS M1: https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_arm64.dmg
-.. _macOS Intel: https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_x86_64.dmg
+.. _macOS Intel: https://github.com/spyder-ide/spyder/releases/latest/download/Spyder.dmg
 
 .. note::
 


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

After discussion, we changed the Spyder 5.x installer link for macOS Intel x86-64back to the original `Spyder.dmg`, for backward compatibility with existing Spyder updaters and other links in the wild. This fixes the docs (again) to reflect that.

Followup to PR #359 and counterpart to spyder-ide/spyder-website#227

<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
