### PR TITLE
Update version warning banner to always point to the latest stable docs

### DIFF
--- a/doc/_templates/layout.html
+++ b/doc/_templates/layout.html
@@ -3,7 +3,7 @@
     {% if current_version and latest_version and current_version != latest_version %}
     <div class="alert-danger text-center" role="alert">
       You're reading the documentation for {% if current_version.is_released %}an out-of-date{% else %}a development{% endif %} version of Spyder.
-      For the currently-supported stable version, see the <a href="{{ vpathto(latest_version.name) }}">Spyder {{latest_version.release}} docs</a>.
+      <a href="{{ vpathto(latest_version.name)|replace('/5/', '/current/', 1) }}">Switch to the docs for the currently-supported version</a>
     </div>
     {% endif %}
 {{ super() }}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -385,6 +385,7 @@ linkcheck_ignore = [
     # Flaky
     r"https://(www\.)?packages\.gentoo\.org/?.*",
     r"https://(www\.)?software\.opensuse\.org/?.*",
+    r"https://(www\.)?packages\.ubuntu\.com/?.*",
     # Blocks GitHub Actions
     r"https://(www\.)?(\w+\.)?reddit\.com/?.*",
     r"https://(www\.)?(\w+\.)?(stackoverflow|stackexchange)\.com/?.*",


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below

## Description of Changes

<!--- Describe what you've changed and why. --->

Currently, the warning banner for old (and new) versions embeds a link title and URL that hardcode the version number of the latest stable docs. With Sphinx-Multiversion that was fine, since all branches were rebuilt in sync so even the old banners would always be up to date, but with the new theme introduced in #367 , this will no longer be the case and unmaintained branches will be static, and not migrated to the new theme. Therefore, we need to update the old banner to be "evergreen" and point to the `/current/` version rather than a hardcoded version value.

I'll also fix any linkcheck issues that may come up.

Required for #367 


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
