### PR TITLE
Improve and refactor noxfile to prepare for translation commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ First off, thanks for your interest in helping out with the documentation for Sp
 For more information about Spyder, please see the [website](https://www.spyder-ide.org/), and for the core Spyder codebase, visit the [main repo](https://github.com/spyder-ide/spyder).
 You can view the live documentation for current and past Spyder versions at [docs.Spyder-IDE.org](https://docs.spyder-ide.org).
 
-Spyder-Docs is part of the Spyder IDE Github org, and is developed with standard Github flow.
+Spyder-Docs is part of the Spyder IDE GitHub org, and is developed with standard GitHub flow.
 If you're not comfortable with at least the basics of ``git`` and GitHub, we recommend reading beginner tutorials such as [GitHub's Git Guide](https://github.com/git-guides/), its [introduction to basic Git commands](https://docs.github.com/en/get-started/using-git/about-git#basic-git) and its [guide to the fork workflow](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project).
 However, this contributing guide should fill you in on most of the basics you need to know.
 
@@ -20,13 +20,15 @@ Let us know if you have any further questions, and we look forward to your contr
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [Reporting Issues](#reporting-issues)
-- [Cloning the repository](#cloning-the-repository)
+- [Cloning the Repository](#cloning-the-repository)
 - [Setting Up a Development Environment with Nox (Recommended)](#setting-up-a-development-environment-with-nox-recommended)
 - [Setting Up a Development Environment Manually](#setting-up-a-development-environment-manually)
   - [Create and activate a fresh environment](#create-and-activate-a-fresh-environment)
   - [Install dependencies](#install-dependencies)
 - [Installing the Pre-Commit Hooks](#installing-the-pre-commit-hooks)
-- [Building the docs](#building-the-docs)
+- [Building the Docs](#building-the-docs)
+  - [Build with Nox](#build-with-nox)
+  - [Build manually](#build-manually)
 - [Deciding Which Branch to Use](#deciding-which-branch-to-use)
 - [Making Your Changes](#making-your-changes)
 - [Pushing your Branch](#pushing-your-branch)
@@ -49,9 +51,9 @@ If referring to a particular word, line or section, please be sure to provide a 
 
 
 
-## Cloning the repository
+## Cloning the Repository
 
-First, navigate to the [project repository](https://github.com/spyder-ide/spyder-docs) in your web browser and press the ``Fork`` button to make a personal copy of the repository on your own Github account.
+First, navigate to the [project repository](https://github.com/spyder-ide/spyder-docs) in your web browser and press the ``Fork`` button to make a personal copy of the repository on your own GitHub account.
 Then, click the ``Clone or Download`` button on your repository, copy the link and run the following on the command line to clone the repo:
 
 ```shell
@@ -208,13 +210,40 @@ Once you're satisfied, ``git add .`` and commit again.
 
 
 
-## Building the docs
+## Building the Docs
 
-To build the docs locally with Sphinx, if you've installed Nox you can just run
+The documentation is built with [Sphinx](https://www.sphinx-doc.org/), which you can invoke either using [Nox](https://nox.thea.codes/) or manually.
+
+
+### Build with Nox
+
+To build the docs using Nox, just run
 
 ```shell
 nox -s build
 ```
+
+and can then open the rendered documentation in your default web browser with
+
+```shell
+nox -s serve
+```
+
+Alternatively, to automatically rebuild the docs when changes occur, you can invoke
+
+```shell
+nox -s autobuild
+```
+
+You can also pass your own custom [Sphinx build options](https://www.sphinx-doc.org/en/master/man/sphinx-build.html) after a ``--`` separator which are added to the default set.
+For example, to rebuild just the install guide and FAQ in verbose mode with the ``dirhtml`` builder (our noxfile automatically prepends the source directory for you, so typing the full relative path is optional):
+
+```shell
+nox -s build -- --verbose --builder dirhtml -- installation.rst faq.rst
+```
+
+
+### Build manually
 
 For manual installations, you can invoke Sphinx yourself with the appropriate options:
 
@@ -222,25 +251,13 @@ For manual installations, you can invoke Sphinx yourself with the appropriate op
 python -m sphinx -n -W --keep-going doc doc/_build/html
 ```
 
-If using Nox, you can open the rendered documentation in your default web browser with
-
-```shell
-nox -s serve
-```
-
-and to additionally automatically keep rebuilding the docs when changes occur, you can invoke
-
-```shell
-nox -s autobuild
-```
-
-Otherwise, navigate to the ``_build/html`` directory inside the ``spyder-docs`` repository and open ``index.html`` (the main page of the docs) in your preferred browser.
+Then, navigate to the ``_build/html`` directory inside the ``spyder-docs`` repository and open ``index.html`` (the main page of the docs) in your preferred browser.
 
 
 
 ## Deciding Which Branch to Use
 
-When you start to work on a new pull request (PR), you need to be sure that your work is done on top of the correct branch, and that you base your PR on Github against it.
+When you start to work on a new pull request (PR), you need to be sure that your work is done on top of the correct branch, and that you base your PR on GitHub against it.
 
 To guide you, issues on GitHub are marked with a milestone that indicates the correct branch to use.
 If not, follow these guidelines:

--- a/noxfile.py
+++ b/noxfile.py
@@ -181,18 +181,24 @@ def run(session):
     session.notify("_execute", posargs=([_run], *session.posargs))
 
 
-def _clean():
-    """Remove the Sphinx build directory."""
+def _clean(session):
+    """Remove the build directory."""
+    print(f"Removing build directory {BUILD_DIR.as_posix()!r}")
+    ignore = session.posargs and session.posargs[0] in {"-i", "--ignore"}
+
     try:
-        BUILD_DIR.unlink()
+        shutil.rmtree(BUILD_DIR, ignore_errors=ignore)
     except FileNotFoundError:
         pass
+    except Exception:
+        print("\nError removing files; pass '-i'/'--ignore' flag to ignore\n")
+        raise
 
 
 @nox.session
-def clean(_session):
-    """Clean build artifacts."""
-    _clean()
+def clean(session):
+    """Clean build artifacts (pass -i/--ignore to ignore errors)."""
+    _clean(session)
 
 
 # ---- Build ---- #

--- a/noxfile.py
+++ b/noxfile.py
@@ -137,7 +137,7 @@ def _execute(session):
                     *CANARY_COMMAND, include_outer_env=False, silent=True)
         except nox.command.CommandFailed:
             print("Installing dependencies in isolated environment...")
-            _install(session)
+            _install(session, use_posargs=False)
 
     if session.posargs:
         for task in session.posargs[0]:
@@ -146,15 +146,16 @@ def _execute(session):
 
 # ---- Install ---- #
 
-def _install(session):
+def _install(session, use_posargs=True):
     """Execute the dependency installation."""
-    session.install("-r", "requirements.txt")
+    posargs = session.posargs[1:] if use_posargs else ()
+    session.install("-r", "requirements.txt", *posargs)
 
 
 @nox.session
 def install(session):
-    """Install the project's dependencies in a virtual environment."""
-    session.notify("_execute", posargs=([_install],))
+    """Install the project's dependencies (passes through args to pip)."""
+    session.notify("_execute", posargs=([_install], *session.posargs))
 
 
 # ---- Utility ---- #

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pre-commit>=2.10.0,<4  # For pre-commit hooks; Lowercap to config syntax
 pydata-sphinx-theme>=0.14.1,<0.16  #  Theme; Lowercap to add version warning
-sphinx>=5,<8  # Docs generator; Cap to range confirmed supported by deps
-sphinx-design>=0.5.0,<0.6  # For dropdowns and panels; lowercap to sphinx>=5,<8
+sphinx>=5,<9  # Docs generator; Cap to range confirmed supported by deps
+sphinx-design>=0.5.0,<0.7  # For dropdowns and panels; lowercap to sphinx>=5,<8


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

Followup to #377 

As I started to work through adding the relevant translation commands, I ended up finding a number of additional limitations, corner-case bugs and structural  or needing to make a number of significant improvements, fixes and refactorings to the noxfile along the way. To keep things atomic and moving along and avoid jamming large and non-directly-related changes (e.g. adding the whole po-file structure and building that I have locally) into one big PR, I've split out these into a separate one that can (hopefully) get merged quickly prior to me dropping the translations PR that I'm working on in parallel.

Additionally, these improvements also further improve the noxfile's suitability to be easily re-used for many other Spyder projects, with only relatively small and self-contained modifications.

In particular, the main changes here:

- [x] Make Nox commands up to ≈2.5x faster by skipping installation entirely if the dependencies are already present, error on bad invocations, refactor and present friendlier output
- [x] Improve Sphinx invocation generator to better handle arbitrary builders (e.g. gettext), be more robust and refactor for cleaner code
- [x] Update the Contributing Guide to incorporate these two improvements, clarify how users can pass extra args to `nox -s build` and split the Build section into separate, easier to follow parts just for Nox and manual installations respectively, as well as other smaller fixes
- [x] Fix `nox -s clean` so it actually works and add --ignore option to it
- [x] Add argument passthrough to `nox -s install` so users can pass extra args to pip, e.g. `--upgrade`  to upgrade the Nox environment to the latest versions of the dependencies
- [x] Upgrade the uppercaps to allow Sphinx 8 and Sphinx-Design 0.6

<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
