### PR TITLE
Changed name of section in Preferences for language settings

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -248,7 +248,7 @@ Using Spyder
 .. dropdown:: Q: How do I change Spyder's language?
    :container: + dropdown-id-using-change-language
 
-   Under :guilabel:`General` in Spyder's :guilabel:`Preferences`, go to the :guilabel:`Advanced settings` tab and select your language from the options displayed under :guilabel:`Language`.
+   Under :guilabel:`Application` in Spyder's :guilabel:`Preferences`, go to the :guilabel:`Advanced settings` tab and select your language from the options displayed under :guilabel:`Language`.
 
    .. image:: /images/faq/faq-change-language.png
       :alt: Spyder change language in preferences.


### PR DESCRIPTION
Just fixing a small mistake. The language can be changed in the "Application" section, not in "General".