### PR TITLE
Add docs translation and the infrastructure and automation it requires

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,7 +51,7 @@ jobs:
       run: ./ci/build.sh
     - name: Postprocess site
       shell: bash
-      run: nox -s deploy
+      run: nox -s prepare-multiversion
     - name: Deploy to GitHub Pages
       if: env.IS_DEPLOY == '1'
       uses: JamesIves/github-pages-deploy-action@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ default_language_version:
 
 default_stages: [commit]
 
-exclude: '\.min\.(js|css)$'
+exclude: '\.(min\.(js|css)|pot?)$'
 
 
 repos:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -218,7 +218,7 @@ repos:
   hooks:
   - id: pretty-format-yaml
     name: Format YAML
-    exclude: '\bworkshops\b'
+    exclude: '\bworkshops\b|crowdin.ya?ml'
     args: [--autofix, --indent, '2', --preserve-quotes]
 
 # Check YAML

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-nox -s build
+nox -s build-multilanguage

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,134 @@
+# yamllint disable rule:quoted-strings
+
+#
+# Your Crowdin credentials
+#
+"project_id": "641502"
+"base_path": ""
+"base_url": "https://api.crowdin.com"
+
+#
+# Choose file structure in Crowdin
+# e.g. true or false
+#
+"preserve_hierarchy": true
+
+#
+# GitHub sync settings
+#
+commit_message: "New %language% translation from Crowdin"
+append_commit_message: false
+
+#
+# Files configuration
+#
+files: [
+  {
+    #
+    # Source files filter
+    # e.g. "/resources/en/*.json"
+    #
+    "source": "doc/locales/en/LC_MESSAGES/*.po",
+
+    #
+    # Where translations will be placed
+    # e.g. "/resources/%two_letters_code%/%original_file_name%"
+    #
+    "translation": "doc/locales/%two_letters_code%/LC_MESSAGES/%original_file_name%",
+
+    #
+    # Files or directories for ignore
+    # e.g. ["/**/?.txt", "/**/[0-9].txt", "/**/*\?*.txt"]
+    #
+    # "ignore": [],
+
+    #
+    # The dest allows you to specify a file name in Crowdin
+    # e.g. "/messages.json"
+    #
+    # "dest": "",
+
+    #
+    # File type
+    # e.g. "json"
+    #
+    # "type": "",
+
+    #
+    # The parameter "update_option" is optional. If it is not set, after the files update the translations for changed strings will be removed. Use to fix typos and for minor changes in the source strings
+    # e.g. "update_as_unapproved" or "update_without_changes"
+    #
+    # "update_option": "",
+
+    #
+    # Start block (for XML only)
+    #
+
+    #
+    # Defines whether to translate tags attributes.
+    # e.g. 0 or 1  (Default is 1)
+    #
+    # "translate_attributes": 1,
+
+    #
+    # Defines whether to translate texts placed inside the tags.
+    # e.g. 0 or 1 (Default is 1)
+    #
+    # "translate_content": 1,
+
+    #
+    # This is an array of strings, where each item is the XPaths to DOM element that should be imported
+    # e.g. ["/content/text", "/content/text[@value]"]
+    #
+    # "translatable_elements": [],
+
+    #
+    # Defines whether to split long texts into smaller text segments
+    # e.g. 0 or 1 (Default is 1)
+    #
+    # "content_segmentation": 1,
+
+    #
+    # End block (for XML only)
+    #
+
+    #
+    # Start .properties block
+    #
+
+    #
+    # Defines whether single quote should be escaped by another single quote or backslash in exported translations
+    # e.g. 0 or 1 or 2 or 3 (Default is 3)
+    # 0 - do not escape single quote;
+    # 1 - escape single quote by another single quote;
+    # 2 - escape single quote by backslash;
+    # 3 - escape single quote by another single quote only in strings containing variables ( {0} ).
+    #
+    # "escape_quotes": 3,
+
+    #
+    # Defines whether any special characters (=, :, ! and #) should be escaped by backslash in exported translations.
+    # e.g. 0 or 1 (Default is 0)
+    # 0 - do not escape special characters
+    # 1 - escape special characters by a backslash
+    #
+    # "escape_special_characters": 0
+    #
+
+    #
+    # End .properties block
+    #
+
+    #
+    # Does the first line contain header?
+    # e.g. true or false
+    #
+    # "first_line_contains_header": true,
+
+    #
+    # for spreadsheets
+    # e.g. "identifier,source_phrase,context,uk,ru,fr"
+    #
+    # "scheme": "",
+  }
+]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -88,6 +88,8 @@ release = "5"
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
 language = "en"
+locale_dirs = ["locales/"]
+gettext_compact = True  # Condense sections into a single gettext catalog
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:

--- a/doc/locales/en/LC_MESSAGES/faq.po
+++ b/doc/locales/en/LC_MESSAGES/faq.po
@@ -1,0 +1,480 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../faq.rst:3
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: ../../faq.rst:7
+msgid "Installing and updating"
+msgstr ""
+
+#: ../../faq.rst:12
+msgid ""
+"The easiest way to install Spyder is with the Anaconda Python "
+"distribution, which comes with everything you need to get started in an "
+"all-in-one package. Download it from its `webpage`_."
+msgstr ""
+
+#: ../../faq.rst:17
+msgid "For more information, visit our :doc:`/installation`."
+msgstr ""
+
+#: ../../faq.rst:23
+msgid ""
+"If you already installed Spyder on your Windows machine, you do not need "
+"to reinstall it on a WSL2-based Linux environment if your code must run "
+"there."
+msgstr ""
+
+#: ../../faq.rst:25
+msgid ""
+"Instead, just install `Miniconda`_ inside WSL2 and create a new conda "
+"environment (or use an existing conda- or virtualenv), then install "
+"Spyder-Kernels into that environment with e.g. ``conda install spyder-"
+"kernels``. You must manually install ``ipython_genutils`` with e.g. "
+"``conda install ipython_genutils``."
+msgstr ""
+
+#: ../../faq.rst:30
+msgid ""
+"Windows creates a network path located at ``\\\\wsl$`` that points to the"
+" partitions of your WSL2 machines, e.g. ``\\\\wsl$\\Ubuntu-20.04``. You "
+"**must** map a network drive letter to your machine path, e.g. ``W:``, "
+"for Spyder to correctly see its files and folders."
+msgstr ""
+
+#: ../../faq.rst:33
+msgid "To start a Spyder kernel, from your Linux terminal run"
+msgstr ""
+
+#: ../../faq.rst:39
+msgid ""
+"It will run the kernel as a subprocess and create a file named "
+":file:`remotemachine.json` in your WSL home folder."
+msgstr ""
+
+#: ../../faq.rst:41
+msgid ""
+"Finally, under the options menu of Spyder's :doc:`panes/ipythonconsole`, "
+"select :guilabel:`Connect to an existing kernel` as described in :ref"
+":`connecting-external-kernel`. Insert the absolute path of "
+":file:`remotemachine.json` into the :guilabel:`Connection file` field. If"
+" you mapped ``W:`` as mentioned in above note, the path should be "
+":file:`W:/home/{username}/remotemachine.json`. A new console will open in"
+" Spyder, running in the Linux environment. Try running ``os.system('ls "
+"-la')`` and see if it lists your WSL home folder. If you run ``exit()`` "
+"from Spyder, the kernel running on Linux will be stopped."
+msgstr ""
+
+#: ../../faq.rst:52
+msgid "From the command line (or Anaconda prompt on Windows), run:"
+msgstr ""
+
+#: ../../faq.rst:59
+msgid ""
+"If this results in an error or does not update Spyder to the latest "
+"version, try:"
+msgstr ""
+
+#: ../../faq.rst:69
+msgid ""
+"Open the \"gear\" menu in Spyder's section under :guilabel:`Home` in "
+"Navigator. Go to :guilabel:`Install specific version` and select the "
+"version of Spyder you want to use. We strongly recommend the latest "
+"available, to benefit from new features, bug fixes, performance "
+"improvements and usability enhancements."
+msgstr ""
+
+#: ../../faq.rst:80
+msgid "Running Spyder"
+msgstr ""
+
+#: ../../faq.rst:85
+msgid "You can launch it in any of the following ways:"
+msgstr ""
+
+#: ../../faq.rst:87
+msgid ""
+"**From the command line**: Type ``spyder`` in your terminal (or Anaconda "
+"prompt on Windows)."
+msgstr ""
+
+#: ../../faq.rst:89
+msgid ""
+"**From Anaconda Navigator**: Scroll to :guilabel:`Spyder` under "
+":guilabel:`Home`, and click :guilabel:`Launch`."
+msgstr ""
+
+#: ../../faq.rst:94
+msgid "***Windows Only***: Launch it via the Start menu shortcut."
+msgstr ""
+
+#: ../../faq.rst:103
+msgid ""
+"Yes! With `Binder`_, you can work with a fully functional copy of Spyder "
+"that runs right in your web browser. Try it `here`_."
+msgstr ""
+
+#: ../../faq.rst:114
+msgid ""
+"Spyder works on modern versions of Windows, macOS and Linux (see the "
+"table below for recommended versions) via Anaconda, as well as other "
+"methods. It typically uses relatively minimal CPU when idle, and 0.5 GB -"
+" 1 GB of RAM, depending on how long you've been using it and how many "
+"files, projects, panes and consoles you have open. It should work on any "
+"system with a dual-core or better x64 processor and at least 4 GB of RAM,"
+" although 8 GB is *strongly* recommended for best performance when "
+"running other applications. However, the code you run, such as scientific"
+" computation and deep learning models, may require additional resources "
+"beyond this baseline for Spyder itself."
+msgstr ""
+
+#: ../../faq.rst:122
+msgid "Operating system"
+msgstr ""
+
+#: ../../faq.rst:122
+msgid "Version"
+msgstr ""
+
+#: ../../faq.rst:124
+msgid "Windows"
+msgstr ""
+
+#: ../../faq.rst:124
+msgid "Windows 8.1"
+msgstr ""
+
+#: ../../faq.rst:125
+msgid "macOS"
+msgstr ""
+
+#: ../../faq.rst:125
+msgid "High Sierra (10.13)"
+msgstr ""
+
+#: ../../faq.rst:126
+msgid "Linux"
+msgstr ""
+
+#: ../../faq.rst:126
+msgid "Ubuntu 16.04"
+msgstr ""
+
+#: ../../faq.rst:133
+msgid ""
+"Select the environment you want to launch Spyder from under "
+":guilabel:`Applications on`. If Spyder is installed in this environment, "
+"you will see it in Navigator's :guilabel:`Home` window. Click "
+":guilabel:`Launch` to start Spyder in your selected environment."
+msgstr ""
+
+#: ../../faq.rst:144
+msgid ""
+"Activate your conda environment by typing the following in your terminal "
+"(or Anaconda Prompt on Windows):"
+msgstr ""
+
+#: ../../faq.rst:150
+msgid "Then, type ``spyder`` to launch the version installed in that environment."
+msgstr ""
+
+#: ../../faq.rst:158
+msgid "Using Spyder"
+msgstr ""
+
+#: ../../faq.rst:163
+msgid ""
+"The first approach for installing a package should be using conda. In "
+"your system terminal (or Anaconda Prompt on Windows), type:"
+msgstr ""
+
+#: ../../faq.rst:170
+msgid ""
+"If your installation is not successful, follow steps 3 through 5 of Part "
+"2 in our video on solving and avoiding problems with pip, Conda and "
+"Conda-Forge."
+msgstr ""
+
+#: ../../faq.rst:184
+msgid ""
+"To work with an existing environment in Spyder, change the default Python"
+" interpreter for new :doc:`/panes/ipythonconsole`\\s to point to this "
+"environment."
+msgstr ""
+
+#: ../../faq.rst:186
+msgid ""
+"To do so, open the :guilabel:`Python interpreter` section of Spyder's "
+"preferences (:menuselection:`Tools --> Preferences`, or "
+":menuselection:`Spyder --> Preferences` on macOS). Here, select the "
+"option :guilabel:`Use the following Python interpreter`, and use the "
+"dropdown below to select your preferred environment. If it's not listed, "
+"see :ref:`the note below <faq-env-not-listed>`."
+msgstr ""
+
+#: ../../faq.rst:197
+msgid ""
+"If you installed Miniconda (or another Conda-based distribution) to a "
+"non-default path, or are using a virtual environment managed by a tool "
+"other than ``pyenv``, your environments likely won't be listed."
+msgstr ""
+
+#: ../../faq.rst:199
+msgid ""
+"Instead, use the text box or the :guilabel:`Select file` button to enter "
+"the path to the Python interpreter you want to use. You can find this "
+"path by activating the venv or Conda env you want to use in your terminal"
+" (Anaconda Prompt on Windows), and running the command:"
+msgstr ""
+
+#: ../../faq.rst:206
+msgid ""
+"Finally, click :guilabel:`Restart kernel` in the :guilabel:`Consoles` "
+"menu for this change to take effect. If ``spyder-kernels`` is not already"
+" installed, the :doc:`/panes/ipythonconsole` will display instructions on"
+" how to install the right version. Execute the given command in your "
+"terminal (the Anaconda Prompt on Windows) with the environment activated,"
+" and finally restart the kernel once more."
+msgstr ""
+
+#: ../../faq.rst:216
+msgid ""
+"Watch our video on using additional packages or follow the instructions "
+"below."
+msgstr ""
+
+#: ../../faq.rst:224
+msgid ""
+"If you want to use other packages in Spyder that don't come with our "
+"installer, you need to have your own Python distribution installed; we "
+"recommend `Miniconda`_ or another Conda-based option. For Spyder to "
+"recognize it automatically, you should use a Conda-based distribution "
+"with its default install path."
+msgstr ""
+
+#: ../../faq.rst:229
+msgid ""
+"Create a new conda environment containing ``spyder-kernels`` and the "
+"packages that you want to use. For example, if you want to use ``scikit-"
+"learn``, open your terminal (or Anaconda prompt on Windows) and run the "
+"following command:"
+msgstr ""
+
+#: ../../faq.rst:236
+msgid ""
+"Finally, connect Spyder to this ``my-env`` environment by changing "
+"Spyder's default Python interpreter, following the instructions in "
+":ref:`the above answer <using-existing-environment>`."
+msgstr ""
+
+#: ../../faq.rst:242
+msgid ""
+"Either use the :guilabel:`Reset Spyder to factory defaults` under "
+":guilabel:`Tools` in Spyder's menu bar, the :guilabel:`Reset Spyder "
+"settings` Start menu shortcut (Windows), or run ``spyder --reset`` in "
+"your system terminal (Anaconda prompt on Windows)."
+msgstr ""
+
+#: ../../faq.rst:251
+msgid ""
+"Under :guilabel:`General` in Spyder's :guilabel:`Preferences`, go to the "
+":guilabel:`Advanced settings` tab and select your language from the "
+"options displayed under :guilabel:`Language`."
+msgstr ""
+
+#: ../../faq.rst:260
+#, python-format
+msgid ""
+"To create a cell in Spyder's :doc:`/panes/editor`, type ``#%%`` in your "
+"script. Each ``#%%`` will make a new cell. To run a cell, press :kbd"
+":`Shift-Enter` (while your cursor is focused on it) or use the "
+":guilabel:`Run current cell` button in Spyder's toolbar."
+msgstr ""
+
+#: ../../faq.rst:271
+msgid ""
+"Spyder plugins are available in the ``conda-forge`` conda channel. To "
+"install one, type on the command line (or Anaconda Prompt on Windows):"
+msgstr ""
+
+#: ../../faq.rst:278
+msgid ""
+"Replace ``<PLUGIN>`` with the name of the plugin you want to use. For "
+"more information on a specific plugin, go to the its repository:"
+msgstr ""
+
+#: ../../faq.rst:281
+msgid "`spyder-unittest`_"
+msgstr ""
+
+#: ../../faq.rst:282
+msgid "`spyder-terminal`_"
+msgstr ""
+
+#: ../../faq.rst:283
+msgid "`spyder-notebook`_"
+msgstr ""
+
+#: ../../faq.rst:284
+msgid "`spyder-memory-profiler`_"
+msgstr ""
+
+#: ../../faq.rst:285
+msgid "`spyder-line-profiler`_"
+msgstr ""
+
+#: ../../faq.rst:297
+msgid ""
+"Check the option :guilabel:`Remove all variables before execution` in the"
+" :guilabel:`Configuration per file...` dialog under the :guilabel:`Run` "
+"menu."
+msgstr ""
+
+#: ../../faq.rst:306
+msgid ""
+"Select the appropriate option in the :guilabel:`Configuration per "
+"file...` dialog under the :guilabel:`Run` menu."
+msgstr ""
+
+#: ../../faq.rst:315
+msgid ""
+"Go to :guilabel:`Preferences` and select the theme you want under "
+":guilabel:`Syntax highlighting theme` in the :guilabel:`Appearance` "
+"section."
+msgstr ""
+
+#: ../../faq.rst:324
+msgid "Troubleshooting"
+msgstr ""
+
+#: ../../faq.rst:329
+msgid ""
+"You should first follow the steps in our :doc:`troubleshooting "
+"guide</troubleshooting/first-steps>`. If you can't solve your problem, "
+"open an issue by following the instructions in our "
+":doc:`/troubleshooting/submit-a-report` section."
+msgstr ""
+
+#: ../../faq.rst:336
+msgid ""
+"First, make sure the error you are seeing is not a bug in your code. To "
+"confirm this, try running it in any standard Python interpreter. If the "
+"error still occurs, the problem is likely with your code and a site like "
+"`Stack Overflow`_ might be the best place to start. Otherwise, start at "
+"the :doc:`/troubleshooting/basic-first-aid` section of our "
+"troubleshooting guide."
+msgstr ""
+
+#: ../../faq.rst:347
+msgid ""
+"If nothing is displayed in the calltip, hover hint or :doc:`/panes/help` "
+"pane, make sure the object you are inspecting has a docstring, and try "
+"executing your code in the :doc:`/panes/ipythonconsole` to get help and "
+"completions there. If this doesn't work, try restarting PyLS by right-"
+"clicking the :guilabel:`LSP Python` label item in the statusbar at the "
+"bottom of Spyder's main window, and selecting the :guilabel:`Restart "
+"Python Language Server` option."
+msgstr ""
+
+#: ../../faq.rst:350
+msgid ""
+"For more information, go to the :ref:`code-completion-problems-ref` "
+"section in the :doc:`/troubleshooting/common-illnesses` page of our "
+"troubleshooting guide."
+msgstr ""
+
+#: ../../faq.rst:356
+msgid ""
+"First, make sure your version of Spyder-Kernels is compatible with that "
+"of Spyder. See the table in the :ref:`spyder-kernels-version-ref` section"
+" of the troubleshooting guide to check."
+msgstr ""
+
+#: ../../faq.rst:359
+msgid ""
+"To install the right version, type the following on the command line (or "
+"Anaconda Prompt on Windows)"
+msgstr ""
+
+#: ../../faq.rst:365
+msgid ""
+"For more information, go to the :ref:`starting-kernel-problems-ref` "
+"section in the :doc:`/troubleshooting/common-illnesses` page of our "
+"troubleshooting guide."
+msgstr ""
+
+#: ../../faq.rst:371
+msgid ""
+"Spyder is in the final stages of being updated for full compatibility "
+"with macOS 11 Big Sur, which will be released by the end of 2020 as part "
+"of version 4.2.1. However, you can get it working right now with the "
+"workaround below. Make sure you have the Anaconda or Miniconda "
+"distribution installed, and run the following commands in the Terminal to"
+" install Spyder from Conda-Forge in a clean environment:"
+msgstr ""
+
+#: ../../faq.rst:381
+msgid ""
+"Then, whenever you want to start Spyder, run the following from the "
+"Terminal:"
+msgstr ""
+
+#: ../../faq.rst:393
+msgid "About Spyder"
+msgstr ""
+
+#: ../../faq.rst:398
+#, python-format
+msgid ""
+"Spyder is 100% free and open source; there is no paid version or "
+"prohibition on commercial use. It is developed by its international user "
+"community, and supported by its users through `OpenCollective`_ and by "
+"its generous sponsoring organizations, including `Quansight`_ and "
+"`NumFOCUS`_. Our source code, standalone installers and most of our "
+"distribution methods (Pip/PyPI, Linux distros, MacPorts, WinPython, etc) "
+"can be freely redistributed, used and modified by anyone, for any "
+"purpose, including commercial use. For more details about the situation "
+"with Anaconda, see `that question`_."
+msgstr ""
+
+#: ../../faq.rst:412
+#, python-format
+msgid ""
+"If you use Spyder with the Anaconda distribution, they `recently "
+"changed`_ their `Terms of Service`_ to add restrictions on large (> 200 "
+"employee) for-profit companies using Anaconda on a large scale. However, "
+"these terms only apply to the package infrastructure (the full Anaconda "
+"distribution and the ``defaults`` conda channel). Instead, you can simply"
+" download the similar `Miniforge distribution`_, which is 100% open "
+"source and identical to full Anaconda (aside from not bundling the Python"
+" packages installed by default in the Anaconda ``base`` environment, "
+"which we recommend you avoid using anyway given any problems here can "
+"break your whole installation). Then, simply install the packages you "
+"need (including Spyder, if you aren't using our recommended :ref"
+":`install-standalone`) with ``conda`` as you usually do. Miniforge will "
+"automatically use the community-maintained Conda-Forge repository, which "
+"has a much wider variety of packages and is generally more up to date "
+"than the Anaconda equivalent, in addition to being free of any commercial"
+" restrictions. For more, see our :doc:`/installation`."
+msgstr ""
+

--- a/doc/locales/en/LC_MESSAGES/index.po
+++ b/doc/locales/en/LC_MESSAGES/index.po
@@ -1,0 +1,154 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../index.rst:137
+msgid "Welcome"
+msgstr ""
+
+#: ../../index.rst:137
+msgid "FAQ"
+msgstr ""
+
+#: ../../index.rst:3
+msgid "Welcome to Spyder's Documentation"
+msgstr ""
+
+#: ../../index.rst:9
+msgid ""
+"Spyder is a powerful scientific environment written in Python, for "
+"Python, and designed by and for scientists, engineers and data analysts. "
+"It features a unique combination of the advanced editing, analysis, "
+"debugging, and profiling functionality of a comprehensive development "
+"tool with the data exploration, interactive execution, deep inspection, "
+"and beautiful visualization capabilities of a scientific package."
+msgstr ""
+
+#: ../../index.rst:18
+msgid "Where to go now?"
+msgstr ""
+
+#: ../../index.rst:20
+msgid ""
+"Spyder's documentation provides a variety of resources that will help you"
+" learn how to use the application and explore each one of its panes. "
+"These include video tutorials, in-depth descriptions and how-to guides "
+"covering a wide range of needs and experience levels with Spyder."
+msgstr ""
+
+#: ../../index.rst:33
+msgid ""
+"If you are looking for a summary of its features and interface, check out"
+" the :doc:`quickstart`."
+msgstr ""
+
+#: ../../index.rst:41
+msgid ""
+"If you don't have Spyder installed and want to get started, follow the "
+":doc:`/installation`."
+msgstr ""
+
+#: ../../index.rst:49
+msgid ""
+"If you are completely new to Spyder, watch our basic tutorial series, "
+":doc:`videos/first-steps-with-spyder`."
+msgstr ""
+
+#: ../../index.rst:57
+msgid ""
+"If you are familiar with Spyder and want to explore the functionality of "
+"its panes in more detail, go to :doc:`panes/index`."
+msgstr ""
+
+#: ../../index.rst:65
+msgid ""
+"If you've run into a Spyder problem and need help solving it, take a look"
+" at our :doc:`troubleshooting guide<troubleshooting/first-steps>`."
+msgstr ""
+
+#: ../../index.rst:73
+msgid "If you have a question about Spyder, visit the :doc:`faq` section."
+msgstr ""
+
+#: ../../index.rst:81
+msgid "Join our community"
+msgstr ""
+
+#: ../../index.rst:83
+msgid ""
+"Spyder is open source software, which means that is free for everyone to "
+"use and anyone can contribute to it. We encourage everyone to become a "
+"part of our community and help develop Spyder!"
+msgstr ""
+
+#: ../../index.rst:90
+msgid "Looking to contribute your code?"
+msgstr ""
+
+#: ../../index.rst:92
+msgid ""
+"Spyder is written in the same Python language that you use it to develop,"
+" so its easy to get started contributing to it. You can follow our "
+"`contributing guide`_ to set up a development environment, and you can "
+"get involved with the project through our `Github repository`_. The "
+"easiest way to get started is helping us resolve items on our `issue "
+"tracker`_, either by fixing bugs in Spyder, or helping users troubleshoot"
+" their problems (which doesn't require writing any code)."
+msgstr ""
+
+#: ../../index.rst:106
+msgid "Want to help writing docs?"
+msgstr ""
+
+#: ../../index.rst:108
+msgid ""
+"We welcome your contributions of corrections, additions and enhancements "
+"to these docs. Check out the `docs contributing guide`_ to learn how to "
+"submit a PR with your changes on our `docs repo`_."
+msgstr ""
+
+#: ../../index.rst:119
+msgid "Interested in translating Spyder?"
+msgstr ""
+
+#: ../../index.rst:121
+msgid ""
+"In order to reach more users around the world in need of a powerful "
+"scientific Python environment, we welcome your help translating the "
+"documentation and the interface into different languages."
+msgstr ""
+
+#: ../../index.rst:123
+msgid ""
+"For this purpose we use `Crowdin`_, which provides a simple web based "
+"interface for translators, proofreaders and managers, so everyone can "
+"help us translate Spyder into any language."
+msgstr ""
+
+#: ../../index.rst:131
+msgid "Want to be part of our social media?"
+msgstr ""
+
+#: ../../index.rst:133
+msgid ""
+"Connect with Spyder through our social media channels to stay up to date "
+"with our current developments!"
+msgstr ""
+

--- a/doc/locales/en/LC_MESSAGES/installation.po
+++ b/doc/locales/en/LC_MESSAGES/installation.po
@@ -1,0 +1,596 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../installation.rst:5
+msgid "Installation Guide"
+msgstr ""
+
+#: ../../installation.rst:7
+msgid ""
+"Spyder is relatively easy to install on Windows, Linux and macOS. Just "
+"make sure to read and follow these instructions with care."
+msgstr ""
+
+#: ../../installation.rst:10
+msgid ""
+"If you run into problems, before posting a report, *please* consult our "
+"comprehensive :doc:`troubleshooting guide</troubleshooting/first-steps>` "
+"and search the `issue tracker`_ for your error message and problem "
+"description. These methods generally fix or isolate the great majority of"
+" install-related difficulties. Thanks!"
+msgstr ""
+
+#: ../../installation.rst:18
+msgid ""
+"For most users on Windows and macOS, we recommend our :ref:`install-"
+"standalone` as the most straightforward and robust option to obtain "
+"Spyder. For users needing Linux support, third-party Spyder plugins or "
+"Variable Explorer compatibility with custom-installed packages—all "
+"capabilities which the standalone installers currently do not yet "
+"provide—we advise using a :ref:`install-conda`. Linux, plugin and "
+"package/environment management support in the standalone installers are "
+"currently under active development for future Spyder versions."
+msgstr ""
+
+#: ../../installation.rst:27
+msgid "Try Spyder online"
+msgstr ""
+
+#: ../../installation.rst:29
+msgid ""
+"Want to try out Spyder without installing it? With `Binder`_ you can work"
+" with a fully functional copy of Spyder online that runs right in your "
+"web browser, no installation needed. Visit the `Spyder Binder`_ to get "
+"started using Spyder."
+msgstr ""
+
+#: ../../installation.rst:45
+msgid "Standalone installers"
+msgstr ""
+
+#: ../../installation.rst:47
+msgid ""
+"The standalone installers are our recommended method for most users on "
+"Windows and macOS, with experimental Linux support under active "
+"development. They work like any other IDE, where Spyder can be installed "
+"and updated independently of the Python environments you use to run your "
+"code. This avoids the problems with incompatible packages and broken "
+"installations users often face when mixing Spyder with the (Conda, etc) "
+"environments they use to run their code."
+msgstr ""
+
+#: ../../installation.rst:51
+msgid ""
+"The installers include a built-in Python environment with the most common"
+" scientific libraries (e.g. NumPy, Pandas, Matpotlib, etc), which can be "
+"used out of the box for basic data analysis tasks. However, to manage "
+"your own packages and environments, you'll currently need to connect an "
+"external Python distribution (such as `Anaconda`_, `Miniconda`_, "
+"`Miniforge/Mambaforge`_, `WinPython`_ or `Python.org <Python_>`__) to "
+"your standalone copy of Spyder. For more information on this, see our "
+":ref:`FAQ entry on the subject <using-packages-installer>`."
+msgstr ""
+
+#: ../../installation.rst:57
+msgid ""
+"The standalone installers do not yet support installing third-party "
+"Spyder plugins not already bundled with them, though this feature is "
+"currently under development. For now, if you need this capability, we "
+"recommend a :ref:`install-conda`."
+msgstr ""
+
+#: ../../installation.rst:64
+msgid "Downloading and installing"
+msgstr ""
+
+#: ../../installation.rst:66
+msgid ""
+"To download the supported Spyder installer for your platform, simply "
+"click the appropriate link below (for Linux, see the :ref:`install-conda`"
+" section). Then, double-click the downloaded file to open the installer. "
+"If a security warning pops up, you may need to click :guilabel:`Yes`, "
+":guilabel:`OK`, :guilabel:`Open`, :guilabel:`Allow` or similar."
+msgstr ""
+
+#: ../../installation.rst:70
+msgid ""
+"On Windows, if a \"SmartScreen\" dialog appears, click :guilabel:`More "
+"info` followed by :guilabel:`Run anyway`, and then proceed through the "
+"steps in the installer."
+msgstr ""
+
+#: ../../installation.rst:72
+msgid ""
+"On macOS, open the disk image and drag Spyder to your "
+":guilabel:`Applications` folder."
+msgstr ""
+
+#: ../../installation.rst:79
+msgid "`Windows Installer`_"
+msgstr ""
+
+#: ../../installation.rst:79
+msgid "`macOS Installer`_"
+msgstr ""
+
+#: ../../installation.rst:87
+msgid ""
+"\"Lite\" versions of both installers are also available from the "
+"`releases page`_, which are somewhat smaller than the full installers. "
+"These lack a number of optional but recommended dependencies, such as "
+"NumPy, SciPy and Pandas, meaning that a few "
+":doc:`/panes/variableexplorer` features, including graphical data import "
+"wizards and support for rich display and editing of NumPy arrays and "
+"Pandas DataFrames, will not be available. Given this only saves a modest "
+"amount of space while missing out on significant features, we recommend "
+"using the full installers unless minimizing download/install size and "
+"memory usage is a priority."
+msgstr ""
+
+#: ../../installation.rst:97
+msgid "Running from a standalone install"
+msgstr ""
+
+#: ../../installation.rst:99
+msgid ""
+"To run Spyder when installed standalone, you can simply use your "
+"operating system's typical method of launching applications, such as "
+"opening it from the :guilabel:`Start` menu on Windows (or the Taskbar, if"
+" you've pinned it there), or from Launchpad, Spotlight or the "
+":guilabel:`Applications` folder on macOS (or the Dock, if you've added it"
+" there)."
+msgstr ""
+
+#: ../../installation.rst:105
+msgid "Updating a standalone install"
+msgstr ""
+
+#: ../../installation.rst:107
+msgid ""
+"By default, Spyder checks for updates automatically on startup, and you "
+"can also check manually with :menuselection:`Help --> Check for updates`."
+" The standalone installers for Spyder 5.4.0+ include update functionality"
+" built right into Spyder, which after checking for updates will display a"
+" prompt to automatically download and install the current version. On "
+"earlier versions, you'll need to manually download and install the latest"
+" release (if on Windows, make sure to remove the old version first from "
+"Control Panel/System Settings)."
+msgstr ""
+
+#: ../../installation.rst:117
+msgid "Conda-based distributions"
+msgstr ""
+
+#: ../../installation.rst:119
+msgid ""
+"Spyder is included by default in the `Anaconda`_ Python distribution, "
+"which comes with everything you need to get started in an all-in-one "
+"package. It can also be easily installed in the much lighter-weight "
+"`Miniconda`_ and `Miniforge/Mambaforge`_, which include just Python and "
+"the Conda/Mamba package and environment manager by default (with "
+"Miniforge defaulting to the Conda-Forge channel, and Mambaforge using "
+"Mamba, a much faster alternative to Conda). This is our recommended "
+"installation method on Linux and for users with third-party Spyder "
+"plugins, as support for both of these in our standalone installers is "
+"still under active development."
+msgstr ""
+
+#: ../../installation.rst:131
+msgid "Conda environment"
+msgstr ""
+
+#: ../../installation.rst:133
+msgid ""
+"With Miniconda/Miniforge/Mambaforge, or to get a more reliable and up-to-"
+"date Spyder version with Anaconda, we strongly recommend installing "
+"Spyder into its own dedicated Conda environment."
+msgstr ""
+
+#: ../../installation.rst:137
+msgid ""
+"If using Mamba/Mambaforge, substitute ``mamba`` for ``conda`` in the "
+"following commands."
+msgstr ""
+
+#: ../../installation.rst:143
+msgid "Installing with Conda"
+msgstr ""
+
+#: ../../installation.rst:145
+msgid ""
+"For a full install of Spyder and all optional dependencies, run the "
+"following command in your Anaconda Prompt (Windows) or terminal:"
+msgstr ""
+
+#: ../../installation.rst:151
+msgid ""
+"For a minimal install without the optional functionality and integration "
+"with the above packages, you can instead run:"
+msgstr ""
+
+#: ../../installation.rst:157
+msgid ""
+"This installs Spyder into a new environment called ``spyder-env``, using "
+"the more up-to-date, community-run Conda-Forge channel. To make sure "
+"future installs/updates in this environment also use Conda-Forge and are "
+"faster and more reliable, make sure to set it as your environment's "
+"default channel with strict channel priority enabled, if this isn't the "
+"case already (as it is with Miniforge/Mambaforge or if you've manually "
+"configured it):"
+msgstr ""
+
+#: ../../installation.rst:166
+msgid "Here's a summary of the main steps."
+msgstr ""
+
+#: ../../installation.rst:175
+msgid "Running with Conda"
+msgstr ""
+
+#: ../../installation.rst:177
+msgid ""
+"You can then run Spyder by the same methods :ref:`as with Anaconda "
+"<install-anaconda-running>`, except that you need to make sure to launch "
+"the Start menu shortcut with ``(spyder-env)`` in the name, select the "
+"``spyder-env`` environment on the left before launching it with "
+"Navigator, or type ``conda activate spyder-env`` before launching it on "
+"the command line."
+msgstr ""
+
+#: ../../installation.rst:179
+msgid ""
+"See :ref:`our FAQ question <using-existing-environment>` for more "
+"information about how to use Spyder with your existing Conda "
+"environments."
+msgstr ""
+
+#: ../../installation.rst:185
+msgid "Updating with Conda"
+msgstr ""
+
+#: ../../installation.rst:187
+msgid ""
+"With any Conda-based distribution and Spyder installed in its own "
+"environment (recommended), update Conda itself, active the environment, "
+"and finally update Spyder. In your system terminal (or Anaconda Prompt if"
+" on Windows), run:"
+msgstr ""
+
+#: ../../installation.rst:196
+msgid ""
+"In case you get an error trying to update, just remove the existing "
+"environment (if using one other than ``base``):"
+msgstr ""
+
+#: ../../installation.rst:202
+msgid "And then :ref:`recreate a fresh one <install-conda-installing>`."
+msgstr ""
+
+#: ../../installation.rst:208
+msgid "Anaconda base"
+msgstr ""
+
+#: ../../installation.rst:210
+msgid ""
+"While we recommend always using a dedicated environment, with Anaconda "
+"you can also run the bundled copy of Spyder from the built-in ``base`` "
+"environment."
+msgstr ""
+
+#: ../../installation.rst:214
+msgid ""
+"The bundled Spyder version can often be quite out of date, missing new "
+"features and bug fixes from the latest version, and if you install, "
+"change or remove other packages, there is a significant chance of "
+"dependency conflicts or a broken Spyder installation. Therefore, we "
+"recommend :ref:`installing Spyder into a new Conda environment <install-"
+"conda-installing>` to avoid all these issues."
+msgstr ""
+
+#: ../../installation.rst:221
+msgid "Running with Anaconda"
+msgstr ""
+
+#: ../../installation.rst:223
+msgid ""
+"To run the bundled version of Spyder after installing it with Anaconda, "
+"the recommended method on Windows is to launch it via the Start menu "
+"shortcut. On other platforms, open Anaconda Navigator, scroll to Spyder "
+"under :guilabel:`Home` and click :guilabel:`Launch`."
+msgstr ""
+
+#: ../../installation.rst:229
+msgid ""
+"If Spyder does not start via this method or you prefer to use the command"
+" line, open Anaconda Prompt (Windows) or your terminal (other platforms),"
+" type ``conda activate base`` then ``spyder``."
+msgstr ""
+
+#: ../../installation.rst:235
+msgid "Updating with Anaconda"
+msgstr ""
+
+#: ../../installation.rst:237
+msgid ""
+"With Spyder installed in Anaconda's ``base`` environment, first update "
+"the ``anaconda`` meta-package, and then Spyder itself (in case there is a"
+" newer version than that pinned to the ``anaconda`` metapackage). In your"
+" system terminal (or Anaconda Prompt if on Windows), run:"
+msgstr ""
+
+#: ../../installation.rst:247
+msgid ""
+"These commands also update all your other packages, which is one reason "
+"we strongly recommend you use an isolated conda environment to avoid any "
+"potential unintended effects on other installed packages."
+msgstr ""
+
+#: ../../installation.rst:249
+msgid ""
+"In case you get an error resolving dependencies, try uninstalling Spyder "
+"and re-installing it:"
+msgstr ""
+
+#: ../../installation.rst:262
+msgid "Using pip"
+msgstr ""
+
+#: ../../installation.rst:266
+msgid ""
+"While this installation method is a viable option for experienced users, "
+"installing Spyder (and other PyData-stack packages) with pip can "
+"sometimes lead to tricky issues, particularly on Windows and macOS. While"
+" you are welcome to try it on your own, we are typically not able to "
+"provide individual support for installation problems with pip, except to "
+"recommend our :ref:`install-standalone` (Windows and macOS) or a :ref"
+":`install-conda`."
+msgstr ""
+
+#: ../../installation.rst:269
+msgid ""
+"You can install Spyder with the pip package manager, which is included by"
+" default with most Python installations. Before installing Spyder itself "
+"by this method, you need to download the `Python`_ programming language."
+msgstr ""
+
+#: ../../installation.rst:276
+msgid ""
+"Due to a known issue with some DEB-based Linux distributions (Debian, "
+"Ubuntu, Mint), you might also need to install the ``pyqt5-dev-tools`` "
+"package first, with ``sudo apt install pyqt5-dev-tools``."
+msgstr ""
+
+#: ../../installation.rst:278
+msgid ""
+"You'll first want to create and activate a virtual environment in which "
+"to install Spyder, via one of the following methods."
+msgstr ""
+
+#: ../../installation.rst:280
+msgid "With ``virtualenvwrapper``:"
+msgstr ""
+
+#: ../../installation.rst:287
+msgid "Otherwise, on macOS/Linux/Unix:"
+msgstr ""
+
+#: ../../installation.rst:294
+msgid "or on Windows:"
+msgstr ""
+
+#: ../../installation.rst:301
+msgid ""
+"After activating your environment, to install Spyder and its optional "
+"dependencies, run:"
+msgstr ""
+
+#: ../../installation.rst:307
+msgid "Or for a minimal installation, run:"
+msgstr ""
+
+#: ../../installation.rst:316
+msgid ""
+"To launch Spyder after installing it, ensure your environment is "
+"activated and run the ``spyder`` or ``spyder3`` command."
+msgstr ""
+
+#: ../../installation.rst:318
+msgid "And to update Spyder, with your Spyder environment activated, run:"
+msgstr ""
+
+#: ../../installation.rst:330
+msgid "Alternative methods"
+msgstr ""
+
+#: ../../installation.rst:334
+msgid ""
+"While we describe alternative Spyder installation options for users who "
+"prefer them, as these are third-party distributions that we have no "
+"direct involvement in, we are usually not able to offer useful individual"
+" assistance for problems specific to installing via these alternative "
+"methods."
+msgstr ""
+
+#: ../../installation.rst:336
+msgid ""
+"Also, the Spyder versions they install may be out of date relative to the"
+" current release, and thus be missing the latest features and bug fixes."
+msgstr ""
+
+#: ../../installation.rst:338
+msgid ""
+"Therefore, we recommend you switch to our :ref:`install-standalone` "
+"(Windows and macOS) or a :ref:`install-conda` if you encounter "
+"installation issues you are unable to solve on your own."
+msgstr ""
+
+#: ../../installation.rst:344
+msgid "Windows"
+msgstr ""
+
+#: ../../installation.rst:346
+msgid ""
+"Spyder is included in the `WinPython`_ scientific Python distribution, "
+"along with many other common numerical computing and data analysis "
+"packages. You can use Spyder immediately after installing, similar to "
+"Anaconda."
+msgstr ""
+
+#: ../../installation.rst:355
+msgid "macOS"
+msgstr ""
+
+#: ../../installation.rst:357
+msgid "Spyder is available as `a cask`_ through `Homebrew`_."
+msgstr ""
+
+#: ../../installation.rst:362
+msgid "To install it using the ``brew`` package manager, run:"
+msgstr ""
+
+#: ../../installation.rst:368
+msgid "It is also available as a `a port`_ through `MacPorts`_."
+msgstr ""
+
+#: ../../installation.rst:373
+msgid "To install it using the ``port`` package manager, run:"
+msgstr ""
+
+#: ../../installation.rst:383
+msgid "Linux"
+msgstr ""
+
+#: ../../installation.rst:385
+msgid ""
+"Spyder can be installed via third-party distro packages on most common "
+"Linux distributions."
+msgstr ""
+
+#: ../../installation.rst:387
+msgid ""
+"Running Spyder installed this way will generally be the same as any other"
+" distro-installed application. Alternatively, it can be launched from the"
+" terminal with ``spyder`` (or ``spyder3``, on older versions of some "
+"distros)."
+msgstr ""
+
+#: ../../installation.rst:394
+msgid "Ubuntu/Debian"
+msgstr ""
+
+#: ../../installation.rst:396
+msgid "Spyder is available as `a Ubuntu package`_ and `a Debian package`_."
+msgstr ""
+
+#: ../../installation.rst:401
+msgid "To install it using the ``apt`` package manager, run:"
+msgstr ""
+
+#: ../../installation.rst:411
+msgid "Other distributions"
+msgstr ""
+
+#: ../../installation.rst:413
+msgid "Spyder is also available in other GNU/Linux distributions, including:"
+msgstr ""
+
+#: ../../installation.rst:415
+msgid "`Arch Linux`_"
+msgstr ""
+
+#: ../../installation.rst:416
+msgid "`Fedora`_"
+msgstr ""
+
+#: ../../installation.rst:417
+msgid "`Gentoo`_"
+msgstr ""
+
+#: ../../installation.rst:418
+msgid "`openSUSE`_"
+msgstr ""
+
+#: ../../installation.rst:425
+msgid ""
+"Please refer to the links or your distribution's documentation for how to"
+" install Spyder."
+msgstr ""
+
+#: ../../installation.rst:433
+msgid "Development builds"
+msgstr ""
+
+#: ../../installation.rst:435
+msgid ""
+"If you want to try the next Spyder version before it is released, you "
+"can! You may want to do this for fixing bugs in Spyder, adding new "
+"features, learning how Spyder works or just getting a taste of what the "
+"IDE can do. For more information, please see the `Contributing Guide`_ "
+"included with the Spyder source or on Github, and for further detail "
+"consult the `Spyder development wiki`_."
+msgstr ""
+
+#: ../../installation.rst:450
+msgid "Additional help"
+msgstr ""
+
+#: ../../installation.rst:454
+msgid ""
+"*Run in to a problem installing or running Spyder?* Read our "
+"`Troubleshooting Guide and FAQ`_."
+msgstr ""
+
+#: ../../installation.rst:458
+msgid ""
+"*Looking for general information about Spyder and its ecosystem?* See our"
+" `main website`_."
+msgstr ""
+
+#: ../../installation.rst:462
+msgid ""
+"*Need to submit a bug report or feature request?* Check out our `Github "
+"repository`_."
+msgstr ""
+
+#: ../../installation.rst:466
+msgid ""
+"*Want development-oriented help and information?* Consult our `Github "
+"wiki`_."
+msgstr ""
+
+#: ../../installation.rst:470
+msgid ""
+"*Have a help request or discussion topic?* Subscribe to our `Google "
+"Group`_."
+msgstr ""
+
+#: ../../installation.rst:474
+msgid ""
+"*Asking a quick question or want to chat with the dev team?* Stop by our "
+"`Gitter chatroom`_."
+msgstr ""
+
+#: ../../installation.rst:478
+msgid ""
+"*Seeking personalized help from expert Spyder consultants?* Visit "
+"`OpenTeams`_."
+msgstr ""
+

--- a/doc/locales/en/LC_MESSAGES/panes.po
+++ b/doc/locales/en/LC_MESSAGES/panes.po
@@ -1,0 +1,2141 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../panes/debugging.rst:3
+msgid "Debugger"
+msgstr ""
+
+#: ../../panes/debugging.rst:5
+msgid ""
+"**Debugging** in Spyder is supported through integration with the "
+"enhanced ``ipdb`` debugger in the :doc:`ipythonconsole`. This allows "
+"breakpoints and the execution flow to be viewed and controlled right from"
+" the Spyder GUI, as well as with all the familiar IPython console "
+"commands."
+msgstr ""
+
+#: ../../panes/debugging.rst:15
+msgid "Debugging with ipdb"
+msgstr ""
+
+#: ../../panes/debugging.rst:17
+msgid ""
+"You can fully control debugger execution from the :guilabel:`Debug` menu,"
+" :guilabel:`Debug toolbar` and via configurable keyboard shortcuts, along"
+" with the standard ``ipdb`` `console commands`_."
+msgstr ""
+
+#: ../../panes/debugging.rst:22
+msgid ""
+"Additionally, the  :doc:`editor` shows the line of code the debugger is "
+"currently stopped on with an arrow."
+msgstr ""
+
+#: ../../panes/debugging.rst:29
+msgid ""
+"Spyder's debugger offers syntax highlighting, code completion and command"
+" history, which work exactly like they do in the normal interactive "
+"interpreter."
+msgstr ""
+
+#: ../../panes/debugging.rst:31
+msgid ""
+"Use the up and down arrows to recall previous commands, and press "
+":kbd:`Tab` to trigger autocomplete suggestions."
+msgstr ""
+
+#: ../../panes/debugging.rst:36
+#, python-format
+msgid ""
+"Furthermore, IPython's `magic functions`_ are available in debugging "
+"mode. You can, for example, run ``%ls`` to list the contents of your "
+"current working directory or ``%timeit`` to check how fast a given "
+"snippet of code is."
+msgstr ""
+
+#: ../../panes/debugging.rst:44
+msgid ""
+"Finally, you can enter and execute multiline statements in Spyder's "
+"debugger just like with the regular IPython prompt, to easily run complex"
+" code."
+msgstr ""
+
+#: ../../panes/debugging.rst:54
+msgid "Breakpoints"
+msgstr ""
+
+#: ../../panes/debugging.rst:56
+msgid ""
+"Spyder's debugger is integrated with the :guilabel:`Breakpoints` pane, "
+"which lists the file, line, and condition (if any) of every breakpoint "
+"defined. To open it, select :menuselection:`Debug --> List breakpoints`, "
+"or press :kbd:`Ctrl-Shift-B` (:kbd:`Cmd-Shift-B` on macOS)."
+msgstr ""
+
+#: ../../panes/debugging.rst:62
+msgid "There are several different ways to set and clear breakpoints:"
+msgstr ""
+
+#: ../../panes/debugging.rst:64
+msgid "With the :guilabel:`Set/clear breakpoint` option in the Debug menu."
+msgstr ""
+
+#: ../../panes/debugging.rst:65
+msgid ""
+"Through pressing the configurable keyboard shortcut (:kbd:`F12` for "
+"normal, or :kbd:`Shift-F12` for conditional breakpoints by default)."
+msgstr ""
+
+#: ../../panes/debugging.rst:66
+msgid ""
+"By clicking to the left of the line number in an open file in the Editor "
+"(adding :kbd:`Shift` for a conditional breakpoint)."
+msgstr ""
+
+#: ../../panes/debugging.rst:67
+msgid "With the ``breakpoint()`` builtin function in your code."
+msgstr ""
+
+#: ../../panes/debugging.rst:68
+msgid "Interactively, using the ``b`` command in a debugging session."
+msgstr ""
+
+#: ../../panes/debugging.rst:73
+msgid ""
+"You can access and edit local and global variables at each breakpoint "
+"through the :doc:`variableexplorer`."
+msgstr ""
+
+#: ../../panes/debugging.rst:82
+msgid "Advanced features"
+msgstr ""
+
+#: ../../panes/debugging.rst:84
+msgid ""
+"You can avoid stepping through other Python packages while debugging by "
+"enabling the new :guilabel:`Ignore Python libraries while debugging` "
+"option in Spyder's preferences, under :menuselection:`IPython Console -->"
+" Debugger --> Debug`. This will skip all the built-in and third-party "
+"Python modules you have installed."
+msgstr ""
+
+#: ../../panes/debugging.rst:90
+msgid ""
+"If your code has variables with the same names as Pdb commands (e.g. "
+"``b`` or ``step``), you can still refer to them as normal while "
+"debugging. To call the respective Pdb command, just add an exclamation "
+"point before it (e.g. ``!b`` or ``!step``)."
+msgstr ""
+
+#: ../../panes/debugging.rst:96
+msgid ""
+"You can have Spyder automatically execute a custom snippet of code every "
+"time the debugger stops. For example, you can use this to set specific "
+"variables, or import commonly-used modules so they are always available "
+"while debugging. To set this up, go to :menuselection:`Preferences --> "
+"IPython Console --> Debugger --> Run code while debugging`, and enter the"
+" code that you want to be executed with each step."
+msgstr ""
+
+#: ../../panes/debugging.rst:107
+msgid "Matplotlib support"
+msgstr ""
+
+#: ../../panes/debugging.rst:109
+msgid ""
+"Generating Matplotlib figures is fully supported while the debugger is "
+"active, including all the different graphics backends. Use the "
+"``%matplotlib`` magic to change to an interactive backend (e.g. "
+"``%matplotlib qt5``) to pan, zoom and adjust your plots in a separate "
+"window, or switch back to the default ``inline`` (``%matplotlib inline``)"
+" to see them displayed right in the :doc:`plots` pane."
+msgstr ""
+
+#: ../../panes/debugging.rst:116
+msgid ""
+"To avoid showing plots while debugging, deactivate the :guilabel:`Process"
+" execute events while debugging` option in :menuselection:`Preferences "
+"--> IPython console --> Debugger`."
+msgstr ""
+
+#: ../../panes/debugging.rst:122 ../../panes/editor.rst:313
+#: ../../panes/fileexplorer.rst:99 ../../panes/findinfiles.rst:65
+#: ../../panes/help.rst:80 ../../panes/historylog.rst:51
+#: ../../panes/ipythonconsole.rst:185 ../../panes/onlinehelp.rst:86
+#: ../../panes/outline.rst:54 ../../panes/plots.rst:85
+#: ../../panes/profiler.rst:99 ../../panes/projects.rst:62
+#: ../../panes/pylint.rst:91 ../../panes/variableexplorer.rst:194
+msgid "Related panes"
+msgstr ""
+
+#: ../../panes/debugging.rst:124 ../../panes/fileexplorer.rst:101
+#: ../../panes/findinfiles.rst:67 ../../panes/help.rst:82
+#: ../../panes/ipythonconsole.rst:188 ../../panes/outline.rst:56
+#: ../../panes/projects.rst:64 ../../panes/pylint.rst:93
+msgid ":doc:`editor`"
+msgstr ""
+
+#: ../../panes/debugging.rst:125 ../../panes/editor.rst:317
+#: ../../panes/help.rst:83 ../../panes/historylog.rst:53
+#: ../../panes/plots.rst:87 ../../panes/profiler.rst:101
+#: ../../panes/variableexplorer.rst:197
+msgid ":doc:`ipythonconsole`"
+msgstr ""
+
+#: ../../panes/debugging.rst:126 ../../panes/ipythonconsole.rst:191
+#: ../../panes/plots.rst:88
+msgid ":doc:`variableexplorer`"
+msgstr ""
+
+#: ../../panes/editor.rst:3
+msgid "Editor"
+msgstr ""
+
+#: ../../panes/editor.rst:5
+msgid ""
+"Spyder's multi-language **Editor** pane is the key element of the IDE, "
+"where you can create, open, and modify source files. The Editor offers a "
+"variety of core features, such as autocompletion, real-time analysis, "
+"syntax highlighting, horizontal and vertical splitting, and much more. In"
+" addition, it integrates a number of powerful tools for an easy to use, "
+"efficient editing experience."
+msgstr ""
+
+#: ../../panes/editor.rst:16
+msgid "Key components"
+msgstr ""
+
+#: ../../panes/editor.rst:18
+msgid "The Editor pane consists of the following areas:"
+msgstr ""
+
+#: ../../panes/editor.rst:23
+msgid ""
+"The left sidebar shows line numbers and displays any code analysis "
+"warnings that exist in the current file. Clicking a line number selects "
+"the text on that line, and clicking to the right of it sets a "
+":ref:`breakpoint <debugging-breakpoints>`."
+msgstr ""
+
+#: ../../panes/editor.rst:25
+msgid "The scrollbars allow vertical and horizontal navigation in a file."
+msgstr ""
+
+#: ../../panes/editor.rst:26
+msgid ""
+"The context (right-click) menu displays actions relevant to whatever was "
+"clicked."
+msgstr ""
+
+#: ../../panes/editor.rst:27
+msgid ""
+"The options menu (\"Hamburger\" icon at top right) includes useful "
+"settings and actions relevant to the Editor."
+msgstr ""
+
+#: ../../panes/editor.rst:28
+msgid ""
+"The location bar at the top of the Editor pane shows the full path of the"
+" current file."
+msgstr ""
+
+#: ../../panes/editor.rst:29
+msgid ""
+"The tab bar displays the names of all opened files. It also has a "
+":guilabel:`Browse tabs` button (at left) to show every open tab and "
+"switch between them—which comes in handy if many are open."
+msgstr ""
+
+#: ../../panes/editor.rst:36
+msgid "Interface"
+msgstr ""
+
+#: ../../panes/editor.rst:39
+msgid "Tabs"
+msgstr ""
+
+#: ../../panes/editor.rst:41
+msgid ""
+"You can browse and navigate between open files in the Editor with tabs. "
+"Click the :guilabel:`Browse tabs` button on the left of the tab bar to "
+"display a list of open files, with the active tab checked."
+msgstr ""
+
+#: ../../panes/editor.rst:47
+msgid ""
+"Reorder files by dragging and dropping, or with :guilabel:`Sort tabs "
+"alphabetically` in the options menu, which also allows closing all tabs "
+"to the right of, or all tabs but the active one."
+msgstr ""
+
+#: ../../panes/editor.rst:54
+msgid "File switcher"
+msgstr ""
+
+#: ../../panes/editor.rst:56
+msgid ""
+"The Editor features a file switcher, which enables you to navigate and "
+"switch between multiple open files. The file switcher is helpful for "
+"locating any file when there are several files opened."
+msgstr ""
+
+#: ../../panes/editor.rst:62
+msgid ""
+"It can be accessed from the :menuselection:`File --> File Switcher` menu "
+"or :kbd:`Ctrl-P`, and includes a search function. You can type in any "
+"part of an open file's name and—if exists—it can be switched to by "
+"pressing :kbd:`Enter`."
+msgstr ""
+
+#: ../../panes/editor.rst:70
+msgid "Split panels"
+msgstr ""
+
+#: ../../panes/editor.rst:72
+msgid ""
+"The Editor can be split horizontally and vertically into as many distinct"
+" panels as desired. This allows viewing and editing the contents of "
+"several files (or different parts of the same file) at the same time."
+msgstr ""
+
+#: ../../panes/editor.rst:78
+msgid ""
+"Split the Editor with the :guilabel:`Split vertically` (:kbd:`Ctrl-"
+"Shift-{`) and :guilabel:`Split horizontally` (:kbd:`Ctrl-Shift--`) "
+"commands in the options menu, and use :guilabel:`Close this panel` (:kbd"
+":`Alt-Shift-W`) to close the selected split panel."
+msgstr ""
+
+#: ../../panes/editor.rst:80
+msgid ""
+":menuselection:`Close this panel` closes a split panel, while "
+":menuselection:`Close` hides the entire Editor *pane* (including all "
+"splits, which are restored when the Editor is re-opened)."
+msgstr ""
+
+#: ../../panes/editor.rst:86
+msgid "Editing features"
+msgstr ""
+
+#: ../../panes/editor.rst:89
+msgid "Syntax highlighting"
+msgstr ""
+
+#: ../../panes/editor.rst:91
+msgid ""
+"To improve the readability of your code, Spyder has a syntax highlighting"
+" feature that determines the color and style of text in the Editor, as "
+"well as in the :doc:`ipythonconsole`."
+msgstr ""
+
+#: ../../panes/editor.rst:93
+msgid ""
+"You can configure and preview syntax highlighting themes and fonts under "
+":menuselection:`Preferences --> Appearance`. The :guilabel:`Syntax "
+"highlighting theme` section allows you to change the color and style of "
+"the syntax elements and background to match your preferences. You can "
+"switch between available themes in the drop-down menu, modify the "
+"selected theme, create a new theme, and more. The :guilabel:`Fonts` "
+"section lets you change the text font and size."
+msgstr ""
+
+#: ../../panes/editor.rst:101
+msgid ""
+"Changes made to the syntax highlighting theme and font settings are "
+"common to all source files, regardless of their language."
+msgstr ""
+
+#: ../../panes/editor.rst:105
+msgid "Code cells"
+msgstr ""
+
+#: ../../panes/editor.rst:107
+msgid ""
+"A \"code cell\" in Spyder is a block of lines, typically in a script, "
+"that can be easily executed all at once in the current "
+":doc:`ipythonconsole`. This is similar to \"cell\" behavior in Jupyter "
+"Notebook and MATLAB. You can divide your scripts into as many cells as "
+"needed, or none at all—the choice is yours."
+msgstr ""
+
+#: ../../panes/editor.rst:114
+msgid "You can separate cells by lines starting with either:"
+msgstr ""
+
+#: ../../panes/editor.rst:116
+#, python-format
+msgid "``# %%`` (standard cell separator), or"
+msgstr ""
+
+#: ../../panes/editor.rst:117
+msgid "``# <codecell>`` (IPython notebook cell separator)"
+msgstr ""
+
+#: ../../panes/editor.rst:119
+#, python-format
+msgid ""
+"Providing a description to the right of the separator will give that cell"
+" its own name in the :doc:`outline`. You can also create \"subsections\" "
+"by adding more ``%`` signs to the cell separator, e.g. ``# %%%`` to "
+"create a level 2 subsection, ``# %%%%`` for level 3, etc. This displays "
+"multiple levels in the :doc:`outline` pane."
+msgstr ""
+
+#: ../../panes/editor.rst:126
+msgid ""
+"This only affects how the cell is displayed in the :doc:`outline`, and "
+"doesn't affect running it in the Editor."
+msgstr ""
+
+#: ../../panes/editor.rst:128
+msgid ""
+"To run the code in a cell, use :menuselection:`Run --> Run cell`, the "
+":guilabel:`Run cell` button in the toolbar or the keyboard shortcut (:kbd"
+":`Ctrl-Enter`/:kbd:`Cmd-Return` by default). You can also run a cell and "
+"then jump to the next one, letting you quickly step through multiple "
+"cells, using :menuselection:`Run --> Run cell and advance` (:kbd:`Shift-"
+"Enter` by default)."
+msgstr ""
+
+#: ../../panes/editor.rst:133
+msgid "Automatic formatting"
+msgstr ""
+
+#: ../../panes/editor.rst:135
+msgid ""
+"The Editor has built-in support for automatically formatting your code "
+"using several popular tools, including `Autopep8 "
+"<https://github.com/hhatto/autopep8>`_ and `Black "
+"<https://black.readthedocs.io/en/stable/>`_. The :guilabel:`Format file "
+"or selection with {tool}` command in the :guilabel:`Source` or context "
+"menu will format either the selected fragment (if text is selected) or "
+"the entire active file."
+msgstr ""
+
+#: ../../panes/editor.rst:141
+msgid ""
+"You can have the Editor automatically autoformat a file every time you "
+"save your work. To set this up, go to :menuselection:`Preferences --> "
+"Completion and linting --> Code style and formatting --> Code formatting`"
+" and check the :guilabel:`Autoformat files on save` option."
+msgstr ""
+
+#: ../../panes/editor.rst:151
+msgid "Running code"
+msgstr ""
+
+#: ../../panes/editor.rst:153
+msgid ""
+"The Editor lets you run an entire file as well as specific lines, "
+"selections or cells."
+msgstr ""
+
+#: ../../panes/editor.rst:155
+msgid "As your code is running,"
+msgstr ""
+
+#: ../../panes/editor.rst:157
+msgid "The :doc:`ipythonconsole` will display output and errors."
+msgstr ""
+
+#: ../../panes/editor.rst:158
+msgid ""
+"The :doc:`variableexplorer` allows you to browse and interact with the "
+"objects generated."
+msgstr ""
+
+#: ../../panes/editor.rst:159
+msgid "The :doc:`plots` pane renders the figures and images created."
+msgstr ""
+
+#: ../../panes/editor.rst:163
+msgid "Run file"
+msgstr ""
+
+#: ../../panes/editor.rst:165
+msgid ""
+"Run an entire Editor file using the :menuselection:`Run --> Run` menu "
+"item, the :guilabel:`Run file` toolbar button or the :kbd:`F5` key. Use "
+":menuselection:`Run --> Re-Run last script` to re-run the most recent "
+"file executed with the above."
+msgstr ""
+
+#: ../../panes/editor.rst:170
+msgid "Run line/selection"
+msgstr ""
+
+#: ../../panes/editor.rst:172
+msgid ""
+"You can execute the current line—or multiple selected lines—using the "
+":guilabel:`Run selection or current line` option from the toolbar or the "
+":menuselection:`Run` menu, as well as with the :kbd:`F9` key. After "
+"running the current line, the cursor automatically advances to the next "
+"one, so you can step through your code line by line. Unlike "
+":guilabel:`Run file`, the executed lines are shown in the "
+":doc:`ipythonconsole`."
+msgstr ""
+
+#: ../../panes/editor.rst:178
+msgid "Run cell"
+msgstr ""
+
+#: ../../panes/editor.rst:180
+msgid ""
+"To run a cell, place your cursor inside it and use the "
+":menuselection:`Run --> Run cell` menu item, the :guilabel:`Run current "
+"cell` toolbar button or the :kbd:`Ctrl-Enter` / :kbd:`Cmd-Return` "
+"keyboard shortcut. Use :guilabel:`Run cell and advance` in the "
+":guilabel:`Run` menu/toolbar or :kbd:`Shift-Enter` to jump to the next "
+"cell after running, useful for stepping through cells quickly."
+msgstr ""
+
+#: ../../panes/editor.rst:185
+msgid "Run configuration"
+msgstr ""
+
+#: ../../panes/editor.rst:187
+msgid ""
+"You can use the :guilabel:`Run configuration per file` dialog to set each"
+" file's working directory, console mode (current, dedicated or external),"
+" command line arguments, execution options (clear all variables, run in "
+"an existing/empty namespace, debug on error), and more."
+msgstr ""
+
+#: ../../panes/editor.rst:192
+msgid ""
+"To access it, click :menuselection:`Run --> Configuration per file...` or"
+" press :kbd:`Ctrl-F6` / :kbd:`Cmd-F6`."
+msgstr ""
+
+#: ../../panes/editor.rst:198
+msgid "Code navigation"
+msgstr ""
+
+#: ../../panes/editor.rst:201
+msgid "Find and replace"
+msgstr ""
+
+#: ../../panes/editor.rst:203
+msgid ""
+"To search for text in the current file, use :menuselection:`Search --> "
+"Find text` or :kbd:`Ctrl-F` / :kbd:`Cmd-F`, and to replace it, use "
+":menuselection:`Search --> Replace text` or :kbd:`Ctrl-R` / :kbd:`Cmd-R`."
+" Typing your search string in the resulting panel below the Editor "
+"highlights each result and counts the total. Navigate between matches "
+"with the :guilabel:`Find Previous` and :guilabel:`Find Next` buttons in "
+"the find/replace panel, their corresponding entries in the "
+":guilabel:`Search` menu, or use the :kbd:`F2` and :kbd:`F3` keys. Use the"
+" :guilabel:`.*` button to process search text as a `regular expression "
+"<https://docs.python.org/3/library/re.html>`_, :guilabel:`Aa` to treat it"
+" as case-sensitive and :guilabel:`[–]` to only match whole words (e.g. "
+"for ``data``, match ``data()`` but not ``dataframe``)."
+msgstr ""
+
+#: ../../panes/editor.rst:213
+msgid "Go to line"
+msgstr ""
+
+#: ../../panes/editor.rst:215
+msgid ""
+"The :guilabel:`Go to line` dialog allows jumping to a specific line in "
+"the active file. Open it with :menuselection:`Search --> Go to line` or "
+":kbd:`Ctrl-L` / :kbd:`Cmd-L`, type the line number you want to scroll to "
+"and press :kbd:`Enter` (or click :guilabel:`OK`)."
+msgstr ""
+
+#: ../../panes/editor.rst:221
+msgid "It also shows the current line number and total line count in the file."
+msgstr ""
+
+#: ../../panes/editor.rst:225
+msgid "Class/function selector"
+msgstr ""
+
+#: ../../panes/editor.rst:227
+msgid ""
+"This panel, activated under :menuselection:`Source --> Show selector for "
+"classes and functions`, displays (as applicable) the name of the cell, "
+"function/method and class the Editor cursor is located inside. Use its "
+"dropdowns to view and jump to the functions, methods and classes in the "
+"current file."
+msgstr ""
+
+#: ../../panes/editor.rst:237
+msgid "Code analysis and completions"
+msgstr ""
+
+#: ../../panes/editor.rst:239
+msgid ""
+"Spyder uses the `Language Server Protocol <https://microsoft.github.io"
+"/language-server-protocol/>`_ (LSP) to provide code completion and "
+"linting for the Editor, similar to VSCode, Neovim, and other popular "
+"editors/IDEs."
+msgstr ""
+
+#: ../../panes/editor.rst:243
+msgid ""
+"Many issues with completion and linting are outside of Spyder's control, "
+"and are either limitations with the LSP or the code that is being "
+"introspected, but some can be worked around. See :ref:`code-completion-"
+"problems-ref` for troubleshooting steps."
+msgstr ""
+
+#: ../../panes/editor.rst:246
+msgid ""
+"Python is supported out of the box, and advanced users can add completion"
+" and linting support for other languages by setting up LSP servers for "
+"them under :menuselection:`Preferences --> Completion and Linting --> "
+"Other languages`."
+msgstr ""
+
+#: ../../panes/editor.rst:250
+msgid "Code completion"
+msgstr ""
+
+#: ../../panes/editor.rst:252
+msgid ""
+"Automatic code completion as you type is enabled by default in the "
+"Editor, and can also be triggered manually with :kbd:`Ctrl-Space`/:kbd"
+":`Cmd-Space`, showing you possible completions (with pop-up help for "
+"each) and available code snippets. For example, typing ``cla`` will "
+"display the keyword ``class``, the decorator ``classmethod`` and two "
+"built-in snippets with class templates. Select the desired completion "
+"with the arrow keys and :kbd:`Enter`, or by double clicking."
+msgstr ""
+
+#: ../../panes/editor.rst:259
+msgid ""
+"You can enable or disable on-the-fly code completion, as well as modify "
+"when it is triggered and what results are shown, under "
+":menuselection:`Preferences --> Completion and Linting --> General --> "
+"Completions`. Spyder also allows you to define custom completion snippets"
+" to use, in addition to the ones offered by the LSP, under "
+":menuselection:`Preferences --> Completion and Linting --> Advanced`."
+msgstr ""
+
+#: ../../panes/editor.rst:264
+msgid "Linting and code style"
+msgstr ""
+
+#: ../../panes/editor.rst:266
+msgid ""
+"Spyder can optionally highlight syntax errors, style issues, and other "
+"potential problems with your code in the Editor, which can help you spot "
+"bugs quickly and make your code easier to read and understand."
+msgstr ""
+
+#: ../../panes/editor.rst:271
+msgid ""
+"The Editor's basic linting, powered by `Pyflakes "
+"<https://github.com/PyCQA/pyflakes>`_, warns of syntax errors and likely "
+"bugs in your code. It is on by default, and can be disabled or customized"
+" under :menuselection:`Preferences --> Completion and Linting --> "
+"Linting`."
+msgstr ""
+
+#: ../../panes/editor.rst:277
+msgid ""
+"Code style analysis, powered by `Pycodestyle "
+"<https://pycodestyle.pycqa.org/en/stable/>`_, flags deviations from the "
+"style conventions in :pep:`8`. It is not active by default, but you can "
+"enable it and customize the `Pycodestyle error codes "
+"<https://pycodestyle.pycqa.org/en/stable/intro.html#error-codes>`_ shown "
+"with the options under :menuselection:`Preferences --> Completion and "
+"Linting --> Code style and formatting --> Code Style`."
+msgstr ""
+
+#: ../../panes/editor.rst:285
+msgid "Introspection features"
+msgstr ""
+
+#: ../../panes/editor.rst:287
+msgid ""
+"If there's a function, class or variable for which you would like to "
+"check its definition, you need to :kbd:`Ctrl`/:kbd:`Cmd`-click its name "
+"in the Editor (or click its name and press :kbd:`Ctrl-G` / :kbd:`Cmd-G` "
+"to jump to the file and line where it is declared."
+msgstr ""
+
+#: ../../panes/editor.rst:292
+msgid ""
+"You can hover over the name of an object for pop-up help, as "
+":ref:`described in the Help pane docs <help-hover-hints>`."
+msgstr ""
+
+#: ../../panes/editor.rst:297
+msgid ""
+"Finally, if you type the name of a function, method or class constructor "
+"and then an open parenthesis, a calltip will pop up which shows the "
+"function's parameters as you type them, as well as a summary of its "
+"documentation. These features can be enabled and customized under "
+":menuselection:`Preferences --> Completion and Linting --> "
+"Introspection`."
+msgstr ""
+
+#: ../../panes/editor.rst:304
+msgid "Keyboard shortcuts"
+msgstr ""
+
+#: ../../panes/editor.rst:306
+msgid ""
+"To view the Editor's primary keyboard shortcuts, consult its section "
+"under :menuselection:`Help --> Shortcuts Summary`. The full list can be "
+"browsed, searched and customized (on double-click) in "
+":menuselection:`Preferences --> Keyboard shortcuts`."
+msgstr ""
+
+#: ../../panes/editor.rst:315 ../../panes/findinfiles.rst:68
+#: ../../panes/outline.rst:57 ../../panes/projects.rst:65
+msgid ":doc:`fileexplorer`"
+msgstr ""
+
+#: ../../panes/editor.rst:316 ../../panes/fileexplorer.rst:102
+msgid ":doc:`findinfiles`"
+msgstr ""
+
+#: ../../panes/editor.rst:318 ../../panes/fileexplorer.rst:103
+#: ../../panes/outline.rst:58
+msgid ":doc:`projects`"
+msgstr ""
+
+#: ../../panes/editor.rst:319 ../../panes/profiler.rst:102
+msgid ":doc:`pylint`"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:3
+msgid "Files"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:5
+msgid ""
+"The **Files** pane is a filesystem and directory browser built right into"
+" Spyder. You can view and filter files according to their type and "
+"extension, open them with the :doc:`editor` or an external tool, and "
+"perform many common operations."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:17
+msgid "File operations"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:19
+msgid ""
+"To browse the files on your system, use the arrows at the top of the "
+"pane. You can expand/collapse the folders in the pane to display the "
+"files and subdirectories hierarchically. Double-clicking a folder will "
+"open it, showing the files inside and making it your working directory."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:26
+msgid ""
+"To open a file in the :guilabel:`Editor` from the :guilabel:`Files` pane,"
+" double-click its name. If you right-click over it, you will see a "
+"context menu that allows you to access a number of functions, including "
+"running scripts; creating, renaming, moving, deleting files; and opening "
+"them in your computer's file manager."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:32
+msgid ""
+"You can copy and paste one or several files to and from the pane, and "
+"copy their absolute or relative paths to the clipboard as text. If "
+"copying the paths for multiple files, they will be automatically "
+"formatted so you can paste them directly into a Python list."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:44
+msgid "Version control support"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:46
+msgid ""
+"The :guilabel:`Files` pane allows you to perform basic operations with "
+"the `Git`_ distributed version control system, like committing your "
+"changes and browsing the repository a given file or folder is part of. "
+"This is :ref:`particularly useful<vcs-section>` when you're working in "
+"Spyder :doc:`projects`."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:58 ../../panes/ipythonconsole.rst:65
+#: ../../panes/outline.rst:16 ../../panes/plots.rst:20
+#: ../../panes/pylint.rst:50 ../../panes/variableexplorer.rst:103
+msgid "Options menu"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:60
+msgid ""
+"The options menu in the top right of the :guilabel:`Files` pane offers "
+"several ways to customize how your files are displayed."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:62
+msgid ""
+"By default, the pane displays the contents of your working directory "
+"without filtering. However, it can filter the list to show only files "
+"matching the patterns set under :guilabel:`Show filenames with these "
+"extensions...`, if you toggle the :guilabel:`Filter filenames` button in "
+"the pane toolbar."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:68
+msgid ""
+"You can also activate the :guilabel:`Show hidden files` option, which "
+"will display files that are invisible by default in your operating "
+"system."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:70
+msgid ""
+"Additionally, you can change which file attributes you want to see by "
+"hiding or displaying the :guilabel:`Type`, :guilabel:`Size` and "
+":guilabel:`Date Modified` columns using the corresponding menu options."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:75
+msgid ""
+"The menu also gives you the option to open files and directories with a "
+"single instead of a double click, to suit your preferences."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:81
+msgid "File associations"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:83
+msgid ""
+":guilabel:`Files` allows you to associate different external applications"
+" with specific file extensions they can open. Under the :guilabel:`File "
+"associations` tab of the :guilabel:`Files` preferences pane, you can add "
+"file types and set the external program used to open each of them by "
+"default."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:89
+msgid ""
+"Once you've set this up, files will automatically launch in the "
+"associated application when opened from Spyder's :guilabel:`Files` pane. "
+"Additionally, when you right-click a file, you will find an "
+":guilabel:`Open with...` option that will allow you to select from the "
+"applications associated with this extension."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:3
+msgid "Find"
+msgstr ""
+
+#: ../../panes/findinfiles.rst:5
+msgid ""
+"The **Find** pane allows you to search the content of text files in a "
+"user-defined location, with advanced features to filter your results."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:14
+msgid "Using the Find pane"
+msgstr ""
+
+#: ../../panes/findinfiles.rst:16
+msgid ""
+"To search for text in the Find pane, enter it in the field in the top "
+"left and press the search button. This will allow you to view and "
+"navigate through all the occurrences of your search text in your working "
+"directory. You can expand or collapse the search results to view the "
+"matches in each file. Clicking on a match will automatically open the "
+"file and highlight the line where the text was found."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:24
+msgid ""
+"If you want to change the scope of your search, select another directory,"
+" project or file in the :guilabel:`Search in` menu. The locations that "
+"you select for your search will be stored in the list so you can access "
+"them easily in the future. To erase all of these saved directories, "
+"select the :guilabel:`Clear the list` option from the dropdown menu in "
+"the :guilabel:`Search in` field."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:35
+msgid "Choosing search options"
+msgstr ""
+
+#: ../../panes/findinfiles.rst:37
+msgid ""
+"You can select from a number of options to enable searches as broad or "
+"refined as you need."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:39
+msgid ""
+"To enable case sensitivity, which only returns matches with identical "
+"capitalization to your search text, toggle the :guilabel:`Aa` button on."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:44
+msgid ""
+"To parse your search string as a `regular expression`_, enable the "
+":guilabel:`.*` button."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:51
+msgid ""
+"To exclude certain filenames, extensions or directories from your search,"
+" click the :guilabel:`Plus` button to display the advanced options for "
+"the pane, and then enter them in the :guilabel:`Exclude` text box."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:56
+msgid ""
+"Finally, to change the number of matches displayed, select the "
+":guilabel:`Set maximum number of results` option under the pane's Options"
+" menu in the top right."
+msgstr ""
+
+#: ../../panes/help.rst:3
+msgid "Help"
+msgstr ""
+
+#: ../../panes/help.rst:5
+msgid ""
+"You can use the **Help** pane to find, render and display rich "
+"documentation for any object with a docstring, including modules, "
+"classes, functions and methods. This allows you to access documentation "
+"easily directly from Spyder, without having to interrupt your workflow."
+msgstr ""
+
+#: ../../panes/help.rst:11
+msgid ""
+"You can also access Spyder's tutorial from here, which will guide you "
+"through some basic steps for using its key features."
+msgstr ""
+
+#: ../../panes/help.rst:21
+msgid "Getting help"
+msgstr ""
+
+#: ../../panes/help.rst:23
+msgid ""
+"Help can be retrieved both by static analysis of open files in the "
+":doc:`editor`, or by dynamically inspecting an object in an "
+":doc:`ipythonconsole`. You can trigger help manually by pressing the "
+"configurable help shortcut (:kbd:`Ctrl-I` by default)."
+msgstr ""
+
+#: ../../panes/help.rst:29
+msgid ""
+"You can also manually enter the object's name into the :guilabel:`Object`"
+" textbox at the top of the pane, if :guilabel:`Console` is selected as "
+"the :guilabel:`Source`."
+msgstr ""
+
+#: ../../panes/help.rst:34
+msgid ""
+"Automatic help can be individually enabled for both the "
+":guilabel:`Editor` and the :guilabel:`Console` under "
+":menuselection:`Preferences --> Help --> Automatic Connections`, and "
+"turned on and off dynamically via the lock icon in the top right corner "
+"of the :guilabel:`Help` pane. If enabled, simply typing a left "
+"parenthesis (``(``) after a function or method name will show its "
+"associated help."
+msgstr ""
+
+#: ../../panes/help.rst:44
+msgid "Understanding help modes"
+msgstr ""
+
+#: ../../panes/help.rst:46
+msgid ""
+"You can use the options menu (:guilabel:`Hamburger` icon) in the top "
+"right of the :guilabel:`Help` pane to toggle the help display mode."
+msgstr ""
+
+#: ../../panes/help.rst:48
+msgid ""
+":guilabel:`Rich Text` mode renders the object's docstrings with "
+"``Sphinx``, :guilabel:`Plain Text` mode displays the docstring without "
+"formatting while :guilabel:`Show Source` displays the docstring inline "
+"with the code for the selected object, or any Python portion of it (if "
+"the object is not pure Python). The latter can be useful when docstrings "
+"are not available or insufficient to document the object."
+msgstr ""
+
+#: ../../panes/help.rst:59
+msgid "Getting help by hovering"
+msgstr ""
+
+#: ../../panes/help.rst:61
+msgid ""
+"You can also get summary help for objects by hovering over them in the "
+":guilabel:`Editor`. Clicking the hover popup will open the full "
+"documentation in the :guilabel:`Help` pane."
+msgstr ""
+
+#: ../../panes/help.rst:71
+msgid "Control automatic import"
+msgstr ""
+
+#: ../../panes/help.rst:73
+msgid ""
+"When you get help in the :guilabel:`IPython Console` for an object that "
+"has not been previously imported, it is automatically loaded in Spyder's "
+"own internal interpreter so that documentation can be shown when "
+"available. This can be disabled in the :guilabel:`Help` pane's top-right "
+"options menu so that only documentation from imported objects is "
+"displayed."
+msgstr ""
+
+#: ../../panes/help.rst:84
+msgid ":doc:`onlinehelp`"
+msgstr ""
+
+#: ../../panes/historylog.rst:3
+msgid "History"
+msgstr ""
+
+#: ../../panes/historylog.rst:5
+msgid ""
+"With the **History** pane, you can view the recent code and commands "
+"you've entered into any :doc:`ipythonconsole`, along with their "
+"timestamp."
+msgstr ""
+
+#: ../../panes/historylog.rst:14
+msgid "Using the History pane"
+msgstr ""
+
+#: ../../panes/historylog.rst:16
+msgid ""
+"Navigating the :guilabel:`History` pane is very straightforward. Each "
+"Spyder session is marked by a date and timestamp, making it easy to "
+"remember when you executed a certain command. Statements can be selected "
+"and copied from the context menu or with the normal system shortcuts. "
+"Just like in the Editor, selecting a word or phrase displays all other "
+"occurrences, and full syntax highlighting is also supported. The last "
+"≈1000 lines entered are stored in the pane."
+msgstr ""
+
+#: ../../panes/historylog.rst:26
+msgid "Options Menu"
+msgstr ""
+
+#: ../../panes/historylog.rst:28
+msgid ""
+"The top-right options menu (:guilabel:`Hamburger` icon) allows you to "
+"toggle wrapping of long lines (:guilabel:`Wrap lines`), and whether the "
+"line number is displayed to the left of the text (:guilabel:`Show line "
+"numbers`)."
+msgstr ""
+
+#: ../../panes/historylog.rst:37
+msgid "Advanced usage"
+msgstr ""
+
+#: ../../panes/historylog.rst:39
+msgid ""
+"The list of commands shown in the :guilabel:`History` pane are stored in "
+":file:`history.py` in the :file:`.spyder-py3` directory in your user home"
+" folder (by default, :file:`C:/Users/{username}` on Windows, "
+":file:`/Users/{username}` for macOS, and typically "
+":file:`/home/{username}` on GNU/Linux). You might need to show invisible "
+"files in order to see it on a non-Windows operating system."
+msgstr ""
+
+#: ../../panes/historylog.rst:45
+msgid ""
+"While there is currently no built-in way to clear history from the Spyder"
+" interface aside from resetting preferences, you can do so by closing "
+"Spyder, deleting this file and restarting Spyder again."
+msgstr ""
+
+#: ../../panes/index.rst:3
+msgid "Panes in Depth"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:3
+msgid "IPython Console"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:5
+msgid ""
+"The **IPython Console** allows you to execute commands and interact with "
+"data inside `IPython`_ interpreters."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:12
+msgid ""
+"To launch a new IPython instance, go to :guilabel:`New console (default "
+"settings)` under the :guilabel:`Consoles` menu, or use the keyboard "
+"shortcut :kbd:`Ctrl-T` (:kbd:`Cmd-T` on macOS) when the console is "
+"focused."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:17
+msgid ""
+"From the same menu, you can stop currently executing code with "
+":guilabel:`Interrupt kernel`, clear a console's namespace with "
+":guilabel:`Remove all variables`, or relaunch a fresh one with "
+":guilabel:`Restart kernel`. As each console is executed in a separate "
+"process, this won't affect any others you've opened, and you will be able"
+" to easily test your code in a clean environment without disrupting your "
+"primary session."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:26
+msgid "Supported features"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:28
+msgid ""
+"Any :guilabel:`IPython Console`, whether :ref:`external<connecting-"
+"external-kernel>` or started by Spyder, supports:"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:30
+msgid "Automatic code completion"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:31
+msgid "Real-time function calltips"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:32
+msgid "Full GUI integration with the enhanced Spyder :doc:`Debugger<debugging>`."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:33
+msgid ""
+"The :doc:`variableexplorer`, with GUI-based editors for many built-in and"
+" third-party Python objects."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:34
+msgid ""
+"Display of Matplotlib graphics in Spyder's :doc:`plots` pane, if the "
+":guilabel:`Inline` backend is selected under :menuselection:`Preferences "
+"--> IPython console --> Graphics --> Graphics backend`, and inline in the"
+" console if :guilabel:`Mute inline plotting` is unchecked under the "
+":guilabel:`Plots` pane's options menu."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:39
+msgid ""
+"For information on the features, commands and capabilities built into "
+"IPython itself, see the `IPython documentation`_."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:47
+msgid "Special consoles"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:49
+msgid ""
+"Spyder also supports several types of specialized consoles. A `Sympy "
+"console`_ enables creating and displaying symbolic math expressions right"
+" inside Spyder. A `Cython console`_ allows you to use the Cython language"
+" to speed up your code and call C functions directly from Python. "
+"Finally, a `Pylab console`_ loads common Numpy and Matplotlib functions "
+"by default; while this is deprecated and strongly discouraged for new "
+"code, it can still be used if necessary for legacy scripts that need it."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:67
+msgid ""
+"The options menu allows you to inspect your current environment variables"
+" (:guilabel:`Show environment variables`), and the contents of your "
+"system's ``PATH`` (:guilabel:`Show sys.path contents`). In addition, you "
+"can have each console display how long it has been running with "
+":guilabel:`Show elapsed time`."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:73
+msgid ""
+"You can also change the name of the current :guilabel:`IPython console` "
+"tab with the :guilabel:`Rename tab` option, or by simply double-clicking "
+"it."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:84
+msgid "Using external kernels"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:86
+msgid ""
+"You can connect to external local and remote kernels (including those "
+"managed by Jupyter Notebook or QtConsole) through the :guilabel:`Connect "
+"to an existing kernel` dialog under the :guilabel:`Consoles` menu. For "
+"this feature to work, a compatible version of the ``spyder-kernels`` "
+"package :ref:`must be installed <starting-kernel-problems-ref>` in the "
+"environment or machine in which the external kernel is running."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:94
+msgid "Connect to a local kernel"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:96
+msgid ""
+"To connect to a local kernel that is already running (e.g. one started by"
+" Jupyter notebook),"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:98
+#, python-format
+msgid ""
+"Run ``%connect_info`` in the notebook or console you want to connect to, "
+"and copy the name of its kernel connection file, shown after ``jupyter "
+"<app> --existing``."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:103
+msgid ""
+"In Spyder, click :guilabel:`Connect to an existing kernel` from the "
+":guilabel:`Consoles` menu, and paste the name of the "
+":guilabel:`Connection file` from the previous step."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:105
+msgid ""
+"As a convenience, kernel ID numbers (e.g. ``1234``) entered in the "
+"connection file path field will be expanded to the full path of the file,"
+" i.e. :file:`{jupyter/runtime/dir/path}/kernal-{id}.json`."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:110
+msgid "Click :guilabel:`OK` to connect to the kernel."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:117
+msgid "Connect to a remote kernel"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:119
+msgid "To connect to a kernel on a remote machine,"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:121
+msgid ""
+"Launch a Spyder kernel on the remote host if one is not already running, "
+"with ``python -m spyder_kernels.console``."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:126
+msgid ""
+"Copy the kernel's connection file "
+"(:file:`{jupyter/runtime/dir/path}/kernel-{pid}.json`) to the machine "
+"you're running Spyder on."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:128
+msgid ""
+"You can get :file:`{jupyter/runtime/dir/path}` by executing ``jupyter "
+"--runtime-dir`` in the same Python environment as the kernel. Usually, "
+"the connection file you are looking for will be one of the newest in this"
+" directory, corresponding to the time you started the external kernel."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:134
+msgid ""
+"Click :guilabel:`Connect to an existing kernel` from the "
+":guilabel:`Consoles` menu, and browse for or enter the path to the "
+"connection file from the previous step."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:136
+msgid ""
+"As a convenience, kernel ID numbers (e.g. ``1234``) entered in the "
+"connection file path field will be expanded to "
+":file:`{jupyter/runtime/dir/path}/kernal-{id}.json` on your local "
+"machine, if you've copied the connection file there."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:141
+msgid ""
+"Check the :guilabel:`This is a remote kernel (via SSH)` box and enter the"
+" :guilabel:`Hostname` or IP address, username and port to connect to on "
+"the remote machine. Then, enter *either* :file:`{username}`'s password on"
+" the remote machine, or browse to an SSH keyfile (typically in the "
+":file:`.ssh` directory in your home folder on the local machine, often "
+"called :file:`id_rsa` or similar) registered on it; only one is needed to"
+" connect. If you check :guilabel:`Save connection settings`, these "
+"details will be remembered and filled for you automatically next time you"
+" open the dialog."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:145
+msgid ""
+"Note that :guilabel:`Port` is the port number on your remote machine that"
+" the SSH daemon (``sshd``) is listening on, typically 22 unless you or "
+"your administrator has configured it otherwise."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:150
+msgid "Click :guilabel:`OK` to connect to the remote kernel"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:155
+msgid ""
+"For more technical details about connecting to remote kernels, see the "
+"`Connecting to a remote kernel`_ page in the IPython Cookbook."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:165
+msgid "Reload changed modules"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:167
+msgid ""
+"When working in an interactive session, Python only loads a module from "
+"its source file once, the first time it is imported."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:169
+msgid ""
+"Spyder's :guilabel:`User Module Reloader` (UMR) automatically reloads "
+"modules right in your existing IPython consoles whenever they are "
+"modified and re-imported. With the UMR enabled, you can test changes to "
+"your code without restarting the kernel."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:175
+msgid ""
+"UMR is enabled by default, and it will provide you with a red ``Reloaded "
+"modules:`` message in the console listing the files it has refreshed when"
+" it is activated. If desired, you can turn it on or off, and prevent "
+"specific modules from being reloaded, under :menuselection:`Preferences "
+"--> Python interpreter --> User Module Reloader (UMR)`."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:187 ../../panes/variableexplorer.rst:196
+msgid ":doc:`debugging`"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:189 ../../panes/onlinehelp.rst:88
+msgid ":doc:`help`"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:190
+msgid ":doc:`historylog`"
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:3
+msgid "Online Help"
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:5
+msgid ""
+"The **Online Help** pane provides a built-in web browser to explore "
+"dynamically generated Python documentation on installed modules—including"
+" your own—rendered by a `pydoc`_ server running in the background."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:16
+msgid "Using the Online Help"
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:18
+msgid ""
+"The Online Help's home shows an index where you can browse the "
+"documentation of standard library modules, third party packages installed"
+" in your Python environment, and your own local code. Click on the name "
+"of any module to open its documentation."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:24
+msgid ""
+"Enter the name of the item you'd like help on in the :guilabel:`Package` "
+"field to load its documentation directly."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:29
+msgid ""
+"The module's file location is linked to the right of the doc's title, "
+"which you can click to view its source code."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:34
+msgid ""
+"Standard library modules also have a link to the corresponding `Python "
+"docs`_, which can be viewed right inside of the pane."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:41
+msgid ""
+"If you're not sure of the name of the object you want help on, or are "
+"looking for a specific keyword, use the :guilabel:`Search` field to get a"
+" list of results."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:46
+msgid ""
+"Links above the search field provide an index of topics with general help"
+" and a list of Python keywords linked to their corresponding docs."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:55
+msgid "Toolbar items"
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:57
+msgid ""
+"Just like in a web browser, the forward and back buttons move through the"
+" pages you have visited, and the home button (house icon) returns you to "
+"the module index."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:62
+msgid ""
+"Perform a realtime search within a page's content with the "
+":guilabel:`Find` button (magnifying glass icon top left) or "
+":kbd:`Ctrl-F`, navigate through matches with the Up and Down buttons, and"
+" make matching case sensitive with the :guilabel:`Aa` button."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:67
+msgid ""
+"You can view and re-run previous searches from the drop-down menu in the "
+":guilabel:`Package` field."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:72
+msgid ""
+"You can also use the zoom in/out buttons (:guilabel:`-` and "
+":guilabel:`+`, top right) to change the font size to suit your "
+"preferences."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:77
+msgid ""
+"To cancel searching or page loading, click the stop button (red square), "
+"and to reload the page (such as when you change your own package's "
+"documentation), press the refresh button (circular arrow)."
+msgstr ""
+
+#: ../../panes/outline.rst:3
+msgid "Outline"
+msgstr ""
+
+#: ../../panes/outline.rst:5
+msgid ""
+"The **Outline** pane allows you to view and navigate the functions, "
+"classes, methods, cells and comments in open Python files. To show or "
+"hide the Outline pane, use :menuselection:`View --> Panes --> Outline` or"
+" :kbd:`Ctrl-Shift-O` / :kbd:`Cmd-Shift-O`. Click an entry in the outline "
+"to jump to its source file location, and use the :guilabel:`Go to cursor "
+"position` toolbar button to highlight the item corresponding to the "
+"current :doc:`editor` position."
+msgstr ""
+
+#: ../../panes/outline.rst:18
+msgid ""
+"The options menu in the top-right of the pane allows customizing how the "
+"outline is displayed."
+msgstr ""
+
+#: ../../panes/outline.rst:23
+msgid "These customization settings include:"
+msgstr ""
+
+#: ../../panes/outline.rst:25
+msgid ""
+":guilabel:`Show absolute path`: Display the full path to each file "
+"instead of just the name."
+msgstr ""
+
+#: ../../panes/outline.rst:26
+msgid ""
+":guilabel:`Show all files`: List every open file rather than just the "
+"current one. This allows using the Outline as a file switcher."
+msgstr ""
+
+#: ../../panes/outline.rst:28
+msgid ""
+":guilabel:`Group code cells`: Group code cells in multiple nested levels "
+"in the outline rather than showing all cells in one level. You can create"
+" subsections by adding more ``%`` signs to the cell separator."
+msgstr ""
+
+#: ../../panes/outline.rst:30
+msgid ""
+":guilabel:`Display variables and attributes`: Display top-level "
+"variable/constant definitions and class attributes in the outline."
+msgstr ""
+
+#: ../../panes/outline.rst:31
+msgid ""
+":guilabel:`Follow cursor position`: Automatically highlight and expand "
+"the entry corresponding to the current cursor position in the "
+":doc:`editor`."
+msgstr ""
+
+#: ../../panes/outline.rst:32
+msgid ""
+":guilabel:`Show special comments`: List special comments in the outline, "
+"which start with ``# ----``."
+msgstr ""
+
+#: ../../panes/outline.rst:33
+msgid ""
+":guilabel:`Sort files alphabetically`: Sort the file list in alphabetical"
+" order. When disabled, all tabs will be sorted by the tab order of the "
+"currently selected Editor panel."
+msgstr ""
+
+#: ../../panes/outline.rst:40
+msgid "Icons"
+msgstr ""
+
+#: ../../panes/outline.rst:42
+msgid "The following icons are used for outline elements:"
+msgstr ""
+
+#: ../../panes/outline.rst:44
+msgid ":guilabel:`m` for methods"
+msgstr ""
+
+#: ../../panes/outline.rst:45
+msgid ":guilabel:`f` for functions"
+msgstr ""
+
+#: ../../panes/outline.rst:46
+msgid ":guilabel:`c` for classes"
+msgstr ""
+
+#: ../../panes/outline.rst:47
+msgid ":guilabel:`%` for code cells"
+msgstr ""
+
+#: ../../panes/outline.rst:48
+msgid ":guilabel:`#` for comments"
+msgstr ""
+
+#: ../../panes/plots.rst:3
+msgid "Plots"
+msgstr ""
+
+#: ../../panes/plots.rst:5
+msgid ""
+"The **Plots** pane shows the static figures and images created during "
+"your session. It will show you plots from the :doc:`ipythonconsole`, "
+"produced by your code in the :doc:`editor` or generated by the "
+":doc:`variableexplorer` allowing you to interact with them in several "
+"ways."
+msgstr ""
+
+#: ../../panes/plots.rst:11
+msgid ""
+"The figures shown in the Plots pane are those associated with the "
+"currently active :guilabel:`Console` tab; if you switch consoles, the "
+"list of plots displayed (or none at all, if a new console) will change "
+"accordingly."
+msgstr ""
+
+#: ../../panes/plots.rst:22
+msgid ""
+"The options menu in the top right of the :guilabel:`Plots` pane offers "
+"several ways to customize how your plots are displayed."
+msgstr ""
+
+#: ../../panes/plots.rst:26
+msgid "Mute inline plotting"
+msgstr ""
+
+#: ../../panes/plots.rst:28
+msgid ""
+"The :guilabel:`Mute inline plotting` option is enabled by default, "
+"preventing your plots from appearing in the Console. If you deactivate "
+"this option, figures will display in both the Plots pane and the Console."
+msgstr ""
+
+#: ../../panes/plots.rst:36
+msgid "Show plot outline"
+msgstr ""
+
+#: ../../panes/plots.rst:38
+msgid ""
+"The :guilabel:`Show plot outline` option, off by default, shows a thin "
+"stroke surrounding the area of the figure area, which will also appear in"
+" the exported images."
+msgstr ""
+
+#: ../../panes/plots.rst:45
+msgid "Fit plots to window"
+msgstr ""
+
+#: ../../panes/plots.rst:47
+msgid ""
+"The :guilabel:`Fit plots to Window` option, also enabled by default, "
+"sizes the figures to match the pane. Disabling it will display plots at "
+"their native size, and allow you use the zoom buttons at the top of the "
+"pane to scale them manually."
+msgstr ""
+
+#: ../../panes/plots.rst:57
+msgid "Toolbar options"
+msgstr ""
+
+#: ../../panes/plots.rst:59
+msgid ""
+"The toolbar at the top of the Plots pane provides several useful features"
+" that allow you to interact with your figures. For example, you can cycle"
+" sequentially through the plot list with the forward and back arrows."
+msgstr ""
+
+#: ../../panes/plots.rst:65
+msgid ""
+"You can also save one or all the plots in the pane to file(s) by clicking"
+" the respective \"save\"/\"save all\" icons in the toolbar. Plots are "
+"rendered and saved as PNG by default, but SVG can be selected as an "
+"option under :menuselection:`Preferences --> IPython console --> Graphics"
+" --> Inline backend --> Format`."
+msgstr ""
+
+#: ../../panes/plots.rst:71
+msgid ""
+"Additionally, if you want to use a figure in another document, you can "
+"click the \"copy to clipboard\" button and paste your plot wherever you "
+"want, such as a word processor."
+msgstr ""
+
+#: ../../panes/plots.rst:76
+msgid ""
+"Finally, you can use the \"remove\" and \"remove all\" buttons in the "
+"toolbar to clear plots from the list."
+msgstr ""
+
+#: ../../panes/profiler.rst:3
+msgid "Profiler"
+msgstr ""
+
+#: ../../panes/profiler.rst:5
+msgid ""
+"The **Profiler** pane recursively determines the run time and number of "
+"calls for every function and method called in a file, breaking down each "
+"procedure into its smallest individual units. This allows you to easily "
+"identify the bottlenecks in your code, points you toward the exact "
+"statements most critical for optimization, and measures the performance "
+"delta after followup changes."
+msgstr ""
+
+#: ../../panes/profiler.rst:15
+msgid "Running the Profiler"
+msgstr ""
+
+#: ../../panes/profiler.rst:17
+msgid ""
+"You can browse for a file using the open button to the right of the "
+"Profiler's path box (top left of the pane), which will run profiling over"
+" this file automatically."
+msgstr ""
+
+#: ../../panes/profiler.rst:22
+msgid ""
+"You can manually enter the path in the pane's path box and then run the "
+"analysis on the file by pressing :guilabel:`Profile` in the Profiler "
+"pane."
+msgstr ""
+
+#: ../../panes/profiler.rst:24
+msgid ""
+"You can also run profiling for the file that is currently open in the "
+":doc:`editor` by clicking :menuselection:`&Run --> Profile` in the menu "
+"bar, or by using a configurable shortcut (:kbd:`F10` by default)."
+msgstr ""
+
+#: ../../panes/profiler.rst:30
+msgid ""
+"If you'd like to cancel an in-progress run, click the :guilabel:`Stop` "
+"button in the top right, and if profiling fails for any reason, the "
+":guilabel:`Output` dialog will be displayed, indicating the error that "
+"occurred."
+msgstr ""
+
+#: ../../panes/profiler.rst:32
+msgid ""
+"By double-clicking an item in the Profiler, you will be taken to the file"
+" and line in the :doc:`editor` where it was called."
+msgstr ""
+
+#: ../../panes/profiler.rst:37
+msgid ""
+"You can increase the number of levels displayed for a particular object "
+"by clicking the dropdown arrows to the left of the name, and "
+"expand/collapse all the items with the buttons in the top left."
+msgstr ""
+
+#: ../../panes/profiler.rst:42
+msgid ""
+"By clicking the dropdown or press the :kbd:`Down Arrow` key in the "
+"filename field, you can recall paths of previous profiled files."
+msgstr ""
+
+#: ../../panes/profiler.rst:47
+msgid ""
+"Finally, you can save the data for a given run to disk as a file with the"
+" ``.Result`` extension using the :guilabel:`Save data` button. This can "
+"be loaded to compare with a previous run of the same file using the "
+":guilabel:`Load data` button. To remove the loaded data, click the "
+":guilabel:`Clear comparison` button."
+msgstr ""
+
+#: ../../panes/profiler.rst:58
+msgid "Interpreting the results"
+msgstr ""
+
+#: ../../panes/profiler.rst:60
+msgid ""
+"Results are broken down by function/method/statement, with each sub-"
+"element listed hierarchically under the top-level item that called them. "
+":guilabel:`Total Time` is that taken by the specified item and every "
+"function \"underneath\" (*i.e.* called by) it, while :guilabel:`Local "
+"Time` only counts the time spent in the particular callable object's own "
+"scope. The :guilabel:`Calls` column displays the total number of times "
+"the specified object was called at that level inside its parent calling "
+"function (or within the ``__main__`` scope, if a top-level object). "
+"Finally, the numbers in the :guilabel:`Diff` columns for each of the "
+"three appear if a comparison is loaded, and indicate the deltas between "
+"each measurement."
+msgstr ""
+
+#: ../../panes/profiler.rst:68
+msgid ""
+"For example, suppose you ran the :guilabel:`Profiler` on a file calling a"
+" function ``sleep_wrapper()`` that in turn called the ``sleep()`` "
+"function, and the ``sleep_wrapper()`` function took a total of 3.87 ms to"
+" run, with 3.86 ms of that spent executing the ``sleep()`` function "
+"inside it. Therefore, if ``sleep()`` called nothing else itself, its "
+":guilabel:`Total Time` and :guilabel:`Local Time` would both be "
+"identical, at 3.87 ms. Meanwhile, :guilabel:`Total Time` for "
+"``sleep_wrapper()`` would be 3.86 ms, but :guilabel:`Local Time` only "
+"0.01 ms as the rest was spent inside the ``sleep()`` function it called."
+msgstr ""
+
+#: ../../panes/profiler.rst:76
+msgid "Profiler plugins"
+msgstr ""
+
+#: ../../panes/profiler.rst:78
+msgid ""
+"There are two additional plugins that you can install to enable other "
+"types of profiling in Spyder. First, Spyder Line Profiler allows you to "
+"benchmark each line of your code individually. To learn more, visit the "
+"`spyder-line-profiler git repository`_."
+msgstr ""
+
+#: ../../panes/profiler.rst:87
+msgid ""
+"Second, Spyder Memory Profiler measures the memory usage of your code. "
+"For more information, go to the `spyder-memory-profiler git repository`_."
+msgstr ""
+
+#: ../../panes/projects.rst:3
+msgid "Projects"
+msgstr ""
+
+#: ../../panes/projects.rst:5
+msgid ""
+"Spyder allows you to associate a given directory with a **Project**, "
+"which automatically saves and restores the files you have open in the "
+":doc:`editor` from the last time you opened that project. With the "
+":ref:`Project <project-explorer>` pane, you can browse all your project's"
+" files, regardless of your current working directory or "
+":doc:`fileexplorer` location."
+msgstr ""
+
+#: ../../panes/projects.rst:11
+msgid ""
+"In addition, your project's root folder is used to set your working "
+"directory, and automatically added to the ``PYTHONPATH``, so you can "
+"easily ``import`` and work with any modules and packages you create "
+"inside of it."
+msgstr ""
+
+#: ../../panes/projects.rst:15
+msgid ""
+"Projects are completely optional and not imposed on users. All of Spyder'"
+" functionality (code completion, session saving, File Explorer, working "
+"directory, etc) is available without creating a :guilabel:`Project`."
+msgstr ""
+
+#: ../../panes/projects.rst:22
+msgid "Creating a Project"
+msgstr ""
+
+#: ../../panes/projects.rst:24
+msgid ""
+"To create a :guilabel:`Project`, click the :guilabel:`New Project` entry "
+"in the :guilabel:`Projects` menu, choose whether you'd like to associate "
+"a :guilabel:`Project` with an existing directory or make a new one, and "
+"enter the :guilabel:`Project`'s name and path."
+msgstr ""
+
+#: ../../panes/projects.rst:35
+msgid "Using the Projects Pane"
+msgstr ""
+
+#: ../../panes/projects.rst:37
+msgid ""
+"Once a :guilabel:`Project` is opened, the :guilabel:`Project` pane is "
+"shown, presenting a tree view of the current :guilabel:`Project`'s files "
+"and directories. It allows you to perform all the same :ref:`operations"
+"<file-operations>` as Spyder's :doc:`fileexplorer` pane."
+msgstr ""
+
+#: ../../panes/projects.rst:49
+msgid "Working with version control"
+msgstr ""
+
+#: ../../panes/projects.rst:51
+msgid ""
+"The :guilabel:`Project` pane has basic integration with the `Git`_ "
+"distributed version control system, just like :ref:`in the Files pane"
+"<files-vcs-support>`. You can commit or browse a file, directory or the "
+"entire repository via the commands in the context menu."
+msgstr ""
+
+#: ../../panes/projects.rst:56
+msgid ""
+"To use this functionality, the :guilabel:`Project` must be located in a "
+"``git`` repository and the ``git`` and ``gitk`` commands must be on the "
+"system path."
+msgstr ""
+
+#: ../../panes/pylint.rst:3
+msgid "Code Analysis"
+msgstr ""
+
+#: ../../panes/pylint.rst:5
+msgid ""
+"The **Code Analysis** pane detects style issues, bad practices, potential"
+" bugs, and other quality problems in your code, all without having to "
+"actually execute it. Based on these results, it also gives your code an "
+"overall quality score. Spyder's code analyzer is powered by the best-in-"
+"class `Pylint`_ back-end, which can intelligently detect an enormous and "
+"customizable range of potential errors, bad practices, quality issues, "
+"style violations, and more."
+msgstr ""
+
+#: ../../panes/pylint.rst:18
+msgid "Using the code analyzer"
+msgstr ""
+
+#: ../../panes/pylint.rst:20
+msgid ""
+"You can select the desired file to analyze directly in the :doc:`editor` "
+"by clicking anywhere within it. To run the analysis, press the "
+"configurable shortcut (:kbd:`F8` by default), select "
+":menuselection:`Source --> Run code analysis` from the menu bar or click "
+"the :guilabel:`Analyze` button in the Code Analysis pane. If the Code "
+"Analysis pane is not visible, you can open it under :menuselection:`View "
+"--> Panes --> Code Analysis`. All standard checks are run by default. To "
+"go directly to a line in the :doc:`editor` highlighted by a failed check,"
+" just click its name."
+msgstr ""
+
+#: ../../panes/pylint.rst:29
+msgid ""
+"You can also manually enter the path of a file you'd like it to check in "
+"the path entry box in the pane's toolbar. The analyzer works with both "
+"individual scripts and whole Python packages (directories containing an "
+":file:`__init__.py` file)."
+msgstr ""
+
+#: ../../panes/pylint.rst:35
+msgid ""
+"Cancel analyzing a file with the :guilabel:`Stop` button, and if analysis"
+" fails, click the :guilabel:`Output` button to find out why. If Pylint "
+"does succeed, the :guilabel:`Output` will show the raw plain text "
+"analysis results on the selected file, allowing you to easily browse and "
+"copy/paste the full message names and descriptions."
+msgstr ""
+
+#: ../../panes/pylint.rst:41
+msgid ""
+"Finally, you can click the dropdown or press the dropdown arrow in the "
+"filename field to view results of previous analyses."
+msgstr ""
+
+#: ../../panes/pylint.rst:52
+msgid ""
+"The number of recent runs Spyder should remember can be customized in the"
+" :guilabel:`History` dialog, available from the Code Analysis options "
+"menu."
+msgstr ""
+
+#: ../../panes/pylint.rst:57
+msgid ""
+"You can also expand or collapse one or all the sections in the pane by "
+"using the corresponding options in the options menu."
+msgstr ""
+
+#: ../../panes/pylint.rst:66
+msgid "Advanced options"
+msgstr ""
+
+#: ../../panes/pylint.rst:68
+msgid ""
+"You can turn certain messages off at the line, block or file/module level"
+" by adding a ``# pylint: disable=MESSAGE-NAMES`` comment at the "
+"respective `scope`_, where ``MESSAGE_NAMES`` should be replaced with a "
+"comma-separated list (or single value) of `Pylint message names`_. For "
+"example, a directive might look like ``# pylint: disable=invalid-name``, "
+"or ``# pylint: disable=fixme, line-too-long``."
+msgstr ""
+
+#: ../../panes/pylint.rst:78
+msgid ""
+"Or, you can globally suppress specific messages and adjust other Pylint "
+"settings by editing the :file:`.pylintrc` configuration file in your user"
+" folder. If it doesn't exist, you can generate it by running ``pylint "
+"--generate-rcfile > .pylintrc`` in your user directory, from Anaconda "
+"Prompt (on Windows) or your terminal (macOS/Linux). For more details on "
+"configuring Pylint, see the `Pylint documentation`_."
+msgstr ""
+
+#: ../../panes/pylint.rst:94
+msgid ":doc:`profiler`"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:3
+msgid "Variable Explorer"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:5
+msgid ""
+"The **Variable Explorer** allows you to interactively browse and manage "
+"the objects generated running your code."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:10
+msgid ""
+"It shows the namespace contents (including all global objects, variables,"
+" class instances and more) of the currently selected "
+":doc:`ipythonconsole` session, and allows you to add, remove, and edit "
+"their values through a variety of GUI-based editors."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:15
+msgid ""
+"The Variable Explorer gives you information on the name, size, type and "
+"value of each object. To modify a scalar variable, like an number, string"
+" or boolean, simply double click it in the pane and type its new value."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:25
+msgid "Object viewers"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:27
+msgid ""
+"Spyder's :guilabel:`Variable Explorer` offers built in support for "
+"editing lists, strings, dictionaries, NumPy arrays, Pandas DataFrames, "
+"Series and more; as well as being able to plot and visualize them with "
+"one click."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:31
+msgid "Strings"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:33
+msgid ""
+"When a string variable is longer than forty characters, you can double "
+"click it to see its value in a text editor to more easily modify it."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:41
+msgid "Dictionaries"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:43
+msgid ""
+"Double-clicking on dictionaries will show a viewer displaying each of its"
+" keys with its associated value. You can double click any of the values "
+"to modify them, which will open a new viewer if the value is itself an "
+"object."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:52
+msgid "Lists"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:54
+msgid ""
+"For lists, the main Variable Explorer displays a preview of the first ten"
+" values. To see them all, double click the list to open a viewer that "
+"will display the index, type, size and value of each element of the list."
+" Just like dictionaries, you can double-click values to edit them."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:64
+msgid "Numpy arrays"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:66
+msgid ""
+"Like lists, for Numpy arrays the Variable Explorer shows a preview of "
+"their values. Double-clicking them will open a viewer displaying the "
+"array values in a \"heat map\", with each value in a grid cell colored "
+"based on its numeric quantity. You can deactivate the background color by"
+" unchecking the appropriate option in the viewer, which will happen "
+"automatically if the array is too large to improve performance."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:73
+msgid ""
+"If supported by the datatype, you can also change the format of the "
+"array's values, choosing the number of decimals that you want the array "
+"to display. For this, click the :guilabel:`Format` button and and set the"
+" desired formatting in the dialog that appears, using standard `Printf-"
+"style syntax`_."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:78
+msgid ""
+"Additionally, you can adjust the size of the rows and columns of the "
+"array by expanding or contracting their headers. Clicking the "
+":guilabel:`Resize` button will set it automatically."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:86
+msgid "DataFrames"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:88
+msgid ""
+"DataFrames, like Numpy arrays, display in a viewer where you can show or "
+"hide \"heatmap\" colors, change the format and resize the rows and "
+"columns either manually or automatically."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:93
+msgid ""
+"Additionally, starting in Spyder 4, the Variable Explorer has MultiIndex "
+"support in its DataFrame inspector, including for multi-level and multi-"
+"dimensional indices."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:105
+msgid ""
+"The options menu in the top right of the Variable Explorer pane allows "
+"you filter the objects shown by a number of different criteria."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:110
+msgid ""
+"It also allows you to display the min and max of Numpy arrays instead of "
+"a preview of their values."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:120
+msgid "Toolbar buttons"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:122
+msgid ""
+"The Variable Explorer's toolbar includes several useful features that "
+"affect the entire namespace. For example, you can save the current "
+"session's data as a ``.spydata`` file, which can be loaded later to "
+"recover all the variables stored."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:130
+msgid ""
+"You should **not** load any ``.spydata`` file from any source you don't "
+"fully trust (ideally, only those files you've saved yourself). Like with "
+"any `Python pickle`_, it is inherently not secure against malicious code,"
+" as it can load any Python object and can execute arbitrary code on your "
+"machine. Additionally, it is not guaranteed to work reliably across all "
+"Python environments other than the one it was created in, so it should be"
+" only used as a local persistence format, not for interchange."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:136
+msgid ""
+"There is also a button to remove all displayed variables, and a search "
+"box to find objects by  name or type."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:141
+msgid ""
+"Finally, there is a button to refresh the Variable Explorer's contents, "
+"which will update it to show the current state of the code running in the"
+" IPython console."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:147
+msgid "Advanced functionality"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:149
+msgid ""
+"The context menu, available by right-clicking any variable, provides "
+"numerous additional options to interact with objects of various types. "
+"These include renaming, removing or editing existing variables, as well "
+"as the :guilabel:`duplicate` option to create a new copy of one of them "
+"under a new name you enter in the resulting dialog box."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:155
+msgid ""
+"Furthermore, you can copy and paste the value of a variable, saving it in"
+" the Variable Explorer with any name that you choose. This allows you to "
+"change the type of the variable that you are pasting which can be very "
+"useful, allowing you to, for example, easily copy the elements of a list "
+"into an array."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:161
+msgid ""
+"Additionally, you can create an object from scratch directly in the "
+"Variable Explorer with the :guilabel:`Insert` option, which allows you to"
+" type the key (which should be in quotation marks) and the value for the "
+"item that you want to insert. In addition to adding a new top-level "
+"variable, this feature also allows you to create a new key in a "
+"dictionary, a new element in a list, and much more."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:167
+msgid ""
+"For lists and Numpy arrays, more advanced options are available, "
+"including generating plots and histograms of their values appropriate to "
+"their type and dimensions."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:172
+msgid ""
+"You can even save an array to a ``.npy`` file by simply clicking the "
+"appropriate option, which can later be loaded by Spyder or in your code "
+"via ``numpy.load()``."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:178
+msgid ""
+"For two-dimensional arrays, you can also display them as images, treating"
+" their values as RGB colors. For this, Spyder uses Matplotlib's "
+"colormaps, which can be `easily changed to match your preferences`_."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:185
+msgid ""
+"Finally, we added a context-menu action to open any object using the new "
+"Object Explorer even if they already have a builtin viewer (DataFrames, "
+"arrays, etc), allowing for deeper inspection of the inner workings of "
+"these datatypes."
+msgstr ""
+

--- a/doc/locales/en/LC_MESSAGES/plugins.po
+++ b/doc/locales/en/LC_MESSAGES/plugins.po
@@ -1,0 +1,332 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../plugins/index.rst:3
+msgid "Spyder Plugins"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:3
+msgid "Spyder Line Profiler"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:5
+msgid ""
+"**Spyder-Line-Profiler** is a plugin to run the Python `line profiler`_. "
+"This package profiles the time that individual lines of code take to "
+"execute."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:17
+msgid "Installing the Line Profiler"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:19
+msgid ""
+"If you installed Spyder using conda, the best way to obtain Spyder-Line-"
+"Profiler is to run the following command in your terminal (or Anaconda "
+"prompt on Windows):"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:27
+msgid ""
+"At the moment it is not possible to use this plugin with the Spyder :ref"
+":`install-standalone` for Windows and macOS. We're working to add support"
+" for them in the future."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:30 ../../plugins/notebook.rst:26
+#: ../../plugins/terminal.rst:27
+msgid "Restart Spyder in order to be able to use the plugin."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:36
+msgid "Using the Line Profiler"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:38
+msgid ""
+"When the Line Profiler is installed, it will be available under the menu "
+"item :menuselection:`View --> Panes --> Line Profiler`."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:43
+msgid ""
+"You will see it then as a tab next to the :guilabel:`Files` tab. For the "
+"Line Profiler to work, you must place the ``@profile`` decorator on the "
+"line above any functions that you wish to profile."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:49
+msgid ""
+"Now that the decorators have been added, you can then either select a "
+"script with the button present in the pane or run the profiler from "
+":menuselection:`Run --> Profile line by line`. Your file will then be "
+"profiled line by line."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:55
+msgid ""
+"After running the profiler, either from the button in the pane or the "
+":menuselection:`Run` menu, the results are shown in the :guilabel:`Line "
+"Profiler` pane. The path displayed there is that of the file being "
+"profiled."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:61
+msgid "The Line Profiler pane shows six columns:"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:63
+msgid "``Line #:`` the number of the line being profiled."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:64
+msgid "``Hits:`` how many times that line is hit in the scope."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:65
+msgid ""
+"``Time (ms):`` time spent running the line in total for all hits, in "
+"milliseconds."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:66
+msgid "``Per hit (ms):`` average time spent per hit, in milliseconds."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:67
+msgid "``% Time:`` percentage of time taken by that line of total scope time."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:68
+msgid "``Line contents:`` the source code in the line."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:70
+msgid "Lines with a stronger color take more time to run."
+msgstr ""
+
+#: ../../plugins/notebook.rst:3
+msgid "Spyder Notebook"
+msgstr ""
+
+#: ../../plugins/notebook.rst:5
+msgid ""
+"**Spyder-notebook** is a plugin that allows you to open, edit and "
+"interact with Jupyter Notebooks right inside Spyder."
+msgstr ""
+
+#: ../../plugins/notebook.rst:10
+msgid ""
+"Using notebooks inside Spyder allows you to take advantage of their web "
+"interface alongside Spyder’s powerful features such as the Variable "
+"explorer, console and debugger."
+msgstr ""
+
+#: ../../plugins/notebook.rst:14
+msgid "Installing the Notebook"
+msgstr ""
+
+#: ../../plugins/notebook.rst:16
+msgid ""
+"If you installed Spyder using conda, the best way to install Spyder-"
+"notebook is to run the following command in your terminal or Anaconda "
+"prompt on Windows:"
+msgstr ""
+
+#: ../../plugins/notebook.rst:24 ../../plugins/terminal.rst:25
+msgid ""
+"At the moment it is not possible to use this plugin with the Spyder :ref"
+":`install-standalone` for Windows and macOS. We're working to make that "
+"possible in the future."
+msgstr ""
+
+#: ../../plugins/notebook.rst:30
+msgid "Using the Notebook"
+msgstr ""
+
+#: ../../plugins/notebook.rst:32
+msgid ""
+"When the Notebook is installed, it will be available under the menu item "
+":menuselection:`View --> Panes --> Notebook`."
+msgstr ""
+
+#: ../../plugins/notebook.rst:37
+msgid ""
+"You will see it then as a tab in the bottom of the editor area. When "
+"switching to it, a welcome screen will be displayed, from where you can "
+"create a new notebook by right-clicking it and selecting :guilabel:`New "
+"notebook`."
+msgstr ""
+
+#: ../../plugins/notebook.rst:42
+msgid ""
+"You can also click the :guilabel:`Plus` button at the top right of the "
+"pane. A new Jupyter Notebook will be opened as a tab, ready for user "
+"input in a temporary file. This can serve as a scratch pad where you can "
+"do quick calculations and plots."
+msgstr ""
+
+#: ../../plugins/notebook.rst:47
+msgid ""
+"To save this notebook go to the options menu at the top right of the pane"
+" and click the :guilabel:`Save as...` option. This will store your "
+"notebook locally with the ``ipynb`` extension, which will allow you to "
+"open it then as a Jupyter Notebook outside of Spyder."
+msgstr ""
+
+#: ../../plugins/notebook.rst:52
+msgid ""
+"You can also open any Jupyter Notebook inside Spyder. For this go to the "
+"options menu at the top right of the pane and click :guilabel:`Open`, "
+"which will allow you to look for ``ipynb`` files in your computer. Click "
+"any notebook that you want to open inside Spyder and you will be able to "
+"see it as a new tab in the Notebook pane."
+msgstr ""
+
+#: ../../plugins/notebook.rst:57
+msgid ""
+"The :guilabel:`Open recent` option displays a list of the recent "
+"notebooks you opened in Spyder, from which you can select them and open "
+"them again in Spyder."
+msgstr ""
+
+#: ../../plugins/notebook.rst:61
+msgid "Connecting an IPython Console"
+msgstr ""
+
+#: ../../plugins/notebook.rst:63
+msgid ""
+"You can connect an :doc:`/panes/ipythonconsole` to your notebook, which "
+"will allow you to view your variables in the "
+":doc:`/panes/variableexplorer`. To do so, go to the options menu and "
+"click the :guilabel:`Open console` option. This will open a new console "
+"with the same name of your notebook and display the variables of the "
+"cells that you have executed previously in your Notebook. If you don't "
+"see them, press :kbd:`Enter` in the console."
+msgstr ""
+
+#: ../../plugins/notebook.rst:68
+msgid "You can view, modify and create new ones in the console too."
+msgstr ""
+
+#: ../../plugins/notebook.rst:70
+msgid ""
+"Since the Variable Explorer is associated to each console, closing the "
+"notebook's console will immediately hide the variables from the Variable "
+"Explorer."
+msgstr ""
+
+#: ../../plugins/notebook.rst:74
+msgid "Additional Options"
+msgstr ""
+
+#: ../../plugins/notebook.rst:76
+msgid ""
+"The context menu, available by right-clicking the pane area outside the "
+"notebook, allows you to zoom your notebook in or out."
+msgstr ""
+
+#: ../../plugins/notebook.rst:81
+msgid ""
+"You can also select the code from your Notebook and copy it on your "
+"clipboard to paste this code anywhere you want."
+msgstr ""
+
+#: ../../plugins/notebook.rst:86
+msgid ""
+"Finally, you can see all the server information of your notebook by "
+"clicking the :guilabel:`Server info` option in the context menu."
+msgstr ""
+
+#: ../../plugins/terminal.rst:3
+msgid "Spyder Terminal"
+msgstr ""
+
+#: ../../plugins/terminal.rst:5
+msgid ""
+"**Spyder-terminal** is a plugin that allows you to have integrated system"
+" terminals inside Spyder."
+msgstr ""
+
+#: ../../plugins/terminal.rst:10
+msgid ""
+"Spyder-terminal allows you to use any system shell installed in your "
+"system (e.g. Bash, Zsh or Powershell) rather than just the IPython "
+"console. You can use it to issue commands, interact with version control "
+"or to run programs."
+msgstr ""
+
+#: ../../plugins/terminal.rst:15
+msgid "Installing the Terminal"
+msgstr ""
+
+#: ../../plugins/terminal.rst:17
+msgid ""
+"If you installed Spyder using conda, the best way to install Spyder-"
+"terminal is to run the following command in your Terminal or Anaconda "
+"prompt on Windows:"
+msgstr ""
+
+#: ../../plugins/terminal.rst:31
+msgid "Using the Terminal"
+msgstr ""
+
+#: ../../plugins/terminal.rst:33
+msgid ""
+"When the Terminal is installed, it will be available under the menu item "
+":menuselection:`View --> Panes --> Terminal`."
+msgstr ""
+
+#: ../../plugins/terminal.rst:38
+msgid ""
+"You will see it then as a tab at the bottom of the console area. When "
+"switching to it, a new terminal tab will be created. You can also create "
+"more terminals by clicking in the :guilabel:`+` button at the upper right"
+" corner of the terminal area."
+msgstr ""
+
+#: ../../plugins/terminal.rst:43
+msgid ""
+"Clicking the :guilabel:`Options` button next to the :guilabel:`+` button "
+"will allow you to rename terminals, undock the terminal, and open a "
+"terminal in the directory of the current Editor file."
+msgstr ""
+
+#: ../../plugins/terminal.rst:48
+msgid ""
+"If you right click the terminal area, it's possible to issue commands "
+"such as :guilabel:`Clear Terminal`, :guilabel:`Zoom In/Out` and "
+":guilabel:`Copy/Paste Text`."
+msgstr ""
+
+#: ../../plugins/terminal.rst:55
+msgid "Terminal Preferences"
+msgstr ""
+
+#: ../../plugins/terminal.rst:57
+msgid ""
+"It's also possible to customize the Terminal by going to "
+":menuselection:`python --> Preferences...` and then clicking on the "
+"Terminal tab on the menu to the left. You can select the shell "
+"interpreter, set the buffer limit and the type of cursor."
+msgstr ""
+

--- a/doc/locales/en/LC_MESSAGES/quickstart.po
+++ b/doc/locales/en/LC_MESSAGES/quickstart.po
@@ -1,0 +1,34 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../quickstart.rst:3
+msgid "Quickstart"
+msgstr ""
+
+#: ../../quickstart.rst:5
+msgid ""
+"Welcome to our Quickstart! Here you will find an interactive tour that "
+"will guide you through Spyder's interface. You'll get familiar with the "
+"most important parts of the IDE, especially those we'll be mentioning "
+"throughout our docs. Finally, you'll get to walk through some of Spyder's"
+" key panes and functionality."
+msgstr ""
+

--- a/doc/locales/en/LC_MESSAGES/troubleshooting.po
+++ b/doc/locales/en/LC_MESSAGES/troubleshooting.po
@@ -1,0 +1,1195 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../troubleshooting/basic-first-aid.rst:3
+msgid "Basic First Aid"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:5
+msgid ""
+"These suggestions, while more of a shotgun approach, tend to fix the "
+"majority of reported issues just on their own."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:11
+msgid "Recommended troubleshooting steps"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:13
+msgid "**Restart Spyder**, and try what you were doing before again."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:15
+msgid ""
+"**Upgrade Spyder** to the latest release, and you might find your issue "
+"is resolved (along with new features, enhancements, and other bug fixes)."
+" Minor releases come out every couple months, so unless you've updated "
+"recently, there is a good chance your version isn't the latest. You can "
+"find out with the :guilabel:`Check for updates` command under the "
+":guilabel:`Help` menu."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:22
+msgid ""
+"To perform the update with Conda (strongly recommended), from your "
+"terminal (or Anaconda Prompt on Windows) run:"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:29
+msgid ""
+"**Update Spyder's dependencies and environment**, either by installing "
+"the latest version of your distribution (e.g. the recommended Anaconda), "
+"or with the relevant \"update all\" command in your terminal (or Anaconda"
+" Prompt on Windows). To get the latest stable version of everything using"
+" Conda, you can run:"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:36
+msgid ""
+"**Restart your machine**, in case the problem lies with a lingering "
+"process or another such issue."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:38
+msgid ""
+"**Restore Spyder's config files** to their defaults, which solves a huge "
+"variety of Spyder issues. From your terminal (or Anaconda Prompt on "
+"Windows), run:"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:47
+msgid ""
+"This will reset your preferences, as well as any custom keyboard "
+"shortcuts or syntax highlighting schemes. If you particularly care about "
+"any of those, you should make a copy of the :file:`.spyder-py3` folder in"
+" your user home directory (:file:`C:/Users/YOUR_USERNAME` on Windows, "
+":file:`/Users/YOUR_USERNAME` on macOS, or :file:`/home/YOUR_USERNAME` on "
+"Linux), and restore it afterwards if this doesn't solve the problem."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:50
+msgid ""
+"**Try installing Spyder into a new Conda environment** (recommended) or "
+"``virtualenv``/``venv``, and see if the issue reoccurs."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:52
+msgid ""
+"In your system terminal (or Anaconda Prompt on Windows), run the "
+"following commands to create an a fresh, clean environment and start "
+"Spyder in it:"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:60
+msgid ""
+"If this fixes the issue, the problem was likely due to another package "
+"installed on your system, particularly if done with pip, which can cause "
+"many problems and should be avoided if at all possible."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:62
+msgid ""
+"**Watch our video** on solving and avoiding problems with pip, Conda and "
+"Conda-Forge, and follow its instructions."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:75
+msgid "Reinstalling Spyder"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:77
+msgid ""
+"If none of the previous steps solve your issue, you should do a full "
+"uninstall of Spyder by whatever means you originally installed it."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:79
+msgid ""
+"For Anaconda, follow all the steps under Option B in the `Anaconda "
+"uninstall guide`_, delete the Anaconda directory wherever it was "
+"originally installed, and (on Windows) remove the "
+":file:`%appdata%/python` directory if it exists."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:84
+msgid ""
+"Then, do a clean install of the latest version of the `Anaconda "
+"distribution`_ which is how we recommend you install Spyder and keep it "
+"up to date."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:88
+msgid ""
+"While you are welcome to get Spyder working on your own by one of the "
+"many other means we offer, we are only able to provide individual support"
+" for install-related issues for users of the Anaconda distribution. In "
+"particular, pip installation, while doable, is only really for experts, "
+"as there are many pitfalls involved and different issues specific to your"
+" setup, which is why we recommend using Conda whenever possible. For "
+"further information, please visit our :doc:`/installation`."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:99
+msgid "Isolating problems"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:101
+msgid ""
+"If you get an error while running a specific line, block, or "
+"script/program, it may not be an issue with Spyder, but rather something "
+"lower down in the packages it depends on. Try running it in the following"
+" in order if and until it starts working as you expect. If you manage to "
+"isolate the bug, report it to the last one it *doesn't* work in."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:105
+msgid ""
+"**Spyder** itself, of course! Make sure you can reproduce the error after"
+" closing and reopening it, if possible."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:108
+msgid ""
+"**A bare QtConsole instance**, e.g. launched from Anaconda navigator or "
+"from the Anaconda Prompt/Terminal/command line (Windows/Mac/Linux) with "
+"``jupyter qtconsole``."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:113
+msgid ""
+"QtConsole is the GUI console backend Spyder depends on to run its code, "
+"so most issues involving Spyder's :doc:`/panes/ipythonconsole` are "
+"actually something with QtConsole instead, and can be reported to their "
+"`issue tracker`_."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:115
+msgid ""
+"**An IPython command line shell**, launched with e.g. ``ipython`` from "
+"the Anaconda Prompt/Terminal/command line (Windows/Mac/Linux). "
+"Reproducible bugs can be reported to their `Github page`_, though make "
+"sure to read their guidelines and docs first."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:118
+msgid ""
+"**A standard Python interpreter**, either run as a script file with "
+"``python path/to/your/file.py`` or launched interactively with ``python``"
+" from your Anaconda Prompt/Terminal/command line (Windows/Mac/Linux). "
+"While it is not impossible that you've found Python bug, it is much more "
+"likely to be an issue with the code itself or a package you are using, so"
+" your best sources are the `Python docs`_ and the other resources listed "
+"above."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:127
+msgid ""
+"If the problem reoccurs in a similar or identical way with any of these "
+"methods (other than only Spyder itself), then it is almost certainly not "
+"an issue with Spyder, and would be best handled elsewhere. As we usually "
+"aren't able to do much about issues not related to Spyder, a forum like "
+"`Stack Overflow`_ or the relevant package's docs is a much better place "
+"to get help or report the issue."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:132
+msgid ""
+"See the :doc:`call-for-help` section for other places to look for "
+"information and assistance."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:138
+msgid "Debugging and patching"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:140
+msgid ""
+"If you know your way around Python, you can often diagnose and even fix "
+"Spyder issues yourself, since the IDE is written in the same language you"
+" use in it. You can explore the error messages you're receiving and "
+"Spyder's inner workings with the :guilabel:`Internal Console`, available "
+"under the menu item :menuselection:`View --> Panes --> Internal Console`."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:146
+msgid ""
+"For more detailed debug output, start Spyder from the command line "
+"(Anaconda Prompt on Windows) with ``spyder --debug-info verbose``."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:148
+msgid ""
+"Even if you don't manage to fix the problem yourself, this output can be "
+"very helpful in aiding us to quickly narrow down and solve your issue for"
+" you."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:3
+msgid "Calling for Help"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:5
+msgid ""
+"Aside from this troubleshooting guide, there are a number of other "
+"sources of documentation and troubleshooting information you can check "
+"before submitting an issue, as they might already offer an answer, or at "
+"least help you better understand the problem. Even if we aren't able to "
+"help you, these places might."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:14
+msgid "Spyder-related platforms"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:19
+msgid "Spyder's FAQ section"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:21
+msgid ""
+"Spyder's documentation has a FAQ section, where you might find the "
+"answers that you are looking for."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:27
+msgid "Spyder's YouTube channel"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:29
+msgid ""
+"Our `YouTube channel`_ contains helpful videos that will guide you "
+"through many of Spyder's features, and provide a starting point for newer"
+" users."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:37
+msgid "Spyder Gitter"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:39
+msgid ""
+"We have a public `Gitter room`_ where you can chat directly with the "
+"Spyder developers. If you've got a quick question to ask the team and are"
+" looking for a quick answer, this is a great place to go."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:48
+msgid "Spyder Google Group"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:50
+msgid ""
+"Our `Google Group`_ is great for help-related questions, particularly "
+"those you aren't sure are a full-on Spyder issue."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:58
+msgid "Spyder website"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:60
+msgid ""
+"The `Spyder site`_ contains basic information about the IDE and links to "
+"many other helpful resources."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:68
+msgid "Stack Overflow tag"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:70
+msgid ""
+"`Stack Overflow`_ is a great place to start searching and posting, "
+"particularly if your question is more programming-related, or has to do "
+"with something specific to your own code. It has an vibrant Spyder "
+"community as well, with new questions posted every day, and the "
+"developers (especially Carlos Cordoba, the lead maintainer) are active in"
+" answering them."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:79
+msgid "OpenTeams support"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:81
+msgid ""
+"On `OpenTeams`_, you can get help from expert Spyder consultants. "
+"OpenTeams offers services from Spyder experts ranging from a brief "
+"consultation to an experienced team to help you with a large scale "
+"implementation project."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:91
+msgid "Python resources"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:96
+msgid "Official Python help page"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:98
+msgid ""
+"The `Python help page`_ is a great resource that lists a number of places"
+" you can get assistance, support and learning resources for the language "
+"and its packages."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:106
+msgid "Python documentation"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:108
+msgid ""
+"The `Python docs`_ can help you understand a number of issues that can be"
+" caused by quirks in the language itself, or misunderstandings as to how "
+"it behaves."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:116
+msgid "Python subreddits"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:118
+msgid ""
+"`r/python`_ and `r/learnpython`_ are resources you can use to ask about "
+"and discuss issues with Python and its packages. The former is aimed more"
+" at general Python usage, and the latter more specifically at beginners."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:130
+msgid "Data science/SciPy resources:"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:136
+msgid "Anaconda help"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:138
+msgid ""
+"The `Anaconda docs`_ site offers free community help and documentation "
+"for the Anaconda applications, installing the Anaconda distribution, and "
+"using the Conda package and environment manager; along with paid support "
+"options."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:145
+msgid "SciPy.org website"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:147
+msgid ""
+"The `Scipy website`_ is the the central home of the SciPy stack, with "
+"information, documentation, help, and bug tracking for many of the core "
+"packages used with Spyder, including NumPy, SciPy, Matplotlib, Pandas, "
+"Sympy and IPython."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:155
+msgid "Project Jupyter"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:157
+msgid ""
+"`Jupyter`_ is the development hub for IPython, Spyder's QtConsole, "
+"Jupyter notebooks used with the `Spyder-Notebook`_ plugin, and more."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:166
+msgid "Data Science Stack Exchange"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:168
+msgid ""
+"The `Data Science`_ site in Stack Exchange can be very useful for "
+"questions that relate more to data science than programming specifically."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:3
+msgid "Common Illnesses"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:5
+msgid ""
+"Beyond the general troubleshooting steps, some frequently-reported "
+"problems require more specialized solutions."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:13
+msgid "Errors starting the kernel"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:15
+msgid ""
+"If you receive the message ``An error occurred while starting the "
+"kernel`` in the :doc:`/panes/ipythonconsole`, Spyder was unable to launch"
+" a new Python interpreter in the current working environment to run your "
+"code. There are a number of problems that can cause this, but most can be"
+" fixed fairly quickly with a few easy steps."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:22
+msgid "Spyder-Kernels not installed/incompatible"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:24
+msgid ""
+"Spyder requires a supported version of the ``spyder-kernels`` package to "
+"be present in the working environment you want to run your console in."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:29
+msgid ""
+"It is included by default with Anaconda, but if you want to run your code"
+" in another Python environment or installation, you'll need to make sure "
+"it's installed and updated to the latest version."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:31
+msgid ""
+"Check the required version of spyder-kernels for your version of Spyder "
+"in the following table:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:33
+msgid "Spyder and Spyder-Kernels version compatibility"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:36
+msgid "Spyder"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:36
+msgid "Spyder-Kernels"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:38
+msgid "4.0.0-4.0.1"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:38
+msgid "1.8.1"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:39
+msgid "4.1.0-4.1.2"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:39
+msgid "1.9.0"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:40
+msgid "4.1.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:40
+msgid "1.9.1"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:41
+msgid "4.1.4"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:41
+msgid "1.9.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:42
+msgid "4.1.5-4.1.6"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:42
+msgid "1.9.4"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:43
+msgid "4.2.0"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:43
+msgid "1.10.0"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:44
+msgid "5.0.0-5.0.5"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:44
+msgid "2.0.5"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:45
+msgid "5.1.0-5.1.5"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:45
+msgid "2.1.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:46
+msgid "5.2.0-5.2.1"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:46
+msgid "2.2.0"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:47
+msgid "5.2.2"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:47
+msgid "2.2.1"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:48
+msgid "5.3.0-5.3.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:48
+msgid "2.3.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:49
+msgid "5.4.0-5.4.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:49
+msgid "2.4.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:52
+msgid ""
+"To do so, activate the environment, then install ``spyder-kernels``. If "
+"using Anaconda, open a terminal (Anaconda Prompt on Windows) and run:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:60
+msgid ""
+"Otherwise, activate your environment by whatever means you created it, "
+"and execute:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:66
+msgid ""
+"For both of the previous commands, replace ``<VERSION>`` with the "
+"corresponding version in the table."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:70
+msgid "Issue with another dependency"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:72
+msgid ""
+"If the kernel displays a long error traceback that mentions other "
+"packages like ``ipython``, ``ipykernel``, ``jupyter_client``, "
+"``traitlets`` or ``pyzmq``, the problem may be an out of date or "
+"incompatible version of a dependency package. To fix this, activate the "
+"environment and update the key dependencies."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:75
+msgid "In an Anaconda environment:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:82
+msgid ""
+"Otherwise, activate your environment by whatever means you created it, "
+"and run:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:90
+msgid "AttributeError/ImportError"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:92
+msgid ""
+"Check the last few lines of the error message, and see if its an "
+"``AttributeError`` or ``ImportError``, or refers to a file you created in"
+" your current working directory or your home folder "
+"(:file:`C:/Users/YOUR_USERNAME` on Windows, :file:`/Users/YOUR_USERNAME` "
+"on macOS, or :file:`/home/YOUR_USERNAME` on Linux)."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:97
+msgid ""
+"If so, the the error is likely due to your file being named the same as a"
+" Python standard library module, such as ``string.py`` or ``time.py``, "
+"which overrides the built-in module that Spyder-Kernels is trying to "
+"load. To fix this, simply rename your file to something other than one of"
+" these names, and try restarting the kernel. To check the names of these "
+"modules, see the list in the `Python standard library documentation`_."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:109
+msgid "Completion/help not working"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:111
+msgid ""
+"To provide code completions, help and real-time analysis in the Editor, "
+"Spyder uses the Python Language Server (PyLS), an implementation of the "
+"Language Server Protocol specification used by VSCode, Atom and other "
+"popular editors/IDEs. Most help and completion issues lie outside of "
+"Spyder's control, and are either limitations with PyLS or the code that "
+"is being introspected, but some can be worked around."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:116
+msgid "Object missing docstring"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:118
+msgid ""
+"If nothing is displayed in the calltip, hover hint or help pane, the "
+"object you're trying to introspect may not have a docstring."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:124
+msgid ""
+"In this case, the only solution is to add one in the source code of the "
+"original function, method or class."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:128
+msgid "Object cannot be found"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:130
+msgid ""
+"Some objects, whether due to being written in C, Cython or another "
+"language; generated dynamically at runtime; or being a method of an "
+"object you create, cannot be easily found without executing the code."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:136
+msgid ""
+"However, once you run your code in the :doc:`/panes/ipythonconsole`, you "
+"might be able to get help and completions on the object there."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:140
+msgid "LSP has stopped working"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:142
+msgid ""
+"Occasionally, especially after using Spyder for a while, code completion,"
+" help and analysis may stop working. If this is the case, you can check "
+"LSP status with the :guilabel:`LSP Python` item in Spyder's status bar at"
+" the bottom of the screen, and restart it by right-clicking it and "
+"selecting the :guilabel:`Restart Python Language Server` item."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:150
+msgid "Spyder bug/dependency issue"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:152
+msgid ""
+"Given the variety of dependencies involved in making LSP work, an "
+"incompatible or out of date version in your environment can result in "
+"error messages, incomplete results, or help/analysis not working at all."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:154
+msgid ""
+"To address this, first try updating Anaconda and Spyder as described in "
+":doc:`basic-first-aid`. If the issue still isn't resolved, update the "
+"various relevant dependencies with:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:165
+msgid "Plugin Problems"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:168
+msgid "Plugin does not work at all"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:170
+msgid ""
+"If you have installed a Spyder plugin, but you can't see it, go to the "
+":guilabel:`Panes` submenu of the :guilabel:`View` menu and select the "
+"plugin's name, which should make its pane visible. If you don't see the "
+"plugin there, select the :guilabel:`Dependencies` item under the "
+":guilabel:`Help` menu and see if the plugin appears at the bottom."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:176
+msgid ""
+"If the plugin with the problem is not listed in the dependencies dialog, "
+"check that you installed it in the same environment as Spyder. If you "
+"have, then the problem may well be caused by a dependency issue. Test "
+"whether you can import the plug-in manually by opening a Python console "
+"in the same environment as Spyder and typing, for instance, ``import "
+"spyder_unittest`` to test the Spyder-Unittest` plug-in; this command "
+"should run without errors."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:180
+msgid ""
+"If none of this helps you to resolve the problem, then continue to the "
+"next section."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:184
+msgid "Other issues"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:186
+msgid ""
+"If you get an error which mentions or involves a Spyder plugin, such as "
+"``spyder-unittest``, ``spyder-terminal`` or ``spyder-notebook``, or if "
+"you encounter any other problem with a Spyder plugin, then the first "
+"approach should be to update Spyder and the plugin to their latest "
+"versions."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:188
+msgid ""
+"If this doesn't fix the problem, you should check the plugin's website or"
+" repository to see if it is compatible with your version of Spyder."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:190
+msgid ""
+"Finally, if compatibility doesn't seem to be the problem, please check "
+"those repositories to see if an issue was already opened, and report it "
+"there if not."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:3
+msgid "Emergency CPR"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:5
+msgid ""
+"Is Spyder not launching at all? The steps on this section should "
+"hopefully get it back up and running in no time."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:12
+msgid "Common solutions"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:14
+msgid ""
+"Try :doc:`basic-first-aid` first, which usually resolves most Spyder "
+"install-related issues."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:16
+msgid ""
+"**Make sure Spyder isn't already running** and no Spyder related windows "
+"(*e.g.* :doc:`/panes/variableexplorer` dialogs) are left open, and check "
+"that the preference setting :menuselection:`Application --> Advanced "
+"Settings --> Use a single instance` isn't checked."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:21
+msgid ""
+"Try **starting Spyder via a different means**, such as from a shortcut, "
+"Anaconda navigator, or your command line (or Anaconda Prompt on Windows) "
+"by simply typing ``spyder`` then :kbd:`Enter`/:kbd:`Return`, and see if "
+"any of those work. If so, then something's wrong with your install, not "
+"Spyder itself, and so we recommend following :ref:`troubleshooting-"
+"reinstalling-spyder-ref` to uninstall and reinstall Anaconda."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:24
+msgid ""
+"**Disable any security software** you may be using, such as a firewall or"
+" antivirus, as these products can occasionally interfere with Spyder or "
+"its related packages. Make sure to re-enable it if it doesn't fix the "
+"problem, and if it does, add a rule or exception for Spyder or Python."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:27
+msgid ""
+"If it is currently installed \"for just you\", **try uninstalling and "
+"reinstalling Anaconda \"for all users\" instead**, and vice versa, as "
+"some systems can have issues with one or the other installation method."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:29
+msgid ""
+"**Check and repair/reset permissions**, your disk, and OS if all else "
+"fails."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:35
+msgid "Advanced tricks"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:37
+msgid ""
+"If none of the above solves the problem, you can try starting Spyder "
+"directly from its Python source files which may either get it running, or"
+" at least provide useful information to help debug the issue further."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:39
+msgid ""
+"This technique consists of starting Spyder from your terminal (or "
+"Anaconda Prompt on Windows) by manually running the Spyder startup "
+"routine ( :guilabel:`start.py` ) with a known good Python interpreter, "
+"and observing the results."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:41
+msgid "To do so, you'll need to:"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:43
+msgid ""
+"Find the path to the Spyder :file:`app` directory from the command line. "
+"For this, run:"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:50
+msgid "Go to the output path of the above command on your command line:"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:56
+msgid ""
+"Once inside the :file:`app` directory, run ``python start.py`` to launch "
+"Spyder."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:62
+msgid ""
+"#. If it doesn't start successfully, then you should see an error "
+"traceback printed; carefully copy that for future reference. Also run "
+"``python mainwindow.py``, and record your results as well."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:65
+msgid ""
+"(*Windows only*) In case the command window disappears immediately after "
+"the error, create a ``.bat`` file in the :file:`app` directory with the "
+"following content:"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:73
+msgid "Replace ``<PYTHON-PATH>`` with the output of:"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:79
+msgid ""
+"Then, double click the batch file to run it, and you should see the error"
+" information you need."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:81
+msgid ""
+"If reading the output (particularly the last line) doesn't help you solve"
+" the problem, then record all of it carefully, and post it as part of "
+"your bug report as described under the :doc:`submit-a-report` section."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:3
+msgid "First Steps"
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:5
+msgid ""
+"If Spyder crashes or you receive an error message, please read the "
+"following troubleshooting steps before opening a new issue. There's a "
+"good chance that someone else has already experienced the same problem, "
+"so checking for an existing solution will likely get Spyder working again"
+" for you as quickly as possible."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:9
+msgid ""
+"To make sure you're getting the most relevant help for your problem, "
+"please make sure the issue is actually related to Spyder:"
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:11
+msgid ""
+"If the problem appears to be a result of *your own code*, `Stack "
+"Overflow`_ is a better place to start."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:12
+msgid ""
+"If the bug also occurs in the *standard Python, IPython, or QtConsole* "
+"environments, or only with *a specific package*, it is unlikely to be "
+"something in Spyder, and you should report it to those sources instead."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:13
+msgid ""
+"If the problem lies with *your specific install*, uninstalling and clean-"
+"reinstalling the `Anaconda`_ distribution is strongly recommended. As the"
+" other methods of installing Spyder can result in tricky user-specific "
+"problems, we generally aren't able to give individual support for install"
+" issues."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:19
+msgid ""
+"Just like the programs you code in it, Spyder is written in Python, so "
+"you can often figure out many problems just by reading the last line of "
+"the traceback or error message. To view it, simply click :guilabel:`Show "
+"details` in the Spyder error dialog."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:25
+msgid ""
+"Often, that alone will tell you how to fix the problem on your own, but "
+"if not, we're here to help."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:31
+msgid "Where to go from here"
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:33
+msgid ""
+"If you check out our list of issue categories and problem descriptions "
+"and see a question, error message or traceback that looks familiar, the "
+"relevant sub-section will likely be of the most specific help solving "
+"your issue as quickly as possible."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:37
+msgid ""
+"As a first step to solving your issue, you can try some :doc:`basic-"
+"first-aid`."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:41
+msgid ""
+"If Spyder won't launch, check the :doc:`emergency-cpr` section and see if"
+" that clears it up."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:45
+msgid ""
+"If your problem is related to the kernel not starting, autocompletion or "
+"a plugin go to :doc:`common-illnesses` section."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:49
+msgid ""
+"If you still can't get it to work, and the problem is indeed Spyder-"
+"related, you should consult the the :doc:`call-for-help` section for "
+"other resources to explore."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:53
+msgid ""
+"Finally, if you couldn't solve your problem and want to submit an issue "
+"to our Github issue tracker, so the bug can hopefully be fixed for "
+"everyone, :doc:`submit-a-report`."
+msgstr ""
+
+#: ../../troubleshooting/index.rst:3
+msgid "Troubleshooting"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:3
+msgid "Submit a Report"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:5
+msgid ""
+"If you can't fix your issue with any of the troubleshooting steps, then "
+"you'll want to submit it to our issue tracker so our team can take a look"
+" at it for you. You'll need a `Github account`_ to do this, so make sure "
+"you have one before you begin (a good idea anyway)."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:13
+msgid ""
+"Before you submit an issue, make sure you've searched a description of "
+"the problem and a relevant portion of the error traceback, on both Google"
+" and Spyder's `issue tracker`_ to make sure it hasn't been submitted "
+"before. If that's the case, your issue will be closed as a duplicate."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:23
+msgid "Ways to submit an issue"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:25
+msgid ""
+"There are several ways to submit an issue, either from Spyder or GitHub "
+"directly. In order of preference and difficulty:"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:28
+msgid ""
+"**If Spyder presents an error dialog** you can submit an issue directly "
+"from it. You will have to fill out a title for your issue, specify the "
+"steps that lead to this problem and click :guilabel:`submit to Github`. "
+"This will prefill an error report with your environment details, key "
+"versions and dependencies and automatically insert the error/traceback "
+"for you."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:36
+msgid ""
+"**If Spyder opens and your issue does not involve an error dialog**, the "
+"best way to do so is to simply select :guilabel:`Report issue` from the "
+":guilabel:`Help` menu, which manually brings up the issue report form and"
+" fills in the key information about your Spyder installation. Describe "
+"the issue you're experiencing (including any error/traceback information)"
+" along with a descriptive title, and click :guilabel:`Submit to Github`."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:42
+msgid ""
+"**If Spyder won't launch**, you can submit a report manually at our "
+"issues page on `Github`_. Unlike the above, you'll need to manually "
+"provide the versions of everything (Spyder, Python, OS, Qt/PyQt, "
+"Anaconda, and Spyder's dependencies) as listed in the error report "
+"template; see below for more on that."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:50
+msgid ""
+"Once you submit your report, our team will try to get back to you as soon"
+" as possible, often within 24 hours or less, to try to help you fix it."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:55
+msgid "What to include in your report"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:57
+msgid ""
+"**Please include as much as possible of the following in your report** to"
+" maximize your chances of getting relevant help and our ability to "
+"diagnose, reproduce and solve your issue."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:59
+msgid "The key items, in order of priority:"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:61
+msgid ""
+"The full, **complete error message or traceback** copy/pasted or "
+"automatically entered exactly as displayed by Spyder:"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:63
+msgid ""
+"Auto-generated reports directly from the error dialog should include this"
+" automatically, but double check to make sure."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:64
+msgid ""
+"You can copy and paste this from the the :guilabel:`Show Details` section"
+" of the error dialog."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:65
+msgid ""
+"If not present, or a dialog is not displayed, you can also find it "
+"printed to Spyder's :guilabel:`Internal Console`, located under the "
+":guilabel:`View` menu at :menuselection:`Panes --> Internal Console`."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:66
+msgid ""
+"If you prefer, or if Spyder won't start, you can start Spyder from your "
+"command line (or Anaconda prompt on windows) with ``spyder`` and copy the"
+" output printed there."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:70
+msgid ""
+"If you are reporting a specific behavior rather than an error, or the "
+"message does not fully explain what occurs, please describe in detail "
+"what actually happened, and what you expected Spyder to do."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:72
+msgid ""
+"A **detailed, step by step description of exactly what you did** leading "
+"up to the error occurring, complete with sample code that triggers it, if"
+" applicable."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:74
+msgid ""
+"**Information about Spyder and its environment** as listed in the error "
+"report template, which you can find under :guilabel:`About Spyder` in the"
+" :guilabel:`Help` menu; along with its key dependencies, shown in the "
+"dialog under :menuselection:`Help --> Dependencies` (there's a button to "
+"copy-paste them)."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:79
+msgid ""
+"If Spyder won't launch, paste the output of ``conda list`` from your "
+"command line (or Anaconda prompt on Windows) in the "
+":guilabel:`Dependencies` section of the issue template."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:85
+msgid ""
+"**How you installed Spyder** and any other relevant packages, *e.g.* "
+"Anaconda, MacPorts or pip and **whether Spyder has worked before** since "
+"you installed it."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:87
+msgid ""
+"**What else you've tried to fix it**, *e.g.* from this guide or elsewhere"
+" on the web, and if you've **tried to reproduce it in standalone "
+"QtConsole, IPython, and/or the plain Python** interpreter."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:89
+msgid ""
+"**Whether the problem occurred consistently before** in similar "
+"situations or if this is the first time you've observed it."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:91
+msgid ""
+"**Anything else special or unusual** about your system, environment, "
+"packages, or specific usage that might have anything to do with the "
+"problem"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:95
+msgid ""
+"If including block(s) of code in your report, be sure to precede and "
+"follow it with a line of three backticks \\`\\`\\` to get a code block "
+"like this:"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:101
+msgid ""
+"Otherwise, your code will likely contain random formatting or missing "
+"indentation, making it difficult to examine and run it to reproduce and "
+"fix your issue."
+msgstr ""
+

--- a/doc/locales/en/LC_MESSAGES/videos.po
+++ b/doc/locales/en/LC_MESSAGES/videos.po
@@ -1,0 +1,778 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../videos/first-steps-with-spyder.rst:3
+msgid "First Steps with Spyder"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:5
+msgid ""
+"The videos in this section provide a starting point for new users who "
+"have never opened Spyder before. You'll get familiar with opening Spyder "
+"in different ways, working with the four main panes and customizing the "
+"Spyder to your heart's content."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:12
+msgid "Getting started"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:14
+msgid ""
+"Discover the basics of using the Spyder interface and get an introduction"
+" to its four main panes, along with a quick look at the others."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:16
+msgid "Find out different ways to open Spyder"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:17
+msgid "Understand the key elements of Spyder’s interface"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:18
+msgid "Learn more about Spyder’s four core panes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:19
+msgid "Explore the other default panes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:33
+msgid ""
+"Hello everyone! I'm Juanita, and in this video I'm going to show you how "
+"to open Spyder and go over the basics of Spyder's interface. We will "
+"learn about Spyder's four panes that you'll likely be using most often, "
+"as well as briefly explore the others that are open by default. If you "
+"don't have Spyder installed and would like to follow along, you can "
+"`download it here`_."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:37
+msgid ""
+"The easiest way to open Spyder is by opening Anaconda Navigator and "
+"clicking on the Spyder application. In case you have an older version of "
+"Spyder in Anaconda, open the command line (or the Anaconda Prompt in the "
+"case of Windows) and type the commands:"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:44
+msgid ""
+"To launch Spyder without opening Navigator, open your command line and "
+"type ``spyder``. If you followed the :doc:`/installation`, you should "
+"have everything necessary to open Spyder 4."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:46
+msgid ""
+"This is what Spyder 4 looks like in its default configuration, though you"
+" can thoroughly customize it, which we'll get to in a later tutorial. You"
+" can see that it is divided into three sections showing three different "
+"panes: the Editor, the IPython Console and the Help viewer. These three, "
+"along with the Variable Explorer, are the four core panes you'll work "
+"with the most in Spyder."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:48
+msgid ""
+"On the left we have the Editor, where you can open, edit and run files. "
+"Bottom right is the IPython Console, which you can use both interactively"
+" and to run your code in the Editor. It shows you which version of Python"
+" you are using. Above it, you'll find the Help pane, where you can get "
+"more information and documentation for any object in the Editor or "
+"Console by pressing :kbd:`Ctrl-I` (or :kbd:`Cmd-I` on macOS). We'll see "
+"how to do this in our next video."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:50
+msgid ""
+"For the two sections on the right, you can switch tabs to see the other "
+"panes that are open by default when launching Spyder. In the top section,"
+" you can switch to the Variable Explorer, which shows you the name, type,"
+" size and value of the variables that you have previously defined in the "
+"Editor or the Console. You can also modify the value of these variables "
+"directly from this pane by double clicking them under the Value column. "
+"The Plots pane will show you the figures you generate with Matplotlib and"
+" other libraries, and the Files pane allows you to browse the files on "
+"your computer and open them in the Editor with just a click."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:52
+msgid ""
+"Finally, in the bottom section you can also access the History pane, "
+"which shows you the commands you have entered in the Console, including "
+"those from previous sessions."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:54
+msgid ""
+"I hope you're now familiar with the basics of using the Spyder interface."
+" In the next video, we will start working with Spyder's core panes."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:56
+msgid "Happy Spydering!"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:62
+msgid "Learning the basics"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:64
+msgid "Learn the basics of using Spyder’s four main panes."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:66
+msgid "Open and edit a file in Spyder’s Editor"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:67
+msgid "Run a script in the Editor and see the output in Spyder’s IPython Console"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:68
+msgid "Execute basic Python commands in the IPython Console"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:69
+msgid ""
+"Define variables in the Editor and modify their values in the IPython "
+"Console"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:70
+msgid "View and interact with the variables in Spyder’s Variable Explorer"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:71
+msgid "Get documentation in the Help pane in two different ways"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:84
+msgid ""
+"Hello everyone! I'm Juanita, and in this video I will show you how to "
+"start working with Spyder's four main panes. First, let's take a look at "
+"the Editor, which you can use to open, edit and run files from your "
+"computer. I will open a short \"Hello World\" program for this demo, "
+"which you can `download here`_. Once you have it open in your Editor, you"
+" can execute it by pressing the green run button. We can see the output "
+"in the Python Console [Show IPython console] as well as the path of the "
+"file that we are running and the working directory where this code was "
+"run."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:88
+msgid ""
+"We can also run any Python code that is entered directly in the IPython "
+"Console. For example, we can type ``print(\"Hello\")`` and see the "
+"output. Or, we can try some math operations and see the results here too."
+" Note that for implicitly printed output, there is a red indication that "
+"differs from the output of the ``print()`` function."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:90
+msgid ""
+"Now, let's start defining some variables. We can do this both from the "
+"editor or from the Console. If I define a variable ``a = 10`` and then "
+"run this code, I can see its value in the console just by typing its name"
+" ``a``. However, you can also assign any variable in the IPython console "
+"(``b = 20``) and its value will be stored too. In both cases, they can "
+"also be seen in the Variable Explorer pane, which shows the name, type, "
+"size and value of each of the objects previously defined. In this case, "
+"we see variables ``a`` and ``b``, both of type int and with size 1. We "
+"can also define a list ``l`` with ``l = [1, 2, 3]`` and see that the type"
+" of the variable is list and the size is 3."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:92
+msgid ""
+"We can change the values of the variables in the Variable Explorer too by"
+" double-clicking them and typing their new value. Now, we can check their"
+" new value in the console. In the case of a more complex type like a "
+"list, double-clicking it will open a viewer in which you can modify each "
+"of its values separately, along with other more complex operations which "
+"we'll demonstrate in a future video. We can remove a variable by right-"
+"clicking it and selecting the option Remove. After doing this, we can "
+"check in the IPython Console that the variable was actually deleted."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:94
+msgid ""
+"Finally, we are going to learn how to get help for objects in two "
+"different ways. First, we can press :kbd:`Ctrl-I` (or :kbd:`Cmd-I` on "
+"macOS) right after the name of an object written in the Editor or the "
+"Console, for example ``numpy.array``. You can see that we obtain its "
+"documentation in the Help pane if it is available. Second, if we change "
+"the Source dropdown option to Console, we can type its name in the object"
+" box in the Help pane. Now we can get help for Numpy arrays."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:96
+msgid ""
+"You should now be ready to start using Spyder's four main panes. Check "
+"out our next video to continue learning and as always, Happy Spydering!"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:102
+msgid "Customization"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:104
+msgid ""
+"Learn how to customize Spyder’s interface to match your workflow and "
+"development style."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:106
+msgid "Choose your preferred fonts"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:107
+msgid "Switch between different interface, icon and syntax themes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:108
+msgid "Show, hide, undock and rearrange Spyder panes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:109
+msgid "Split, close and pop out Editor panels"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:123
+msgid ""
+"Hello everyone, I'm Juanita! In this video, I will show you how to "
+"customize Spyder to match your workflow and development style."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:125
+msgid ""
+"First, we are going to learn how to change the font in the Editor, "
+"IPython Console and Help panes. To do this, go to Preferences, select the"
+" Appearance entry and scroll down to Fonts. You can change both the style"
+" and the size of the font for both plain and rich text. You can see how "
+"this affects the font in the Editor, Console and Help panes."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:127
+msgid ""
+"In this same dialog, you can easily change the syntax highlighting theme,"
+" for which you can see the preview at the right of the window. Note that "
+"Spyder's interface theme changes to match the highlighting theme because "
+"the Interface theme option is set to Automatic by default. However, you "
+"can change the theme for the entire Spyder interface, choosing between "
+"Light and Dark. After selecting this change, click Apply to restart "
+"Spyder to apply the new theme."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:129
+msgid ""
+"Beyond just Spyder's preferences, you can freely rearrange the panes in "
+"Spyder's main window. To show or hide panes, go to Panes under the View "
+"menu, and select which ones you want to see. For example, let's hide the "
+"Files pane and show the Profiler pane. You can also close a pane from its"
+" options menu, which will hide it from the main window."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:131
+msgid ""
+"By default, the panes and toolbars are locked so they can't be moved "
+"accidentally. However, unchecking the option Lock panes and toolbars in "
+"the View menu will allow you to move them freely anywhere on the window, "
+"by dragging them from the top and dropping them at any position you like."
+" You can also undock a pane, which will open a new window with it. You "
+"can have as many separate windows as you have panes, if you choose. This "
+"feature is very useful if you work with several monitors because you can "
+"undock the Editor and move it to a different monitor, while working with "
+"the rest of the panes in your main monitor."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:133
+msgid ""
+"Additionally, you can split the Editor pane vertically or horizontally in"
+" as many copies as you want, and open one or more panels in separate "
+"Spyder windows, complete with their own toolbar, outline and status bar."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:135
+msgid ""
+"Finally, each pane can be customized further under its respective options"
+" menu and Preferences panel."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:137
+msgid ""
+"With all these options, you can customize Spyder to your heart's content."
+" However, if you ever want to return to its default configuration, you "
+"can always reset the window layout under Window Layouts in the View menu,"
+" or your entire Spyder configuration with the Reset to Default button in "
+"the Preferences."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:139
+msgid "Enjoy your customized version of Spyder, and Happy Spydering!"
+msgstr ""
+
+#: ../../videos/index.rst:3
+msgid "Intro Videos"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:3
+msgid "Working with Spyder"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:5
+msgid ""
+"In this section, you will learn about Spyder's more advanced "
+"functionality, and explore most of the panes."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:11
+msgid "Beyond the main panes"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:13
+msgid ""
+"Explore how to take advantage of Spyder’s functionality beyond just the "
+"four core panes."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:15
+msgid "View, manage and save figures with the Plots pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:16
+msgid "Browse, interact with and open external programs in the in the Files pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:17
+msgid "Quickly navigate within and between files with the Outline pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:18
+msgid ""
+"Search for text or regular expressions across your entire project with "
+"the Find pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:19
+msgid "Discover and explore structured documentation in the Online Help pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:33
+msgid ""
+"Hello everyone! I'm Juanita, and I am going to show you how to use some "
+"of the remaining panes available in Spyder beyond just the four primary "
+"ones."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:35
+msgid ""
+"Let's start with the Plots pane, which is open by default when launching "
+"Spyder. To see how it works, let's open a file that will generate a "
+"couple plots from Matplotlib's documentation. You can view the generated "
+"plots in the Plots pane and browse between them using the arrows, or "
+"simply clicking them in the sidebar."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:37
+msgid ""
+"If you open the pane's options menu, you will see that Fit Plots to "
+"Window is enabled by default. Disabling it will allow you to zoom the "
+"plots in or out. You can also see that Mute inline plotting is enabled, "
+"which prevents the same figures from also appearing in the IPython "
+"Console. Note that every time that the code is run, new copies of the "
+"plots are generated in the pane, but you can remove any you don't want to"
+" keep around with the X button in the pane toolbar. Additionally, the "
+"pane automatically updates to show the plots generated by each console as"
+" you switch between them."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:39
+msgid ""
+"To use a plot in another document, click the Copy to Clipboard button and"
+" paste it wherever you want, such as a word processor. Additionally, you "
+"can save a plot as a PNG by clicking the save icon."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:41
+msgid ""
+"The Files pane, also open by default, lets you browse the contents of the"
+" directories on your computer, open them in the Editor, and perform a "
+"variety of other file operations. You can show or hide the size, kind and"
+" date of the files in the pane's options menu. As you change the top-"
+"level folder you're viewing in the pane, Spyder's working directory shown"
+" in the top right of the main toolbar will update, which will also be "
+"synchronized with the currently active console. Double-clicking a text "
+"file will open it in the Editor, and copying one or more files will allow"
+" you to paste them as automatically-formatted absolute or relative paths."
+" Right-clicking any item will offer an array of additional options for "
+"interacting with it."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:43
+msgid ""
+"You can also open a file in the system default external application, or "
+"set up a custom file association in the File Associations tab of the "
+"Files preferences pane. For example, we can add the ``.csv`` extension "
+"and associate it with LibreOffice Calc under associated applications. Now"
+" every time you click a file with this extension, it opens externally "
+"with this program."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:45
+msgid ""
+"Now, let's see how to use the Outline pane to navigate within a file. "
+"First, we have to open the pane under Panes in the View menu, since it "
+"isn't visible by default. As you can see, it shows you all the classes, "
+"methods and functions that are currently defined, and allows you to move "
+"between them with just a click. For a very large file like this one, it "
+"is very useful to switch between classes easily instead of scrolling "
+"through the four-thousand-plus lines of code. You can also browse the "
+"methods of a class by expanding it using the arrows, or the buttons in "
+"the Outline pane's toolbar. The Outline continuously updates to highlight"
+" the function, method or class corresponding to the cursor position in "
+"your code, so you can easily keep track of what object you are working "
+"on. Finally, by going to the pane options menu and activating Show all "
+"files, you can easily switch between the scripts and modules you have "
+"open, which is particularly important for navigating larger projects."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:47
+msgid ""
+"The Files pane is another useful tool for particularly larger projects. "
+"Like the Outline pane, it can be opened under Panes in the View menu. "
+"This allows you to view and navigate through all occurrences of text or "
+"regular expressions in any file in the working directory, project or "
+"another custom directory. We see, for example, in the ``mainwindow.py`` "
+"file we import the ``is_dark_font_color`` function. If we want to quickly"
+" find the file where it was defined, we can write this string in the "
+"search bar. With this search, we get 7 matches from 3 different files. "
+"When we click on any of these matches, the file is opened automatically "
+"in the Editor, right where this string appears."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:49
+msgid ""
+"Finally, we'll learn how to browse documentation using the Online Help "
+"pane. Once you open it, again under Panes in the View menu, you will see "
+"an index of modules from which documentation is available, including both"
+" those in the Python standard library and any third-party packages that "
+"may be installed in Spyder's environment. For example, we can find help "
+"for Numpy, Pandas and Matplotlib, which are all installed if you've "
+"downloaded Spyder with Anaconda. You can browse the contents in the "
+"built-in web browser provided by the pane, and click the hyperlinks "
+"within to navigate to different pages. You can also enter the name of the"
+" item you'd like documentation on in the Get field or in the space over "
+"the pane's toolbar, to load its information directly. If you're not sure "
+"of the object's name, use the Search field to view a list of results "
+"applicable to any keyword."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:51
+msgid ""
+"Now that you're familiar with a wider array of Spyder's panes and "
+"features, you can accomplish a variety of common programming tasks with "
+"ease. Stay tuned for our our next videos to further add to your "
+"scientific toolbox, and as always, Happy Spydering!"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:57
+msgid "Improving your code quality"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:59
+msgid "Learn how to improve the quality of your programs using code analysis."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:61
+msgid ""
+"Open and use Code Analysis to evaluate the quality and style of Python "
+"files"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:62
+msgid "Run analysis on a file in the Editor or anywhere on your computer"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:63
+msgid "Determine what an error, warning or message means and how to fix it"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:64
+msgid "Turn off messages on a line, in a file or globally"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:78
+msgid ""
+"Hello everyone! I'm Juanita, and in this video we will learn how to "
+"improve your code quality using the Code Analysis pane. To display it, we"
+" can click its name under Panes in the View menu."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:80
+msgid ""
+"This pane detects style issues, bad practices, potential bugs and other "
+"quality problems in your code, without having to execute it. There are "
+"three ways of running code analysis:"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:82
+msgid ""
+"To analyze a file that is open in the Editor, we can press the "
+"configurable shortcut, :kbd:`F8` by default, or select Source --> Run "
+"code analysis from the menu bar."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:84
+msgid ""
+"We can also select a file to analyze by browsing for it using the file "
+"button next to the path box. This will start the analysis automatically."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:86
+msgid ""
+"The third way is to manually enter the path of a file we'd like to check "
+"in the path entry box in the pane's toolbar, and click the Analyze button"
+" in the pane."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:88
+msgid ""
+"Based on these results, the code analysis shows an overall score of "
+"4.34/10, which allows us to track improvements in our code quality. We "
+"can also expand or collapse one or all the sections in the pane to be "
+"able to see the Pylint errors, warnings and messages identifying the "
+"issues with our code."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:90
+msgid ""
+"For example, the results tell us that there is a warning on line 20. To "
+"go directly to this line in the Editor, just click the message. Here, the"
+" code analysis says there is a ``bad-whitespace`` issue. To understand "
+"what this means, open the Pylint documentation. On the `Pylint docs "
+"page`_ , click on Pylint features and search for the code of the message."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:94
+msgid ""
+"We can see that the docs say that we used the wrong number of spaces "
+"around an operator."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:102
+msgid ""
+"We can fix the error by adding one space before and after the operator in"
+" this variable assignment. If we run the analysis again, we can see the "
+"error isn't shown any more on this line."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:104
+msgid ""
+"We can click the dropdown arrow in the filename field to view the list of"
+" previous analyses. Clicking one of them will show us the results."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:106
+msgid ""
+"Sometimes, it is useful to turn certain messages off. We can do that in "
+"three different ways."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:108
+msgid ""
+"We might want to silence warnings on only one line; for example, this "
+"\"unused\" import that is still necessary for the code execution. For "
+"this, type ``# pylint: disable=unused-import`` as a comment at the end of"
+" the line. Running the analysis again will show us that the error is no "
+"longer visible."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:110
+msgid ""
+"If we want to silence a message in the whole file, we can do it by "
+"writing the disable command at the beginning of the file. For example, we"
+" can disable the ``invalid-name`` warning that appears several times in "
+"this file. If we run the analysis again, all of these warnings are gone."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:112
+msgid ""
+"Finally, we can suppress specific messages for all files by editing the "
+"``.pylintrc`` configuration file in your user folder. If it doesn't "
+"exist, we can generate it by opening our terminal, or the Anaconda Prompt"
+" if you're using Windows, and running ``pylint --generate-rc > "
+".pylintrc`` in our user directory."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:114
+msgid ""
+"Now, we can go to the ``MESSAGE CONTROL`` section in this file and add "
+"the corresponding Pylint message name, for example ``no-name-in-module``."
+" If we run the analysis one more time, we see that the ``no-name-in-"
+"module`` warnings don't appear anymore."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:116
+msgid ""
+"We can see that the score of our file increased to 7.63/10, a big "
+"improvement over the previous 4.34."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:118
+msgid ""
+"Now that we've learned how to improve the quality of our code, you are "
+"ready to write cleaner and more correct programs using Spyder. Stay tuned"
+" for our next videos and as always, Happy Spydering!"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:124
+msgid "Optimizing your code"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:126
+msgid "Learn how to optimize your code using the Profiler."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:128
+msgid "Use the Profiler to find bottlenecks in your programs"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:129
+msgid "Run profiling on a file in the Editor or elsewhere on your machine"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:130
+msgid "Interpret the results to evaluate function and method performance"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:131
+msgid "Use the information to speed up the run time of your code"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:145
+msgid ""
+"Hello everyone! I'm Juanita, and in this video we will learn how to "
+"optimize your code using the profiler. To display it, click its name "
+"under Panes in the View menu."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:147
+msgid ""
+"The Profiler will determine the run time and number of calls for every "
+"function and method used in a file. There are three ways of profiling a "
+"file:"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:149
+msgid ""
+"We can browse for a file using the open button to the right of the "
+"Profiler's path box, which will run profiling over it automatically."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:151
+msgid ""
+"We can also manually enter the path in the pane's path box, and then run "
+"the analysis on the file by pressing the Profile button."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:153
+msgid ""
+"If we want to run the profiler for the file that is currently open in the"
+" Editor, we can click Run --> Profile... in the menu bar, or use the "
+"configurable shortcut :kbd:`F10`."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:155
+msgid ""
+"We see that the results in the pane show us the different functions and "
+"methods in our file, with each sub-function listed hierarchically under "
+"the item that called them. The columns show the total time taken by each "
+"function and everything it called, while the local time includes only the"
+" time spent in that particular function."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:157
+msgid ""
+"For example, the function ``values`` in this file calls a function "
+"``internal_values`` values took a total of 482 us to run, with 338 us of "
+"that spent executing internal_values inside of it. Therefore, the total "
+"time for values is 482 us, but its local time is only 144 us as the rest "
+"was spent inside ``internal_values``."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:159
+msgid ""
+"The Calls column displays the total number of times that function was "
+"called at that level. Finally, the numbers in the Diff columns for each "
+"of the three appear if a comparison is loaded, and indicate the change in"
+" runtime between the two measurements."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:161
+msgid ""
+"By double-clicking an item in the Profiler, we will be taken to the file "
+"and line in the Editor where it was called. If this function was not "
+"called in one of your open scripts, clicking it will open the file that "
+"contains it. We can click the down arrow button in the filename field to "
+"recall paths of previously profiled files."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:163
+msgid ""
+"Now that we know how to interpret the results of our profiling, let's "
+"optimize our code by finding the functions that take the longest time and"
+" making them faster. In this case, ``to_datetime`` takes 39 seconds to "
+"run. The reason for this is Pandas has to parse the non-standard "
+"timestamp format and is not told to try to use a faster parser than the "
+"default."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:165
+#, python-format
+msgid ""
+"We can reduce the time this function takes and compare it with the one "
+"before. For this, first we have to save the data as a ``.Result`` file "
+"with the save button in the pane. Now we have to figure out how to "
+"optimize the function, so let's search for it. We see that we can speed "
+"up this function by `manually specifying a datetime format`_. So, we add "
+"the appropriate argument, ``format=\"%Y-%m-%d %H:%M:%S.%f %z\"``, to our "
+"function call."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:169
+msgid ""
+"Now, we run the profiling again to see how our script's performance has "
+"improved. If we want to see how much we lowered the time, we can load our"
+" previous result and take a look at the diff columns. Notice the "
+"difference is green because the time was reduced by three times, taking "
+"only 13 seconds instead of 39. Our code is now 26 seconds faster!"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:171
+msgid ""
+"Now that you've learned how to analyze the execution time of your code, "
+"you are ready to write more efficient programs with Spyder's help. Stay "
+"tuned for our next videos and as always, Happy Spydering!"
+msgstr ""
+

--- a/doc/locales/en/LC_MESSAGES/workshops.po
+++ b/doc/locales/en/LC_MESSAGES/workshops.po
@@ -1,0 +1,4511 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: en\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+
+#: ../../workshops/financial.rst:3
+msgid "Financial Data Analysis with Spyder"
+msgstr ""
+
+#: ../../workshops/financial.rst:5
+msgid ""
+"By the end of this workshop participants will be able to use Spyder "
+"effectively for  applying some normative financial theories and models to"
+" assemble a portfolio of assets in a way that maximizes the expected "
+"return for a given level of risk. In this way, statistically-based tools "
+"are used to construct investment portfolios."
+msgstr ""
+
+#: ../../workshops/financial.rst:11 ../../workshops/plugin-development.rst:15
+#: ../../workshops/scientific-computing.rst:11
+msgid "Prerequisites"
+msgstr ""
+
+#: ../../workshops/financial.rst:13
+msgid ""
+"To follow this workshop we recommend that you have a intermediate "
+"knowledge of Python. You can visit `The Python Tutorial`_ to learn the "
+"basics of this programming language or to refresh your knowledge of "
+"Python."
+msgstr ""
+
+#: ../../workshops/financial.rst:17
+msgid ""
+"You will also need to have `Anaconda "
+"<https://www.anaconda.com/products/individual>`_ (or `Miniconda "
+"<https://docs.conda.io/en/latest/miniconda.html>`_) and Spyder installed."
+" More information about Spyder installation in :doc:`installation "
+"guide<../installation>`."
+msgstr ""
+
+#: ../../workshops/financial.rst:21 ../../workshops/scientific-computing.rst:17
+msgid ""
+"Spyder now offers :ref:`install-standalone` for Windows and macOS, making"
+" it easier to get up and running with the application without having to "
+"download Anaconda or manually install it in your existing environment. "
+"While we still support Anaconda, we recommend this install method on "
+"those platforms to avoid most problems with package conflicts and other "
+"issues."
+msgstr ""
+
+#: ../../workshops/financial.rst:25 ../../workshops/plugin-development.rst:24
+#: ../../workshops/scientific-computing.rst:20
+msgid "It is also desirable to have the following prior knowledge:"
+msgstr ""
+
+#: ../../workshops/financial.rst:27
+msgid "Intermediate level of Python"
+msgstr ""
+
+#: ../../workshops/financial.rst:28
+msgid "Basic knowledge of Statistics"
+msgstr ""
+
+#: ../../workshops/financial.rst:29
+msgid "Some knowledge of Financial Econometrics is desirable"
+msgstr ""
+
+#: ../../workshops/financial.rst:34 ../../workshops/scientific-computing.rst:34
+msgid "Learning goals"
+msgstr ""
+
+#: ../../workshops/financial.rst:36 ../../workshops/scientific-computing.rst:36
+msgid "After completing this workshop, you should be able to:"
+msgstr ""
+
+#: ../../workshops/financial.rst:38
+msgid ""
+"Apply elementary statistical analysis to stock and cryptocurrency "
+"portfolios to measure their performance"
+msgstr ""
+
+#: ../../workshops/financial.rst:39
+msgid ""
+"Understand the advantages of programming with an IDE, such as inspecting "
+"variables using the Variable Explorer and interacting with plots "
+"leveraging the Plots Pane."
+msgstr ""
+
+#: ../../workshops/financial.rst:44 ../../workshops/scientific-computing.rst:45
+msgid "Learner profile"
+msgstr ""
+
+#: ../../workshops/financial.rst:46
+msgid ""
+"This workshop is intended for people interested in finance who want to "
+"take their first steps in Financial Analysis using Python and Spyder."
+msgstr ""
+
+#: ../../workshops/financial.rst:52 ../../workshops/scientific-computing.rst:53
+msgid "Intro"
+msgstr ""
+
+#: ../../workshops/financial.rst:54
+msgid ""
+"In this workshop we will obtain financial data in real-time from `Yahoo! "
+"Finance`_ API and explore financial portfolios using Econometrics and "
+"computational tools."
+msgstr ""
+
+#: ../../workshops/financial.rst:58
+msgid "Why use Python for financial analysis?"
+msgstr ""
+
+#: ../../workshops/financial.rst:60
+msgid ""
+"Real-time analysis of historical and current financial data is essential "
+"for those investing in financial instruments. Python has a number of "
+"features that make it ideal for financial tasks:"
+msgstr ""
+
+#: ../../workshops/financial.rst:62
+msgid ""
+"It is easy to learn for anyone, whether they have previous programming "
+"experience or not"
+msgstr ""
+
+#: ../../workshops/financial.rst:63
+msgid ""
+"It has a variety of specialized mathematical and statistical libraries "
+"(`SciPy <https://scipy.org>`_, `NumPy <https://numpy.org>`_, `Pandas "
+"<https://pandas.pydata.org>`_) that are commonly used for financial "
+"analysis"
+msgstr ""
+
+#: ../../workshops/financial.rst:64
+msgid "It can be connected to APIs for loading financial data in real time"
+msgstr ""
+
+#: ../../workshops/financial.rst:65
+msgid ""
+"It is the programming language with the most resources for machine "
+"learning (supervised learning, unsupervised learning, reinforcement "
+"learning), which is one of the most useful tools for Econometrics "
+"nowadays"
+msgstr ""
+
+#: ../../workshops/financial.rst:66 ../../workshops/scientific-computing.rst:68
+msgid "It has excellent libraries for plotting"
+msgstr ""
+
+#: ../../workshops/financial.rst:67
+msgid ""
+"You can use resources such as `Google Colab "
+"<https://colab.research.google.com>`_ or `Binder <https://mybinder.org>`_"
+" to do your analysis in the cloud."
+msgstr ""
+
+#: ../../workshops/financial.rst:71
+msgid "Why should I use an IDE?"
+msgstr ""
+
+#: ../../workshops/financial.rst:73
+msgid ""
+"Although you can use Python without an IDE (Integrated Development "
+"Environment), you will work much better with one. Spyder is a Scientific "
+"Integrated Development Environment written in Python, and designed by and"
+" for scientists, engineers, and data analysts. Spyder's capabilities and "
+"its integration with Python make it perfect for financial analysis."
+msgstr ""
+
+#: ../../workshops/financial.rst:77
+msgid "Introduction to financial analysis with Spyder"
+msgstr ""
+
+#: ../../workshops/financial.rst:79 ../../workshops/scientific-computing.rst:96
+msgid ""
+"If you're not familiar with Spyder, we recommend you start with our "
+":doc:`Quickstart<../quickstart>`. But if you want a  summary, here's a "
+"quick overview."
+msgstr ""
+
+#: ../../workshops/financial.rst:83
+msgid "If you already have experience with Spyder, you can skip this section."
+msgstr ""
+
+#: ../../workshops/financial.rst:87
+#: ../../workshops/scientific-computing.rst:104
+msgid "Editor"
+msgstr ""
+
+#: ../../workshops/financial.rst:89
+#: ../../workshops/scientific-computing.rst:106
+msgid ""
+"The :doc:`Editor<../panes/editor>` is the place where you write your code"
+" and save it as a file (script). It allows you to easily persist your "
+"work. This is where you write the code you want to keep from the data "
+"analysis you do in IPython Console. **Here you will also be able to read,"
+" edit and run the code from this workshop**."
+msgstr ""
+
+#: ../../workshops/financial.rst:93
+#: ../../workshops/scientific-computing.rst:110
+msgid "IPython Console"
+msgstr ""
+
+#: ../../workshops/financial.rst:95
+#: ../../workshops/scientific-computing.rst:112
+msgid ""
+"The :doc:`IPython Console<../panes/ipythonconsole>` is the Spyder's "
+"component where you write chunks of code that you want to experiment "
+"with. **In this workshop, we are going to give you pieces of code that "
+"you can copy and run in this console**."
+msgstr ""
+
+#: ../../workshops/financial.rst:97
+#: ../../workshops/scientific-computing.rst:114
+msgid ""
+"In essence, the IPython Console allows you to execute commands and "
+"interact with data using Python."
+msgstr ""
+
+#: ../../workshops/financial.rst:101
+#: ../../workshops/scientific-computing.rst:118
+msgid "Variable Explorer"
+msgstr ""
+
+#: ../../workshops/financial.rst:103
+#: ../../workshops/scientific-computing.rst:120
+msgid ""
+"The :doc:`Variable Explorer<../panes/variableexplorer>` is one of "
+"Spyder's best features. It allows you to interactively browse and manage "
+"the objects generated in the code of the currently selected "
+":doc:`../panes/ipythonconsole` session."
+msgstr ""
+
+#: ../../workshops/financial.rst:105
+msgid ""
+"The Variable Explorer is one of the most frequently used components in "
+"this workshop. **This is the pane where we will observe the data and most"
+" of the results of the analysis, except for the plots**."
+msgstr ""
+
+#: ../../workshops/financial.rst:109
+#: ../../workshops/scientific-computing.rst:126
+msgid "Plots pane"
+msgstr ""
+
+#: ../../workshops/financial.rst:111
+msgid ""
+"The :doc:`Plots pane <../panes/plots>` shows all the static graphs and "
+"images created in your IPython Console session. **All plots generated by "
+"the code will appear in this component**.  This pane also allows you to "
+"save each graphic in a local file or copy it to the clipboard to share it"
+" with other people."
+msgstr ""
+
+#: ../../workshops/financial.rst:117
+#: ../../workshops/scientific-computing.rst:140
+msgid "Preparation work"
+msgstr ""
+
+#: ../../workshops/financial.rst:119
+#: ../../workshops/scientific-computing.rst:142
+msgid ""
+"Before starting, you must have installed some packages and libraries "
+"needed to run the code. We recommend you to install these requirements in"
+" a virtual environment. Here we explain step by step how to do it."
+msgstr ""
+
+#: ../../workshops/financial.rst:123
+msgid "Set up Conda environment"
+msgstr ""
+
+#: ../../workshops/financial.rst:125
+#: ../../workshops/scientific-computing.rst:148
+msgid ""
+"If you would like to have Spyder in a dedicated environment to update it "
+"separately from your other packages and avoid any conflicts, you can."
+msgstr ""
+
+#: ../../workshops/financial.rst:127
+#: ../../workshops/scientific-computing.rst:150
+msgid "You can set up your environment in two different ways."
+msgstr ""
+
+#: ../../workshops/financial.rst:131
+msgid ""
+"We recommend creating the virtual environment with Anaconda (or "
+"Miniconda) as it integrates seamlessly with Spyder. You can find "
+"installation instructions in `Anaconda documentation`_."
+msgstr ""
+
+#: ../../workshops/financial.rst:137
+msgid "With commands"
+msgstr ""
+
+#: ../../workshops/financial.rst:139
+msgid ""
+"Just run the following command in your Anaconda Prompt (Windows) or "
+"terminal (other platforms), to create a new environment called "
+"``financial-analysis``:"
+msgstr ""
+
+#: ../../workshops/financial.rst:145
+msgid ""
+"To install Spyder's optional dependencies as well for full functionality,"
+" use the following command:"
+msgstr ""
+
+#: ../../workshops/financial.rst:156
+msgid ""
+"Spyder now offers :ref:`install-standalone` for Windows and macOS, making"
+" it easier to get up and running with the application without having to "
+"download Anaconda or manually install it in your existing environment."
+msgstr ""
+
+#: ../../workshops/financial.rst:160
+msgid "Download the datasets"
+msgstr ""
+
+#: ../../workshops/financial.rst:162
+msgid ""
+"Although during the workshop we will explain how to use some APIs to "
+"download up-to-date data, you can also download the datasets in csv "
+"format from `this link "
+"<https://figshare.com/articles/dataset/Historical_financial_datasets_for_Financial_Analysis_with_Spyder_workshop/14995215>`_."
+msgstr ""
+
+#: ../../workshops/financial.rst:164
+msgid ""
+"To follow this workshop you do not need to create a new directory. "
+"However, if you have downloaded the data and want to use it instead of "
+"the APIs, you must set the directory that has the downloaded data as the "
+"working directory. In order to do this, check that the working directory "
+"is correct. You should see in the upper right corner the path to the "
+"directory where you have the downloaded data. Something like this:"
+msgstr ""
+
+#: ../../workshops/financial.rst:171
+msgid "Setting up the virtual environment in Spyder"
+msgstr ""
+
+#: ../../workshops/financial.rst:173
+msgid ""
+"Let's check that the virtual environment we created is enabled in Spyder."
+" Go to :guilabel:`Preferences > Python interpreter`, and use the dropdown"
+" below :guilabel:`Use the following Python interpreter` to choose your "
+"virtual environment. You should see something like this:"
+msgstr ""
+
+#: ../../workshops/financial.rst:178
+#: ../../workshops/scientific-computing.rst:239
+msgid "Now, you have everything ready to proceed with the workshop."
+msgstr ""
+
+#: ../../workshops/financial.rst:182
+#: ../../workshops/scientific-computing.rst:243
+msgid "Download the code"
+msgstr ""
+
+#: ../../workshops/financial.rst:184
+msgid ""
+"Although the workshop is designed for you to write the code in the "
+"IPython Console, we have created a file that you can download "
+":download:`here <financial-analysis.py>`. This script provides all the "
+"code you will write in this workshop, and you can use it as a guide if "
+"you get lost."
+msgstr ""
+
+#: ../../workshops/financial.rst:190
+msgid "Obtain financial data"
+msgstr ""
+
+#: ../../workshops/financial.rst:192
+msgid ""
+"When it comes to finance, being up to date is very important. So we are "
+"going to use a Python library that allows us to get updated historical "
+"Stock Market records from `Yahoo! Finance`_ API. In this way, we will be "
+"able to download data in the period of time we are interested in "
+"analyzing."
+msgstr ""
+
+#: ../../workshops/financial.rst:197
+#: ../../workshops/scientific-computing.rst:261
+msgid ""
+"Remember to type and run all code for this workshop in the \"IPython "
+"Console\" at the bottom right of Spyder."
+msgstr ""
+
+#: ../../workshops/financial.rst:202
+msgid ""
+"You can also write your code in the Editor (the pane that occupies the "
+"entire left side of Spyder). If you use the Editor, you can run the code "
+"by selecting it and pressing the :guilabel:`Run selection or current "
+"line` button in the :guilabel:`Run toolbar` or by pressing the :kbd:`F9` "
+"key."
+msgstr ""
+
+#: ../../workshops/financial.rst:207
+#: ../../workshops/scientific-computing.rst:271
+msgid "To get started, import the libraries."
+msgstr ""
+
+#: ../../workshops/financial.rst:222
+msgid ""
+"The first group of imports is for basic operations. The second "
+"(``Historic_Crypto`` and ``yfinance``) imports the libraries that we will"
+" use to download financial data."
+msgstr ""
+
+#: ../../workshops/financial.rst:224
+msgid ""
+"Let's start exploring libraries with an example. We are going to get "
+"financial information about Netflix with one line of code:"
+msgstr ""
+
+#: ../../workshops/financial.rst:230
+msgid ""
+"We have used the ``Ticker`` class of the ``yfinance`` library to create a"
+" ``netflix`` object. This object contains attributes and methods that we "
+"can query to obtain various types of information."
+msgstr ""
+
+#: ../../workshops/financial.rst:234
+msgid "General stock information"
+msgstr ""
+
+#: ../../workshops/financial.rst:236
+msgid ""
+"If you want to know which methods and attributes you can query, you can "
+"do so with the built-in ``help()`` function."
+msgstr ""
+
+#: ../../workshops/financial.rst:238
+msgid ""
+"You can also type the name of the object (``netflix``) in the console, "
+"then type a period and hit the Tab key once. IPython suggestions will "
+"then appear to help you navigate the object:"
+msgstr ""
+
+#: ../../workshops/financial.rst:243
+msgid ""
+"For example, we can obtain general information with the ``info`` property"
+" of the object."
+msgstr ""
+
+#: ../../workshops/financial.rst:249
+msgid ""
+"We can observe the result in the Variable Explorer, in the "
+"``netflix_info`` variable."
+msgstr ""
+
+#: ../../workshops/financial.rst:254
+msgid ""
+"If we double-click on it, a new window with detailed information will be "
+"displayed."
+msgstr ""
+
+#: ../../workshops/financial.rst:259
+msgid ""
+"In that window we can see a Python dictionary in which each key has a "
+"value assigned to it. Each type of value is represented by a distinctive "
+"color. For example, we see that Netflix is an Entertainment industry, the"
+" summary of the business type, among other indicators. The Variable "
+"Explorer is a very convenient way to view these types of results. We can "
+"compare it to viewing them in the IPython Console with the ``pprint`` "
+"function:"
+msgstr ""
+
+#: ../../workshops/financial.rst:268
+msgid ""
+"Although ``pprint`` displays all the information, it is easier to view it"
+" in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:272
+msgid "Historical stock data"
+msgstr ""
+
+#: ../../workshops/financial.rst:274
+msgid ""
+"We can download in a dataset the history of a stock with the following "
+"line of code:"
+msgstr ""
+
+#: ../../workshops/financial.rst:280
+msgid ""
+"We can see a summary and more details of this dataset in the Variable "
+"Explorer. It appears as a DataFrame object, with 7 columns and thousands "
+"of rows. If we double-click on it we will see the historical records of "
+"Netflix stock organized by ascending dates."
+msgstr ""
+
+#: ../../workshops/financial.rst:285
+msgid ""
+"Throughout this workshop we will use this historical information to "
+"compare, with various normative financial theories, different types of "
+"financial portfolios."
+msgstr ""
+
+#: ../../workshops/financial.rst:291
+msgid "First portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:293
+msgid ""
+"Let's build our first stock investment portfolio! Say we are interested "
+"in investing in technology, and we want to know what performance can be "
+"obtained by putting money into some of the \"heavyweights\" in this "
+"industry."
+msgstr ""
+
+#: ../../workshops/financial.rst:295
+msgid ""
+"To measure the performance of our first portfolio we are going to use a "
+"classic theory in the world of finance: `mean-variance portfolio (MVP) "
+"theory`_. This model assumes that investors only care about expected "
+"returns and the variance of such returns. The analysis is based entirely "
+"on statistical measures based on a time series of share prices, such as "
+"periodic mean returns and the variances of those returns with the same "
+"periodicity."
+msgstr ""
+
+#: ../../workshops/financial.rst:301
+msgid "Prepare portfolio data"
+msgstr ""
+
+#: ../../workshops/financial.rst:303
+msgid ""
+"Before we start, let's run some lines of code to style the plots.  These "
+"lines are optional, but we recommend that you run them so that the "
+"graphics look like the screenshots we present in this workshop."
+msgstr ""
+
+#: ../../workshops/financial.rst:312
+msgid ""
+"Suppose we want to measure the performance of a portfolio consisting of "
+"Google, Apple, Microsoft, Netflix and Amazon stocks. Let's call this set "
+"``SYMBOLS_1``."
+msgstr ""
+
+#: ../../workshops/financial.rst:320
+msgid ""
+"If you search for ``SYMBOLS_1`` in Variable Explorer you will not find "
+"it: Python interprets this element not as a variable, but as a "
+"**constant**. This is because the name is written with uppercase letters "
+"(no letter is lowercase). By default, the Variable Explorer doesn't show "
+"this, but actually you can change the settings in the "
+":guilabel:`Preferences` to be able to see these constants."
+msgstr ""
+
+#: ../../workshops/financial.rst:322
+msgid ""
+"We are going to download the historical data for this portfolio. To do "
+"this, we are going to use the ``yfinance`` ``download()`` function, which"
+" takes as its first argument a string with the symbols (``SYMBOLS_1``) "
+"defined above. The rest of the arguments are the start date "
+"(``start=\"2012-01-01\"``), the end date (``end=\"2021-01-01\"``) and how"
+" the data will be grouped (``group_by=\"Ticker\"``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:328
+msgid ""
+"The last argument (``group_by=\"Ticker\"``) groups the information mainly"
+" by stock. Otherwise, the primary grouping is done by the type of "
+"information (e.g., opening price, closing price, volume traded) of the "
+"transactions. In the following image you can see the differences (above "
+"is the default organization and below is the grouping by \"Ticker\")."
+msgstr ""
+
+#: ../../workshops/financial.rst:334
+msgid ""
+"The historical data has been downloaded as a Pandas DataFrame. We can "
+"explore this data in the variable ``data_1`` in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:339
+msgid ""
+"Let's change the formatting of the data a bit so that the symbols appear "
+"as the column names, and the Ticker moves from columns to rows. We will "
+"do this with the ``stack()`` operation of the DataFrame."
+msgstr ""
+
+#: ../../workshops/financial.rst:348
+msgid ""
+"From the Ticker we are only interested in the daily closing price. So we "
+"will leave only the values for ``\"Close\"`` and eliminate the Ticker "
+"column afterwards."
+msgstr ""
+
+#: ../../workshops/financial.rst:354
+msgid ""
+"You will notice that there is a new DataFrame in the Variable Explorer "
+"called ``close_data_1`` with 2,265 rows and 5 columns."
+msgstr ""
+
+#: ../../workshops/financial.rst:358
+msgid "A first glance at the portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:360
+msgid ""
+"We want to see how our portfolio would have performed if we had invested "
+"in it from 2012 to early 2021. How could we obtain this measurement? "
+"Let's look at the monthly closing prices of each stock. To do this we "
+"will do an automatic resample of the data. And then we will calculate the"
+" change in relative frequencies (percentages)."
+msgstr ""
+
+#: ../../workshops/financial.rst:362
+msgid ""
+"The resampling will be performed with the ``resample(\"M\")`` method and "
+"the calculation of percentages with the ``pct_change()`` method. The "
+"result will be stored in the ``monthly_data_1`` variable."
+msgstr ""
+
+#: ../../workshops/financial.rst:368
+msgid ""
+"Since each stock is a column, we can use the ``mean()`` method on the "
+"DataFrame to see the results."
+msgstr ""
+
+#: ../../workshops/financial.rst:383
+msgid ""
+"Remember that this closing information represents the relative growth of "
+"each stock, not its closing price in any currency."
+msgstr ""
+
+#: ../../workshops/financial.rst:385
+msgid ""
+"As we can see, all the results are positive, so this portfolio has been "
+"profitable over the years. In relative terms, the biggest gains would "
+"come from Netflix (0.4 percent). These percentages show an average of the"
+" monthly variation of the stock price. But how stable have that prices "
+"been? To find this out, we can calculate the standard deviation of stock "
+"price growth:"
+msgstr ""
+
+#: ../../workshops/financial.rst:398
+msgid ""
+"The highest volatility is found in Netflix (0.1454), which indicates that"
+" its price, despite being the fastest growing, has also had a lot of "
+"variation during these years. The most stable price, on the other hand, "
+"has been Microsoft's (0.0583)."
+msgstr ""
+
+#: ../../workshops/financial.rst:400
+msgid ""
+"A good way to observe both growth and variability is to draw a time-"
+"series plot. To scale the values, we are going to divide the relative "
+"frequency of the closing price of the actions by the initial value it has"
+" in the dataframe ``close_data_1`` (these initial values can be found "
+"with ``close_data_1.iloc[0])``). The plot is drawn with the ``plot()`` "
+"method of the Pandas DataFrame (to which we pass as arguments the size of"
+" the plot and the plot title)."
+msgstr ""
+
+#: ../../workshops/financial.rst:411
+msgid ""
+"You will be able to see the graph in the Plots pane. On the left, you "
+"will see the plot in detail. On the right, a stack will be created with "
+"all the plots that are generated both in the Console and by running the "
+"code directly in the Editor. You can copy, delete or save the plot to "
+"disk by clicking on it with the right mouse button or trackpad."
+msgstr ""
+
+#: ../../workshops/financial.rst:413
+msgid ""
+"The above time-series plot clearly shows the growth of all stocks, "
+"particularly Netflix. The high volatility discussed above can also be "
+"seen. For example, it can be seen from the plots that, due to high "
+"volatility, investing in Netflix in the years 2014 and 2019 left "
+"virtually no profit (if shares were bought at the beginning of the year "
+"and sold right at the end)."
+msgstr ""
+
+#: ../../workshops/financial.rst:415
+msgid ""
+"We can also plot with the ``plot()`` method the DataFrame we already have"
+" with the monthly data. To do this, we will add 1 to all the values and "
+"calculate the accumulated product with the ``cumprod()`` method:"
+msgstr ""
+
+#: ../../workshops/financial.rst:424
+msgid ""
+"This plot of the monthly data is \"smoother\" than the plot of the daily "
+"data."
+msgstr ""
+
+#: ../../workshops/financial.rst:428
+msgid "Returns and volatility"
+msgstr ""
+
+#: ../../workshops/financial.rst:430
+msgid ""
+"Remember that in the *mean-variance portfolio theory* what matters are "
+"the expected returns and variances. To calculate these returns, we will "
+"divide the price of the stock on one day by the price of the same stock "
+"on the previous day. We will do this by dividing the ``close_data_1`` "
+"DataFrame by a version of itself in which we shift each record one date "
+"backwards (``shift(1)``). For example, if on the date 2012-01-03 a stock "
+"was valued at 1, and on the next day (2012-01-02), it was valued at 2, "
+"then in our shifted dataset, on the day 2012-01-03 the stock would be "
+"worth 1. In this way, we would divide 1 by 2. And so on with all the "
+"values of all the shares. We will also normalize the results by passing "
+"them to a logarithmic scale with ``np.log()``."
+msgstr ""
+
+#: ../../workshops/financial.rst:434
+msgid ""
+"Trend lines are more easily drawn in logarithmic scale because they tend "
+"to fit better to the minimums. In addition, the logarithmic scale gives a"
+" more realistic view of price movements."
+msgstr ""
+
+#: ../../workshops/financial.rst:440
+msgid ""
+"In the variable ``rets_1`` you can see the resulting DataFrame. If you "
+"double-click on the variable name in the Variable Explorer, you will see "
+"that there are positive values (the share price increased) and negative "
+"values (the price decreased at the time of closing)."
+msgstr ""
+
+#: ../../workshops/financial.rst:445
+msgid ""
+"In addition to the returns of each stock, we will need the specific "
+"weight of each stock in the portfolio, i.e., how many shares of each "
+"company are in the portfolio. In this workshop we will assume that there "
+"is one share of each company and, therefore, the weights will be "
+"distributed equally."
+msgstr ""
+
+#: ../../workshops/financial.rst:449
+msgid ""
+"A stock is a financial security that represents that you own a part of a "
+"company (whatever the size of this part). A share, on the other hand, is "
+"the smallest unit of denomination of a stock. A stock is composed of one "
+"or several shares."
+msgstr ""
+
+#: ../../workshops/financial.rst:451
+msgid ""
+"This weight will be a vector (Python list) composed of the relative "
+"weight (between 0 and 1) of each stock in the portfolio. The sum of these"
+" weights has to be 1. Since we will assume that each stock is a single "
+"share, the distribution will be equal: ``[0.2, 0.2, 0.2, 0.2, 0.2]``."
+msgstr ""
+
+#: ../../workshops/financial.rst:457
+msgid ""
+"With this information we can calculate the expected return of this "
+"portfolio. The math is simple: this is given by the dot product of the "
+"portfolio weights vector and the vector of expected returns. This result "
+"must be multiplied by the number of days for which the return is to be "
+"calculated (a year has approximately 252 stock price closings)."
+msgstr ""
+
+#: ../../workshops/financial.rst:459
+msgid "Let's put all this into a function:"
+msgstr ""
+
+#: ../../workshops/financial.rst:466
+msgid ""
+"Let's look at the expected return of this portfolio if we hold it for one"
+" year:"
+msgstr ""
+
+#: ../../workshops/financial.rst:474
+#, python-format
+msgid ""
+"An expected gain of almost 30% in one year. Not bad, right? But don't "
+"forget the other side of this coin: volatility. This calculation is a bit"
+" more complex. First, the dot product of the annualized covariance of the"
+" returns (this is multiplied by the number of trading days in a year) and"
+" the weights is calculated. Then the dot product of the weights and the "
+"previous result is obtained. Finally, the square root of this result is "
+"extracted. Let's implement this into a function as well."
+msgstr ""
+
+#: ../../workshops/financial.rst:481
+msgid "Let's see how our portfolio performs with respect to its volatility:"
+msgstr ""
+
+#: ../../workshops/financial.rst:489
+msgid ""
+"If high return is desirable, high volatility is undesirable. The risk of "
+"this portfolio is relatively large."
+msgstr ""
+
+#: ../../workshops/financial.rst:493
+msgid "Sharpe ratio"
+msgstr ""
+
+#: ../../workshops/financial.rst:495
+msgid ""
+"The `Sharpe`_ ratio or index is a measure of portfolio performance. It "
+"relates the portfolio's return to its volatility, comparing the "
+"expected/realized return with the expected/realized risk. It is "
+"calculated as the difference between the actual investment returns and "
+"the expected return in a zero-risk situation, divided by the volatility "
+"of the investment. **It provides a model of the additional amount of "
+"returns received for each additional unit of risk**."
+msgstr ""
+
+#: ../../workshops/financial.rst:499
+msgid "Let's formalize this in a function:"
+msgstr ""
+
+#: ../../workshops/financial.rst:506
+msgid "And let's apply this to our portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:516
+msgid ""
+"The Sharpe ratio measure is best understood in context: when comparing "
+"two or more portfolios, the one with the higher Sharpe ratio provides "
+"more profit for the same amount of risk."
+msgstr ""
+
+#: ../../workshops/financial.rst:518
+msgid ""
+"We can also use a `Monte Carlo "
+"<https://en.wikipedia.org/wiki/Monte_Carlo_method>`_ simulation to "
+"randomize the weights of each stock in the portfolio so that we can see "
+"the range over which the Sharpe ratio can vary. In this way we can plot "
+"some scenarios that together will give us a good insight of the "
+"relationship between expected returns and expected volatility."
+msgstr ""
+
+#: ../../workshops/financial.rst:520
+msgid ""
+"We are going to do this with a function that we will explain step by step"
+" in the `monte_carlo_sharpe function explained`_ section."
+msgstr ""
+
+#: ../../workshops/financial.rst:538
+msgid ""
+"You do not need to type the following code in the IPython Console. If you"
+" write the function above it will be enough. It is just a code "
+"presentation to explain what is inside the function."
+msgstr ""
+
+#: ../../workshops/financial.rst:542
+msgid "``monte_carlo_sharpe`` function explained"
+msgstr ""
+
+#: ../../workshops/financial.rst:544
+msgid ""
+"Let's now break the function down to understand what is happening. First,"
+" we create a numpy array of length 1,000 and width of the number of "
+"shares in the portfolio. Each row of the array has random weights that "
+"always add up to 1:"
+msgstr ""
+
+#: ../../workshops/financial.rst:552
+msgid ""
+"The next section calculates the volatility and returns for the new random"
+" weights using a list comprehension. The resulting list is transformed "
+"back into a numpy array:"
+msgstr ""
+
+#: ../../workshops/financial.rst:559
+msgid ""
+"Finally, we obtain the Sharpe ratio by dividing the index 1 "
+"(volatilities) by the index 0 (returns) of the numpy array:"
+msgstr ""
+
+#: ../../workshops/financial.rst:567
+msgid "Using the ``monte_carlo_sharpe`` function"
+msgstr ""
+
+#: ../../workshops/financial.rst:569
+msgid ""
+"We use the function to get the simulated returns and volatility of "
+"portfolio 1 (``port_1_vr``) and the related Sharpe ratios "
+"(``port_1_sr``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:571
+msgid "Enter the following code in the console."
+msgstr ""
+
+#: ../../workshops/financial.rst:579
+msgid ""
+"Remember that the weights are initialized randomly, so each time you run "
+"this code you will get different results."
+msgstr ""
+
+#: ../../workshops/financial.rst:581
+msgid ""
+"With this we obtain two arrays with 1,000 simulated cases for our "
+"portfolio. But the best way to explore this is with a plot."
+msgstr ""
+
+#: ../../workshops/financial.rst:593
+msgid "You should see in the Plots pane something like this:"
+msgstr ""
+
+#: ../../workshops/financial.rst:598
+msgid ""
+"A roughly linear relationship can be observed between returns and "
+"volatility: the higher the volatility, the higher the gains. And the "
+"Sharpe ratio shows an important amount of variability (it is noticeable "
+"in the \"width\" of the line drawn)."
+msgstr ""
+
+#: ../../workshops/financial.rst:600
+msgid ""
+"This seems to be a good portfolio because it has a good performance with "
+"a not very large variance."
+msgstr ""
+
+#: ../../workshops/financial.rst:604
+msgid "Optimal portfolio weights"
+msgstr ""
+
+#: ../../workshops/financial.rst:606
+msgid ""
+"Can we use the data obtained to calculate the optimal weights for the "
+"portfolio by year? Of course we can. Let's start by delimiting the "
+"previous years as variables."
+msgstr ""
+
+#: ../../workshops/financial.rst:612
+msgid "We will now write a function to calculate these optimal weights."
+msgstr ""
+
+#: ../../workshops/financial.rst:629
+msgid ""
+"Let's describe this function in broad strokes. ``bounds`` indicates the "
+"maximum and minimum weights for each stock in the portfolio. The lowest "
+"weight will be 0 and the highest weight will be 1 for each stock in the "
+"portfolio. ``constraints`` is a function that ensures that the sum of the"
+" weights of all actions always adds up to 1. Then a loop is initialized "
+"that will segment the data for each year. In the variable ``_rets`` the "
+"returns for the specified year are obtained. In ``_opt_w`` the "
+"``portfolio_shape()`` function is used to calculate the weights that "
+"maximize the Sharpe ratio. This is done with the ``minimize()`` function "
+"of SciPy (which takes as arguments the ``portfolio_shape`` function, the "
+"actual weights of our stocks in the portfolio, and the ``bounds`` and the"
+" ``constraints`` variables). Notice the ``-`` sign before "
+"``portfolio_sharpe``? It's because ``minimize()`` aims to find the "
+"minimum value of a function relative to a parameter, but we are "
+"interested in the maximum, so we make the result of ``portfolio_sharpe`` "
+"a negative one."
+msgstr ""
+
+#: ../../workshops/financial.rst:631
+msgid ""
+"We will use the function we just defined to calculate the optimal weights"
+" for each year, and we are going to save the result in a Pandas DataFrame"
+" to take advantage of the Variable Explorer display options."
+msgstr ""
+
+#: ../../workshops/financial.rst:639
+msgid ""
+"Double click on the ``port_1_ow`` variable in the Variable Explorer. In "
+"the table, you can specify the number of decimal places to display, by "
+"clicking the format button at the bottom left of the pane, as you can see"
+" in the following image:"
+msgstr ""
+
+#: ../../workshops/financial.rst:644
+msgid ""
+"We set the number of decimal places to 4 and uncheck the **Column "
+"min/max** checkbox to better appreciate the contrasts in the row values "
+"(years)."
+msgstr ""
+
+#: ../../workshops/financial.rst:646
+msgid ""
+"You can see, for example, how 2015 was a particularly good year for "
+"investing in Amazon and Netflix, while 2014 was the year of Apple. "
+"Despite Netflix's rapid growth over the years, its high volatility means "
+"that its Sharpe Ratio is not very remarkable in any year, especially (as "
+"we said above) in 2014 and 2019. In the same respect, Apple and Microsoft"
+" seem to be safer bets in the return/volatility ratio."
+msgstr ""
+
+#: ../../workshops/financial.rst:650
+msgid "Comparison of expected and realized returns"
+msgstr ""
+
+#: ../../workshops/financial.rst:652
+msgid ""
+"Finally, we will use the optimal weights to calculate the expected "
+"returns and compare them with the actual returns."
+msgstr ""
+
+#: ../../workshops/financial.rst:668
+msgid ""
+"In this function we compare year to year realized returns with "
+"theoretically expected returns. This is done by estimating:"
+msgstr ""
+
+#: ../../workshops/financial.rst:670
+msgid ""
+"The returns from applying the optimal weights of the previous year's "
+"stocks to the data for that same year (``expected_pr``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:671
+msgid ""
+"The returns from applying the optimal weights of the previous year's "
+"stocks to the following year's data (``realized_pr``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:673
+msgid ""
+"We are going to apply this function to the data in portfolio 1 and store "
+"the results in a DataFrame that we can review in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:680
+msgid ""
+"The expected column shows the predicted values if the optimal portfolio "
+"composition had been used. The realized column, on the other hand, shows "
+"the actual profits that would have been obtained with those weights. It "
+"can be seen that there are notable differences in some years. Let's look "
+"at this in a plot."
+msgstr ""
+
+#: ../../workshops/financial.rst:689
+msgid ""
+"The most notable differences are seen in 2014 and 2016. In those years, "
+"the previous year's optimal portfolio weights (in blue in the above plot)"
+" are a lousy indicator of the following year's stock performance (in "
+"red). In 2013, our model estimated that Google and Netflix were excellent"
+" investments. But by 2014 their share price did not grow if we compare "
+"the price at the beginning and at the end of that year. And something "
+"similar happened in 2016, in which Amazon's growing trend of the previous"
+" year diminished, and the value of Microsoft and Apple shares grew."
+msgstr ""
+
+#: ../../workshops/financial.rst:691
+msgid "Let's summarize these numbers."
+msgstr ""
+
+#: ../../workshops/financial.rst:701
+msgid ""
+"Our optimal weight model offered us a profit of around 40%, but the "
+"profit we would have obtained, due to real market fluctuations, would "
+"have been almost 20%. Not bad, but the mean-variance portfolio model we "
+"have applied for annual calculations is not very accurate, is it?"
+msgstr ""
+
+#: ../../workshops/financial.rst:703
+msgid ""
+"And this result is less encouraging if we calculate the correlations "
+"between expected and realized profits."
+msgstr ""
+
+#: ../../workshops/financial.rst:713
+msgid ""
+"As we can see, the correlations are negative, which warns us that we "
+"should be cautious when using this type of modeling."
+msgstr ""
+
+#: ../../workshops/financial.rst:719
+msgid "Second portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:721
+msgid ""
+"We are now going to apply all the previous code with a portfolio of a "
+"different nature. Let's assume that instead of technology companies, we "
+"are now interested in pharmaceuticals. We will build a portfolio with "
+"stocks of Pfizer, Astra Zeneca, Johnson & Johnson."
+msgstr ""
+
+#: ../../workshops/financial.rst:725
+msgid "Download the data"
+msgstr ""
+
+#: ../../workshops/financial.rst:727
+msgid "Let's download the data and format it."
+msgstr ""
+
+#: ../../workshops/financial.rst:740
+msgid ""
+"If you do not want to use the yfinance API, you can download the "
+"``close_data_2.csv`` file containing the closing information for this "
+"portfolio. Copy this file to your working directory. Load the data with "
+"the following instruction:  ``>>> close_data_2 = "
+"pd.read_csv(\"close_data_2.csv\")``."
+msgstr ""
+
+#: ../../workshops/financial.rst:744
+msgid "Mean and standard deviation"
+msgstr ""
+
+#: ../../workshops/financial.rst:746
+msgid ""
+"We are going to put the data in a monthly format and observe the mean and"
+" standard deviation."
+msgstr ""
+
+#: ../../workshops/financial.rst:768
+msgid ""
+"As in portfolio 1, all means are positive. But its largest value (that of"
+" JNJ) barely reaches 1% per month, which is slower growth than that of "
+"portfolio 1. The variation is also smaller compared to that of the "
+"previous portfolio (here the largest deviation is 0.06) which makes it a "
+"lower risk investment."
+msgstr ""
+
+#: ../../workshops/financial.rst:772
+msgid "Daily and monthly timelines"
+msgstr ""
+
+#: ../../workshops/financial.rst:774
+msgid "Let's better visualize the above with a couple of charts."
+msgstr ""
+
+#: ../../workshops/financial.rst:791
+msgid ""
+"These two plots show a steady growth over the years, but also a high "
+"variability in each year. This seems to be a good portfolio only if taken"
+" as a long-term investment."
+msgstr ""
+
+#: ../../workshops/financial.rst:795
+msgid "Returns, volatility and Sharpe ratio"
+msgstr ""
+
+#: ../../workshops/financial.rst:797
+msgid ""
+"To confirm what was said in the previous section, let's calculate "
+"returns, volatility and Sharpe ratio."
+msgstr ""
+
+#: ../../workshops/financial.rst:811
+msgid ""
+"The return of this portfolio is significantly lower than that of the "
+"previous portfolio (0.0809 < 0.2859). Its volatility (0.1637 < 0.2370) is"
+" also lower, but to a lesser extent. This is reflected in a lower Sharpe "
+"ratio as well (0.4940 < 1.2062). This means, within the mean-variance "
+"theory approach, that the first portfolio is a better investment than the"
+" second one."
+msgstr ""
+
+#: ../../workshops/financial.rst:813
+msgid ""
+"The different behavior is clearly observed if we apply a Monte Carlo "
+"simulation and visualize it with a graph:"
+msgstr ""
+
+#: ../../workshops/financial.rst:830
+msgid ""
+"High volatility does not correspond in most cases with high returns. In "
+"fact, there are scenarios in the simulation in which higher expected "
+"returns are related to lower expected volatility."
+msgstr ""
+
+#: ../../workshops/financial.rst:834
+msgid "Optimal pharmaceutical stock weights"
+msgstr ""
+
+#: ../../workshops/financial.rst:836
+msgid ""
+"Let us now see what are the optimal weights for each stock using the "
+"``optimal_weights`` function."
+msgstr ""
+
+#: ../../workshops/financial.rst:849
+msgid ""
+"In addition, we can use these optimal weights to plot the expected and "
+"realized returns of this portfolio for each year."
+msgstr ""
+
+#: ../../workshops/financial.rst:861
+msgid ""
+"Due to the high volatility of this portfolio, our model has not been able"
+" to adequately forecast expected returns in several of the years. Higher "
+"than expected returns would have been realized in 2013 and 2017, but in "
+"2015 and 2018 using the model would have generated losses."
+msgstr ""
+
+#: ../../workshops/financial.rst:863
+msgid ""
+"Finally, let us look at the differences between the expected and realized"
+" means, and the linear correlation between the data."
+msgstr ""
+
+#: ../../workshops/financial.rst:881
+msgid ""
+"As we can see, the model with optimal weights predicted a return close to"
+" 15% per year, but the realized return would have barely reached 6%. And "
+"the negative correlations show, as with portfolio 1, that there does not "
+"seem to be any correspondence between these values."
+msgstr ""
+
+#: ../../workshops/financial.rst:883
+msgid ""
+"The comparison is then favorable for portfolio 1. But what if we compare "
+"portfolio 1 with a \"higher risk\" investment such as cryptocurrencies? "
+"Let's discuss it below."
+msgstr ""
+
+#: ../../workshops/financial.rst:889
+msgid "Third portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:892
+msgid "Download cryptocurrencies data"
+msgstr ""
+
+#: ../../workshops/financial.rst:894
+msgid ""
+"Our third portfolio will consist of three cryptocurrencies: bitcoin "
+"(BTC), ethereum (ETH) and litecoin (LTC). To access historical data, we "
+"are going to use a library called **Historic-Crypto**."
+msgstr ""
+
+#: ../../workshops/financial.rst:898
+msgid ""
+"If you want to make use of the data without the Historic-Crypto library, "
+"you can `download the dataset "
+"<https://figshare.com/articles/dataset/Historical_financial_datasets_for_Financial_Analysis_with_Spyder_workshop/14995215>`_"
+" \"crypto_hist.csv\" in your working directory, and load it in memory "
+"with the instruction ``crypto_hist = pd.read_csv(\"crypto_hist.csv\")``, "
+"and skip to section `Monthly data`_."
+msgstr ""
+
+#: ../../workshops/financial.rst:900
+msgid "Import the libraries:"
+msgstr ""
+
+#: ../../workshops/financial.rst:907
+msgid ""
+"We are going to use the ``Cryptocurrencies`` class to obtain a list of "
+"available cryptocurrencies."
+msgstr ""
+
+#: ../../workshops/financial.rst:915
+msgid ""
+"If you want more information about the use of this library you can make a"
+" quick query using the Spyder Help panel (type in the console "
+"``Cryptocurrencies`` and use :kbd:`Ctrl-I` or :kbd:`Cmd-I` to display "
+"it). Or you can read the documentation in their `official repository "
+"<https://github.com/David-Woroniuk/Historic_Crypto>`_"
+msgstr ""
+
+#: ../../workshops/financial.rst:917
+msgid ""
+"A new variable has appeared in the Variable Explorer: ``crypto_list``. It"
+" is a Pandas DataFrame that has a basic description of the types of "
+"cryptocurrency transactions. For example, we can look up which token is "
+"the token for ethereum transactions in US dollars."
+msgstr ""
+
+#: ../../workshops/financial.rst:923
+msgid "In this case, we are interested in the symbol with ID 171: ETH-USD."
+msgstr ""
+
+#: ../../workshops/financial.rst:925
+msgid ""
+"We can use the HistoricalData class of Historic-Crypto to download the "
+"history of transactions done in the cryptocurrencies of our portfolio, in"
+" US dollars."
+msgstr ""
+
+#: ../../workshops/financial.rst:946
+msgid ""
+"Let's merge the resulting dataframes to have all the data in a single "
+"table."
+msgstr ""
+
+#: ../../workshops/financial.rst:953
+msgid ""
+"We will not present the procedures and code in this section, but only the"
+" results of the analysis. You can follow the steps in the previous "
+"sections to recreate these results."
+msgstr ""
+
+#: ../../workshops/financial.rst:957
+msgid ""
+"Use all this section on portfolio 3 to check your understanding of the "
+"concepts and code we have presented until now. If you have any questions,"
+" you can consult the :download:`code <financial-analysis.py>` code that "
+"accompanies this workshop. But we encourage you to try as much as "
+"possible to solve the code on your own."
+msgstr ""
+
+#: ../../workshops/financial.rst:961
+msgid "Monthly data"
+msgstr ""
+
+#: ../../workshops/financial.rst:963
+msgid "Let's take a look at the monthly history of cryptocurrency price growth."
+msgstr ""
+
+#: ../../workshops/financial.rst:968
+msgid ""
+"We can note that the scale here is much larger. And the proportion of ETH"
+" growth over the other two coins is quite remarkable."
+msgstr ""
+
+#: ../../workshops/financial.rst:972
+msgid "Return, volatility and Sharpe ratio"
+msgstr ""
+
+#: ../../workshops/financial.rst:974
+msgid "Let's consider the return, volatility and Sharpe ratio of this portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:976
+msgid "Return: 0.6203"
+msgstr ""
+
+#: ../../workshops/financial.rst:977
+msgid "Volatility: 0.7587"
+msgstr ""
+
+#: ../../workshops/financial.rst:978
+msgid "Sharpe: 0.8176"
+msgstr ""
+
+#: ../../workshops/financial.rst:980
+msgid ""
+"These numbers are higher than those obtained for portfolios 1 and 2, "
+"except for the Sharpe ratio. This is a very volatile portfolio (in fact "
+"three times more volatile than that of the technology companies), and "
+"that makes it ultimately not as profitable as portfolio 1. The returns "
+"are higher (almost double) but the risk may not compensate for it."
+msgstr ""
+
+#: ../../workshops/financial.rst:984
+msgid "Monte carlo simulation"
+msgstr ""
+
+#: ../../workshops/financial.rst:986
+msgid ""
+"The Monte Carlo simulation also shows the non-linear correlation between "
+"risk and returns (as you can see, sometimes high risk involves only "
+"modest profits):"
+msgstr ""
+
+#: ../../workshops/financial.rst:991
+msgid ""
+"As can be seen, there are points (bottom right) that show a very high "
+"volatility and yet have a very low expected return. In this sense, "
+"portfolio 1 represents a safer investment because the higher risk is "
+"consistently offset by higher returns."
+msgstr ""
+
+#: ../../workshops/financial.rst:995
+msgid "Optimal cryptocurrency weights"
+msgstr ""
+
+#: ../../workshops/financial.rst:1000
+msgid ""
+"The optimal portfolio weights, if calculated annually, suggest that our "
+"portfolio should have been quite polarized in some years: the "
+"recommendation is to have bought only bitcoins before the start of 2016 "
+"and 2019, and only ethereum in 2018. Starting 2017 and 2020, on the other"
+" hand, our weights recommended a more balanced investment between bitcoin"
+" and ethereum. Litecoin is not recommended by our model."
+msgstr ""
+
+#: ../../workshops/financial.rst:1004
+msgid "Expected and realized returns"
+msgstr ""
+
+#: ../../workshops/financial.rst:1009
+msgid ""
+"In this graph we can see that in 2017 and 2020 the earnings obtained "
+"would have exceeded the expected earnings (with our calculated weights). "
+"In 2019 our model predicted a sharp drop in the portfolio, but in reality"
+" the portfolio did not make either annualized gains or losses that year. "
+"In contrast, in 2018, our model would have brought us heavy losses, as "
+"the value of cryptocurrencies declined sharply that year."
+msgstr ""
+
+#: ../../workshops/financial.rst:1011
+msgid ""
+"The mean expected return for our portfolio is 0.6972, which is higher "
+"than the realized return of 0.4181 that we would have obtained. Having "
+"invested in this portfolio over the long term (from 2016 to the present) "
+"would have been a very good deal. Due to the high variability, investing "
+"in the short term would have been very risky. In terms of gross profits, "
+"the realized returns of this portfolio were more than double those of "
+"portfolio 1 (0.4181 > 0.1997)."
+msgstr ""
+
+#: ../../workshops/financial.rst:1017
+#: ../../workshops/plugin-development.rst:1394
+#: ../../workshops/scientific-computing.rst:751
+msgid "Final words"
+msgstr ""
+
+#: ../../workshops/financial.rst:1019
+msgid ""
+"The mean-variance portfolio (MVP) theory is one of the many tools "
+"available to financial analysis. In recent years, machine learning "
+"algorithms have even been used to predict the behavior of stock prices "
+"more accurately than can be achieved with any standard financial theory."
+msgstr ""
+
+#: ../../workshops/financial.rst:1021
+msgid ""
+"The examples given during this workshop are not intended to serve as "
+"guidelines for you to invest your money. It is only a first step towards "
+"learning financial analysis using Python and a scientific IDE."
+msgstr ""
+
+#: ../../workshops/financial.rst:1023
+#: ../../workshops/plugin-development.rst:1402
+#: ../../workshops/scientific-computing.rst:759
+msgid "In this workshop you have learned how to:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1025
+#: ../../workshops/scientific-computing.rst:761
+msgid "Set up a Conda environment."
+msgstr ""
+
+#: ../../workshops/financial.rst:1026
+msgid "Use the Spyder Editor to write and run code."
+msgstr ""
+
+#: ../../workshops/financial.rst:1027
+msgid "Write and test code with the IPython Console."
+msgstr ""
+
+#: ../../workshops/financial.rst:1028
+msgid "Obtain financial data using an API."
+msgstr ""
+
+#: ../../workshops/financial.rst:1029
+msgid "Graphing data."
+msgstr ""
+
+#: ../../workshops/financial.rst:1030
+#: ../../workshops/scientific-computing.rst:764
+msgid "Inspect objects in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:1031
+#: ../../workshops/scientific-computing.rst:766
+msgid "Browse between plots using the Plots pane."
+msgstr ""
+
+#: ../../workshops/financial.rst:1032
+#: ../../workshops/scientific-computing.rst:768
+msgid "Manipulate data in a Pandas DataFrame."
+msgstr ""
+
+#: ../../workshops/financial.rst:1033
+msgid "Build a financial portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:1034
+msgid "Calculate returns and volatility of a portfolio over time."
+msgstr ""
+
+#: ../../workshops/financial.rst:1035
+msgid "Obtain the optimal weights of the stocks in a portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:1037
+msgid ""
+"With the skills learned here, you will be able to approach more complex "
+"topics of financial analysis such as those you will find in the "
+"references in the next section."
+msgstr ""
+
+#: ../../workshops/financial.rst:1039
+#: ../../workshops/scientific-computing.rst:774
+msgid ""
+"Thank you for reaching the end of this workshop! We hope you found it "
+"helpful and informative."
+msgstr ""
+
+#: ../../workshops/financial.rst:1041
+#: ../../workshops/plugin-development.rst:1422
+msgid ""
+"If you are interested in an introduction to scientific computing with "
+"Spyder, you can visit the workshop :doc:`Scientific Computing and "
+"Visualization with Spyder <../workshops/scientific-computing>`."
+msgstr ""
+
+#: ../../workshops/financial.rst:1045
+#: ../../workshops/plugin-development.rst:1429
+#: ../../workshops/scientific-computing.rst:780
+msgid "Homework"
+msgstr ""
+
+#: ../../workshops/financial.rst:1047
+msgid ""
+"If you want to check what you have learned, we suggest you try to obtain "
+"the results presented for the third portfolio. If you have any questions,"
+" you can consult the code that accompanies this workshop in our "
+"repository."
+msgstr ""
+
+#: ../../workshops/financial.rst:1053
+#: ../../workshops/plugin-development.rst:1436
+#: ../../workshops/scientific-computing.rst:788
+msgid "Further reading"
+msgstr ""
+
+#: ../../workshops/financial.rst:1055
+msgid ""
+"Much of the math used to apply MVP was the mathematics outlined in Yves "
+"Hilpisch's excellent book, which we recommend to you:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1057
+msgid "Yves Hilpisch, Y. (2020). *Artificial Intelligence in Finance*. O'Reilly.*"
+msgstr ""
+
+#: ../../workshops/financial.rst:1059
+msgid ""
+"A classic that has been with us for decades and is one of Warren "
+"Buffett's favorites:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1061
+msgid "Graham, B. (1949). *The Intelligent Investor*. HarperCollins."
+msgstr ""
+
+#: ../../workshops/financial.rst:1063
+msgid ""
+"Another good resource for financial analysis with Python is the following"
+" book by James Ma Weiming:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1065
+msgid "Ma Weiming, J. (2019). *Mastering Python for Finance*. Packt"
+msgstr ""
+
+#: ../../workshops/index.rst:3
+msgid "Workshops"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:3
+msgid "Plugin Development with Spyder"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:5
+msgid ""
+"This workshop reviews the features and possibilities of the API offered "
+"by `Spyder`_ 5—the recently released version of our favorite IDE for "
+"scientific Python—for plugin development and to extend its functionality."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:7
+msgid ""
+"As a practical exercise, we will develop a simple plugin that "
+"incorporates a configurable pomodoro timer in the status bar and some "
+"toolbar buttons to interact with it."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:17
+#: ../../workshops/scientific-computing.rst:13
+msgid ""
+"You will need to have Spyder installed. Visit our :doc:`installation "
+"guide<../installation>` for more information."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:21
+msgid ""
+"Spyder now offers :ref:`install-standalone` for Windows and macOS, making"
+" it easier to get up and running with the application without having to "
+"download Anaconda or manually install it in your existing environment. "
+"However, readers of this workshop should install Spyder using Anaconda or"
+" Miniconda, as standalone installers currently do not allow to add extra "
+"packages like the plugin we are going to develop in this workshop."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:26
+#: ../../workshops/scientific-computing.rst:22
+msgid ""
+"Basic level of Python. You can visit `The Python Tutorial`_ to learn the "
+"basics of this programming language."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:27
+msgid ""
+"Know the basics of Qt application development using Python, either with "
+"`PyQT`_ or `PySide`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:29
+msgid ""
+"To quickly get started in desktop application development with Qt and "
+"Python here is a set of open access resources:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:31
+msgid "`Tutorials Point - PyQt tutorial`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:32
+msgid "`Real Python - PyQt entries`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:33
+msgid "`Guru99 - PyQt tutorial`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:34
+msgid "`Python GUIs - PyQt and PySide tutorials`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:46
+msgid "Learning Goals"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:48
+msgid "By the end of this workshop participants will know:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:50
+msgid ""
+"The basics to develop plugins for Spyder, and get a general idea of its "
+"inner workings."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:51
+msgid "What types of plugins can be developed with Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:52
+msgid ""
+"The structure of a plugin and the functionality of each component and how"
+" it connects to Spyder to extend its features."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:53
+msgid ""
+"How to package and publish our plugin so that it can be easily installed "
+"and used by others."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:59
+msgid "Spyder for developers"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:61
+msgid ""
+"The best place to find information about contributing to Spyder or "
+"developing for Spyder is its Github repository, in particular the "
+"`contribution guide`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:66
+msgid ""
+"The core of **Spyder** is `Spyder-IDE`_ , a desktop application developed"
+" in *Qt*, which requires for its operation two packages with it is "
+"closely related (and without which it cannot work): *spyder-kernels* and "
+"*python-lsp-server*."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:68
+msgid ""
+"`Qt`_ is an open source multiplatform widget toolkit for creating native "
+"graphical user interfaces. Qt is a very complete development framework "
+"that offers utilities for building applications, and has extensions for "
+"Networking, Bluetooth, Charts, 3D rendering, Navigation (as GPS), among "
+"others."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:70
+msgid ""
+"Spyder uses `qtpy`_ which is an abstraction layer that allows you to work"
+" with Qt from Python regardless of whether you use either of the two "
+"reference libraries: PyQt or PySide."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:72
+msgid ""
+"`spyder-kernels`_ provide Jupyter kernels to Spyder, for use within its "
+"consoles."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:76
+msgid ""
+"Spyder is currently developed in such a way that most of its features are"
+" implemented as plugins."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:89
+msgid "Types of plugins we can develop in Spyder"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:97
+msgid ""
+"A plugin is a component that adds functionality to an application, it can"
+" be a graphical component, for example, to display maps, or a non-"
+"graphical one that adds additional syntax coloring schemes."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:99
+msgid ""
+"Formally, plugins are instances of Qt classes that modify the behavior of"
+" Spyder. Aside from a few fundamental components, most of Spyder's "
+"functionality arises from the interaction of plugins of two types:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:104
+msgid "SpyderDockablePlugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:106
+msgid ""
+"It is a plugin that works as a `QDockWidget`_, this is a Qt class that "
+"provides a graphical control that can be docked inside a `QMainWindow`_ "
+"or floated as a top-level window on the desktop."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:113
+msgid "SpyderPluginV2"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:115
+msgid ""
+"``SpyderPluginV2`` is a plugin that does not create a new dock widget on "
+"Spyder's main window. In fact, ``SpyderPluginV2`` is the parent class of "
+"``SpyderDockablePlugin``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:120
+msgid "Discovering Spyder plugins"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:124
+msgid ""
+"If we look at the Spyder interface, we can find a number of different "
+"panes on the right side (with the default layout), such as *Help*, "
+"*Variable Explorer*, *Plots*, *Files* and *History*."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:126
+msgid ""
+"Each of these panes is a ``SpyderDockablePlugin`` that offers an *Undock*"
+" option by clicking the hamburger menu button in the upper right corner."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:128
+msgid ""
+"These plugins can also be hidden or shown via their entry in the *View > "
+"Panes* menu, or using its corresponding keyboard shortcut displayed "
+"there."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:132
+msgid ""
+"High-level interface elements that do not offer an undocking option are "
+"basically instances of ``SpyderPluginV2``. These are typically used to "
+"handle more abstract functionality."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:134
+msgid ""
+"Examples of this are the *appearance* and *layout* plugins that manage "
+"Spyder's code color schemes and window layouts respectively."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:136
+msgid ""
+"Other examples of this type of plugins are the *main menu* and keyboard "
+"*shortcuts*. Some graphical elements, such as the main toolbar and the "
+"status bar are also instances of the ``SpyderPluginV2`` class."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:142
+msgid "What will we do?"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:144
+msgid ""
+"Our practical work will consist in the implementation of the Pomodoro "
+"technique for time management in the Spyder interface."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:151
+msgid ""
+"The `Pomodoro Technique`_, designed by Francesco Cirillo, is a time "
+"management practice used to increase your focus and productivity when "
+"trying to complete assignments or meet deadlines. Choosing to use a "
+"Pomodoro Timer can help to give a task your full, undivided attention."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:154
+msgid ""
+"The typical process of the Pomodoro Technique consists of the following "
+"six steps:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:157
+msgid "Choose a task to be done."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:158
+msgid "Set the Pomodoro Timer (default is 25 minutes)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:159
+msgid "Work only on that task until the timer ends."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:160
+msgid ""
+"When the timer rings, put a checkmark on a piece of paper, this is called"
+" \"a pomodoro\"."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:161
+msgid ""
+"If you have less than 3 checkmarks take a short break (by default, 5 "
+"minutes), and return to step 2."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:162
+msgid ""
+"When you have completed four Pomodoro cycles, you deserve a longer break "
+"(our default is 15 minutes). Checkmarks are reset to zero, go back to "
+"step 1."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:168
+msgid "Steps"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:170
+msgid ""
+"These are the general steps that we will be following throughout this "
+"workshop:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:172
+msgid ""
+"Select the most suitable plugin type and create its initial structure "
+"using `cookiecutter`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:173
+msgid ""
+"Install the plugin in development mode in the virtual environment from "
+"which we run Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:174
+msgid ""
+"Implement the functionality of our plugin using the Spyder classes and "
+"following the guidelines indicated in the plugin structure."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:175
+msgid ""
+"Build a configuration page for our plugin, which would appear in Tools > "
+"Preferences."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:180
+msgid "Location of Spyder Pomodoro Timer widgets in Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:185
+msgid "Spyder Pomodoro Timer in the preferences window."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:189
+msgid "Features"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:191
+msgid "A minimal planning to organize ideas."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:193
+msgid "Pomodoro Timer"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:195
+msgid "Status bar widget: to display the time for the current pomodoro interval."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:196
+msgid ""
+"State: we have three activity states: *pomodoro*, *short-break* and "
+"*long-break*. We can show a message (with `QMessageBox`_) to tell users "
+"that the time to take a break has arrived."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:197
+msgid ""
+"Interactions: the user could use Start, Stop and Reset buttons to handle "
+"the Pomodoro Timer. This can be implemented adding `QAction`_ instances "
+"in a menu on the toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:199
+msgid ""
+"Tasks Logger - Counter: We need a variable to count the number of "
+"pomodoros completed."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:202
+msgid "Notifications"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:204
+msgid ""
+"Dialog: Each time a pomodoro or break interval is completed, a message "
+"should appear to prompt the user to start working on a task or take a "
+"break."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:206
+msgid ""
+"When working on a plugin for any system, we must check the data "
+"structures and functions available in that system that can facilitate our"
+" development. This involves spending considerable time understanding its "
+"inner workings."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:219
+msgid "Set up a development environment"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:221
+msgid ""
+"In principle, we could use any Spyder installed within a `conda "
+"environment`_ according to the instructions given in the `installation "
+"guide`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:223
+msgid ""
+"However, if you use a working environment that has other dependencies and"
+" you want to keep your plugin development independent of them, it is "
+"recommended to create a new environment which only has Spyder with the "
+"minimum dependencies needed for your plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:228
+msgid "We can install it in the following way:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:240
+msgid ""
+"`Anaconda Individual Edition`_ is a Python distribution for data science "
+"and machine learning to be used in a single machine."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:241
+msgid ""
+"`Conda`_ is an Anaconda tool that manages virtual environments and their "
+"packages."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:242
+msgid ""
+"Conda can work with *channels* that allow the use of packages that are "
+"not part of the official distribution. The most important channel is "
+"`conda-forge`_, where a more extensive and updated list of packages than "
+"those offered by Anaconda Individual Edition are maintained."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:243
+msgid ""
+"Finally, `mamba`_, is an optimized implementation of conda's package "
+"management features, that resolves dependencies and installs packages "
+"much faster than conda."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:256
+msgid "Create a repository"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:258
+msgid ""
+"Now that we have our local virtual environment, it is good practice to "
+"manage our source code with a version control system, and the most widely"
+" used web service for this purpose is currently Github. Here you can "
+"find, for example, the Spyder and Python repositories."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:263
+msgid "To create a git repository on Github, we need to follow these steps:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:265
+msgid "Log in to your Github account."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:266
+msgid ""
+"Click on the \"New repository\" option in the \"+\" menu at the top right"
+" next to your profile picture."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:267
+msgid ""
+"A dialog will appear where you can insert the repository name and some "
+"basic options, e.g. to initialize the repository with a README or license"
+" files."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:268
+msgid "Click the “Create repository” button."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:269
+msgid ""
+"In the main window of the recently created repository, click on the green"
+" \"Code\" button an copy the clone link."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:270
+msgid ""
+"In your local command line run ``$ git clone [repo-link]``. You must have"
+" git installed and configured on your computer. If you don't have "
+"experience using git we recommend The Carpentries workshop `Version "
+"control with git`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:272
+msgid ""
+"A detailed description of `repository creation`_ could be found in the "
+"official Github documentation, and a `hello world`_ tutorial with basic "
+"git operations from the Github interface."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:282
+msgid "Let's get started"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:284
+msgid ""
+"We already have a git repository and a virtual environment where Spyder 5"
+" is installed."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:286
+msgid ""
+"Let's activate our environment and go into the local folder of our "
+"repository."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:293
+msgid ""
+"Then we need to use ``cookiecutter`` to create the initial structure of "
+"our plugin. `cookiecutter`_ is a tool made in Python specifically "
+"designed to create project templates. We have developed one of these "
+"templates to generate the basic structure of a plugin, it can be found "
+"at: https://github.com/spyder-ide/spyder5-plugin-cookiecutter"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:301
+msgid "Let's run cookiecutter to generate our"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:331
+msgid "The plugin structure"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:334
+msgid ""
+"After ``cookicutter`` finishes its job, you'll get the following tree "
+"structure in your repository"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:356
+msgid "In the root folder you'll find two important files:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:358
+msgid "The Makefile, which has several useful commands:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:375
+msgid ""
+"``setup.py``, which helps you to install, package and distribute your "
+"plugin with ``setuptools``, the standard for distributing Python Modules."
+" On this file the ``entry_points`` parameter of ``setup`` is quite "
+"important, as it is the one that allows Spyder to identify this package "
+"as a plugin, and to know how to access its functionalities."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:380
+msgid ""
+"The ``spyder-pomodoro-timer`` folder has the name you introduced when "
+"running ``cookiecutter``. Inside this you'll see a folder called "
+"``spyder``, where we will place the code of our plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:382
+msgid "In the ``spyder`` directory you'll find the following files:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:384
+msgid ""
+"``api.py``: where the functionality of the plugin is exposed to the rest "
+"of Spyder. That would allow additional functionality to be added from "
+"other plugins."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:386
+msgid ""
+"``plugin.py``: is the core of the plugin. Depending on the type of plugin"
+" we created, here you'll see an instance of ``SpyderDockablePlugin`` or "
+"``SpyderPluginV2``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:388
+msgid ""
+"If it is a ``SpyderPluginV2`` you should set a constant class named "
+"``CONTAINER_CLASS`` with an instance of ``PluginMainContainer``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:389
+msgid ""
+"If it is a ``SpyderDockablePlugin`` you should set a constant class named"
+" ``WIDGET_CLASS`` with an instance of ``PluginMainWidget``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:391
+msgid ""
+"``container.py``: only used for ``SpyderPluginV2`` plugins. This file "
+"contains an instance of ``PluginMainContainer`` that holds a reference to"
+" all graphical elements (or widgets) that the plugin is going to add to "
+"the interface. This is necessary because Qt requires widgets to be "
+"children of other widgets before using them (otherwise they appear as "
+"floating windows). Since ``SpyderPluginV2`` is not a widget, we need a "
+"data structure (i.e. the container) that is a widget for that."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:393
+msgid ""
+"``widgets.py``: in this file we will add the graphical components of our "
+"plugin. If it is of type ``SpyderPluginV2`` and it does not have widgets,"
+" then it is not necessary. We can also place here the instance of "
+"``PluginMainWidget`` necessary for ``SpyderDockablePlugin``, if we are "
+"developing that kind of plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:396
+msgid ""
+"``confpage.py``: this is where you specify the configuration page that "
+"will be displayed in ``Preferences``, so that the user can adjust the "
+"options of our plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:402
+msgid "Building our first plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:404
+msgid ""
+"From now on we will be building the plugin step by step. In the `spyder "
+"pomodoro timer repository`_ you will find the final version of the code "
+"for you to take a look at it, in case we are missing any detail."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:409
+#: ../../workshops/qt_fundamentals.rst:45
+msgid "Widgets"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:411
+msgid ""
+"The best way to start building our plugin is by implementing its "
+"graphical components first in ``widgets.py``"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:413
+msgid ""
+"Let's call the initial version, without any editing ``INITIAL``. In "
+"`INITIAL`_, widgets.py is as follows:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:431
+msgid ""
+"The preset imports are a guide to what we will need in our plugin. The "
+"``on_conf_change`` decorator will allow us to propagate the changes in "
+"configuration. ``get_translation`` helps us to generate translation "
+"strings for the plugin and ``SpyderWidgetMixin`` adds to any widget the "
+"attributes and methods needed to integrate it with Spyder (icon, style, "
+"translation, actions and extra options)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:433
+msgid ""
+"When taking a look at the Spyder ``api`` module, we can find that in "
+"Spyder there are two types of predefined components for the status bar:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:435
+msgid ""
+"``StatusBarWidget``, a class derived from ``QWidget`` and "
+"``SpyderWidgetMixin``, which contains an icon, a label and a spinner (to "
+"show the plugin loading)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:436
+msgid ""
+"``BaseTimerStatus``, a class derived from ``StatusBarWidget`` with an "
+"internal ``QTimer`` to periodically update its content."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:440
+msgid ""
+"Below, we will be indicating links in github with the diffs between the "
+"tags, this as an aid to check the progressive changes that will be made "
+"in the code."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:442
+msgid ""
+"The first version that we are going to reach after the first editions "
+"will be called ``HELLO WORLD``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:444
+msgid "`INITIAL -> HELLO WORLD widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:448
+msgid ""
+"Since we want a widget that shows the pomodoro countdown and is "
+"periodically updated, we will use a ``BaseTimerStatus`` instance."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:450
+msgid "So, we can substitute"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:456
+msgid "with"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:463
+msgid "Add an initial import:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:470
+msgid "With that, we can write our first widget like this"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:493
+msgid ""
+"Spyder needs ``ID`` to be defined for ``BaseTimerStatus``. Its "
+"constructor calls the parent class constructor and initializes the label "
+"with ``value``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:495
+msgid ""
+"We add a tooltip to verify the presence of our widget. Since Spyder uses "
+"``qtawesome`` (another of our projects that eases the incorporation of "
+"iconic fonts into PyQt applications), we can select an appropriate icon "
+"by running the ``qta-browser`` command on a terminal."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:501
+msgid "From here we can select and copy the name of the icon of our preference."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:506
+msgid ""
+"To finish the implementation of our widget, we need to add the following "
+"method:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:516
+msgid ""
+"``BaseTimerStatus`` requires this method to be implemented to update its "
+"content every time it is requested by the internal timer."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:520
+msgid "The container"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:522
+msgid ""
+"The next step in the development of our plugin is to create an instance "
+"of the widget we wrote above, so we can add it to Spyder's status bar. "
+"For that, we need to use a container. Due to Qt specifics, we need an "
+"instance of ``QWidget`` (the container) to be the parent of all other "
+"widgets part of our plugin (as mentioned above)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:524
+msgid "Thus, the `COOKIECUTTER`_ version of ``container.py`` is:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:547
+msgid "`INITIAL -> HELLO WORLD container.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:551
+msgid ""
+"In this case ``SpyderPomodoroTimerContainer`` is already defined, and we "
+"must implement the ``setup`` and ``update_actions`` methods."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:553
+msgid ""
+"Now we are going to add the widget created earlier to the container. To "
+"do so, first we need to import the widget."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:560
+msgid "Then we edit the ``setup`` method to add an instance of our widget."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:570
+msgid "Plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:572
+msgid ""
+"Finally, we define our plugin so that it is registered within Spyder. The"
+" `INITIAL`_ version (i.e. the one created by cookiecutter)  for "
+"``plugin.py`` is:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:575
+msgid "Imports:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:592
+msgid "Plugin class:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:633
+msgid "`INITIAL -> HELLO WORLD plugin.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:637
+msgid ""
+"First, we need to declare the dependencies of our plugin, by defining the"
+" ``REQUIRES`` class constant. Since we're going to add a status bar "
+"widget, we require the ``StatusBar`` plugin, as shown below."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:643
+msgid "Then we need to set the icon for our plugin. For that, we substitute"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:651
+#: ../../workshops/plugin-development.rst:668
+msgid "and"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:658
+#: ../../workshops/plugin-development.rst:871
+msgid "by"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:676
+msgid ""
+"Due to recent changes to the Spyder API, we need to add to the spyder "
+"imports"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:683
+msgid "And add the following after the ``on_initialize`` method:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:693
+msgid ""
+"With these changes, Spyder will be aware of the presence of our plugin, "
+"and that this plugin adds a new widget to the status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:695
+msgid "Finally, we add the following method to our plugin:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:704
+msgid ""
+"In this way, ``SpyderPomodoroTimer`` can access ``pomodoro_timer_status``"
+" of ``SpyderPomodoroTimerContainer`` as if it were its own property."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:706
+msgid "In summary, we did the following:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:711
+msgid ""
+"We created a widget, then we added it to the container, which is "
+"registered in the plugin through the ``CONTAINER_CLASS`` constant. In the"
+" plugin, we accessed the instance of that widget and added it to the "
+"status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:717
+msgid "How to test our plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:719
+msgid "Now it is time to see how our plugin looks in the Spyder interface."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:721
+msgid ""
+"**From the root folder of our plugin**, we activate the environment where"
+" Spyder is installed, and run:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:729
+msgid "Now we can see two outputs. The first one is shown in the command line:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:736
+msgid ""
+"And in Spyder you'll see our plugin in the status bar with the tooltip "
+"\"I am the Pomodoro tooltip\"."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:741
+msgid ""
+"Keep in mind that every time we make a change to our code, it is "
+"necessary to restart Spyder so that the plugin is reloaded and we can "
+"check the changes."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:747
+msgid "Enhancing our plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:749
+msgid ""
+"From now on we are going to go into details of how things are implemented"
+" in Qt. So in case you have any doubts, the Qt documentation will be your"
+" best guide. We created an annex to this workshop that quickly explains "
+"way the fundamental concepts of Qt for those in a hurry: :ref:`qt-"
+"fundamentals`"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:754
+msgid "Timer updates"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:756
+msgid ""
+"The first problem with our plugin is that its pomodoro timer is not being"
+" updated. To activate it we can use the ``QTimer`` in "
+"``PomodoroTimerStatus``, which is present because it's an instance of "
+"``BaseTimerStatus``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:758
+msgid ""
+"The second version where the value in the status bar is updated is called"
+" ``TIMER``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:760
+msgid ""
+"Let's go back to ``widgets.py`` and add this constant below the import "
+"lines (line 22)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:762
+msgid "`HELLO WORLD -> TIMER widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:774
+msgid ""
+"``POMODORO_DEFAULT`` is to set the pomodoro time limit in milliseconds, "
+"and ``INTERVAL`` to the timer update rate."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:776
+msgid "Now, in the ``__init__`` method of ``PomodoroTimerStatus`` we need to add:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:788
+msgid ""
+"Up to this point, we created a default value (``POMODORO_DEFAULT``) for "
+"the timer duration during pomodoros; we added it to the "
+"``pomodoro_limit`` attribute to be able to configure it; and with that "
+"value we initialized the ``countdown`` attribute that will be modified "
+"over time. As for the update interval of the timer, we set it to to the "
+"value of ``INTERVAL``, which corresponds to 1 second (one thousand "
+"milliseconds)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:791
+msgid ""
+"The function of ``self.timer`` is to update our timer periodically. This "
+"is done through the method ``timeout.connect()``, to which we pass as "
+"parameter the reference to the ``update_timer`` function that will "
+"perform the required adjustments."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:793
+msgid "Now let's implement ``update_timer`` at the end of the file:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:813
+msgid ""
+"Here we rely on the ``display_time`` method that converts the current "
+"``countdown`` value, which is measured in milliseconds, into a human-"
+"readable format. And ``update_timer`` simply keeps updating the countdown"
+" until it reaches zero."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:815
+msgid "If we run Spyder again we will find that our timer has come to life."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:824
+msgid "Timer controls"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:826
+msgid ""
+"Now we need a way to control our timer. We can achieve this by adding "
+"some buttons to Spyder's toolbar, which will be useful to learn how to "
+"work with toolbars, menus and actions in Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:830
+msgid "PomodoroTimerToolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:832
+msgid ""
+"The next version where actions are added to the toolbar is called "
+"``ACTIONS``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:834
+msgid "`TIMER -> ACTIONS widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:838
+msgid ""
+"Let's go back to ``widgets.py`` and import the Spyder application toolbar"
+" class:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:844
+msgid ""
+"And create an instance of it by adding the following code before the "
+"definition of ``PomodoroTimerStatus``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:853
+msgid ""
+"As you can see, this statement is very simple. It only needs to declare "
+"an ``ID``, that serves to identify our toolabr among the rest."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:855
+msgid ""
+"It is possible to include other Qt widgets in our toolbar, but in this "
+"case it's better to use the appropriate Spyder methods for that in order "
+"to maintain their relationship with the rest of the application. In other"
+" words, as long as the widget you need exists in ``spyder.api.widgets``, "
+"use it!"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:858
+msgid ""
+"Next, we need to declare a boolean variable in our status widget to "
+"indicate if the countdown is paused or not. For that, let's add the "
+"following inside the ``__init__`` method of ``PomodoroTimerStatus``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:864
+msgid "And inside the ``update_timer`` method, substitute"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:880
+msgid "Create the Pomodoro Toolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:882
+msgid ""
+"Now we are going to create a new section in our toolbar and associate "
+"some functionality to it by means of actions. This particular information"
+" is recommended to be included in the ``api.py`` file because this way we"
+" can offer endpoints to the rest of Spyder and new plugins for tweaking "
+"the behavior of our plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:884
+msgid "`TIMER -> ACTIONS api.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:888
+msgid "Let's add the following to the end of ``api.py``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:904
+msgid ""
+"With these we are telling the rest of Spyder, and our own plugin, that we"
+" are going to have a new toolbar section called \"pomodoro_timer\". This "
+"section will consist of a button containing a menu (with a single section"
+" \"main_section\") and actions identified as \"start_timer\", "
+"\"pause_timer\" and \"stop_timer\", to start, pause and stop (resetting) "
+"our timer, respectively."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:906
+msgid ""
+"Note that these are simple class definitions with class constants, to "
+"ease the encapsulation and exchange of this information in a simple way."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:909
+msgid "Add actions to the toolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:911
+msgid "`TIMER -> ACTIONS container.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:915
+msgid ""
+"Now let's go to ``container.py``, where we are going to implement the "
+"behavior of our new toolbar and its actions. In this case, we are not "
+"going to specify the internal behavior of our plugin, but the "
+"relationship between its widgets and other areas of Spyder, so it is more"
+" convenient to do it in the container."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:918
+msgid ""
+"As we did with ``PomodoroTimerStatus``, we are going to use ``qtawesome``"
+" icons for our actions. For this purpose, let's add at the beginning of "
+"our imports:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:926
+msgid ""
+"We also imported ``QToolButton`` because it will be used to set the "
+"button that we will add in our toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:928
+msgid "At the end of the Spyder imports we also need:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:934
+msgid ""
+"Now, let's include ``PomodoroTimerToolbar`` and the actions and sections "
+"we just declared in ``api.py`` in our local imports:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:948
+msgid ""
+"Next, we need to do following things in the ``setup`` method of "
+"``SpyderPomodoroTimerContainer``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:950
+msgid ""
+"The first one is to create an instance of the toolbar class we declared "
+"earlier:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:957
+msgid ""
+"The second one is to create the actions corresponding to Start, Pause and"
+" Stop our pomodoro timer:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:986
+msgid ""
+"The third one is to create the menu that will contain our actions and add"
+" them to it."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1004
+msgid ""
+"The fourth one is to create a button that will contain the menu and "
+"configure it as ``PopupMode``, so that it is displayed when clicked."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1017
+msgid "And finally, the fifth one is to add the button to our toolbar:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1028
+msgid ""
+"When creating the actions, we indicate by means of the ``triggered`` "
+"parameter the methods to be executed when they are activated, i.e. when "
+"the corresponding buttons on the toolbar are clicked."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1030
+msgid ""
+"We can insert these methods at the end of the "
+"``SpyderPomodoroTimerContainer`` declaration, in the section that our "
+"cookiecutter template indicates as ``# --- Public API``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1050
+msgid ""
+"These methods simply manipulate the ``pause`` field of "
+"``pomodoro_timer_status``, and in the case of ``stop_pomodoro_timer`` the"
+" countdown is restarted."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1053
+msgid "Register the toolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1055
+msgid "`TIMER -> ACTIONS plugin.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1059
+msgid ""
+"A final mandatory step is to go to ``plugin.py`` and register this new "
+"toolbar component."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1061
+msgid "To do this, add ``Plugins.Toolbar`` to the plugin requirements:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1067
+msgid ""
+"And use this plugin's API to add the toolbar we have created in the "
+"container to Spyder's toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1078
+msgid "Review the changes"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1080
+msgid ""
+"The first thing we can notice is that we already have the corresponding "
+"buttons in the toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1085
+msgid ""
+"The strings that were entered as the ``tip`` parameter in the creation of"
+" the actions are shown here as the buttons' tooltips."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1087
+msgid ""
+"Also, if we check the menu \"View > Toolbars\", we find that there is a "
+"new entry there corresponding to our toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1093
+msgid ""
+"Finally, let's check how the new Pomodoro Timer control buttons in the "
+"toolbar interact with the component in the status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1102
+msgid "Add a Configuration Page"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1104
+msgid ""
+"Another feature of Spyder plugins is that they can have configurable "
+"options that appear in Spyder's Preferences window."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1107
+msgid "Configuration defaults"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1109
+msgid ""
+"The final version in which we add a configurable parameter will be called"
+" ``CONFPAGE``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1111
+msgid ""
+"The first step is to define what options we want to offer to our users. "
+"For this we must create a new file, which we can call ``conf.py``. In "
+"this file we will write the following:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1113
+msgid "`ACTIONS -> CONFPAGE config.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1138
+msgid ""
+"We must highlight the declaration of ``CONF_SECTION``, which is the "
+"internal name of the section in Preferences corresponding to our plugin; "
+"and the dictionary keys associated with ``CONF_DEFAULTS``. In this case, "
+"we are indicating that ``pomodoro_limit`` is a configurable parameter "
+"within the ``spyder_pomodoro_timer`` section."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1140
+msgid ""
+"At the end of this file it is necessary to set another important "
+"constant, ``CONF_VERSION``, which must be updated when adding, removing "
+"or renaming configurable parameters in successive versions of the plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1153
+msgid ""
+"Note that we are moving the definition of ``POMODORO_DEFAULT`` from "
+"``widgets.py`` to ``conf.py``, since we now have a dedicated place for "
+"default configuration values."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1156
+msgid "Configuration page"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1158
+msgid ""
+"Now, we need to build the page that will appear in the Preferences "
+"window. For this, we edit the ``confpage.py`` file generated by "
+"cokkiecutter as follows:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1160
+msgid "`ACTIONS -> CONFPAGE confpage.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1206
+msgid ""
+"This mostly corresponds to the regular code for user interfaces based on "
+"Qt widgets. In this case, our options section corresponds to a "
+"``QGroupBox``, where the parameters are organized vertically using a "
+"``QVBoxLayout``, and each parameter corresponds to a ``QGridLayout`` "
+"where labels and inputs are distributed (in this case a ``QSpinBox``)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1208
+msgid ""
+"Configuration pages in Spyder provide some helper methods to facilitate "
+"this work. For instance, ``create_spinbox`` allows to instantiate and "
+"initialize in a single step the widgets corresponding prefix an suffix "
+"labels together with the spinbox."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1211
+msgid "Propagate configuration changes"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1213
+msgid ""
+"Since we moved all the configuration information to ``conf.py``, now we "
+"have to import it from there into ``widgets.py``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1215
+msgid "`ACTIONS -> CONFPAGE widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1228
+msgid ""
+"Now we can access the configuration options from anywhere in our plugin "
+"using the ``get_conf`` method. In this case we use it to access the value"
+" of ``pomodoro_limit`` from the configuration instead of the constant "
+"``POMODORO_DEFAULT``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1236
+msgid ""
+"Now we can add a method that updates our configurable parameter "
+"``pomodoro_limit``. The ``@on_conf_change`` decorator is the one in "
+"charge of capturing the signal that is generated when applying the change"
+" of a specific option."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1247
+msgid "Registering preferences"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1249
+msgid ""
+"Finally, it is necessary to activate the use of preferences in "
+"``plugin.py``, by requiring the Preferences plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1251
+msgid "`ACTIONS -> CONFPAGE plugin.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1262
+msgid ""
+"and registering our plugin in a method with the decorator "
+"``@on_plugin_available``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1271
+msgid ""
+"Now we can access the Preferences window either from the toolbar or from "
+"the \"Tools > Preferences\" menu. There we will find a section called "
+"*Spyder Pomodoro Timer* and inside it is the *Pomodoro timer limit* "
+"parameter. If we change that value, we will see how the corresponding "
+"label in the status bar changes."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1276
+msgid "Now your plugin is in an initial version ready to publish..."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1282
+msgid "Publishing your plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1284
+msgid ""
+"Since the recommended way to install Spyder is through conda, the obvious"
+" choice would be to publish our plugin through a channel like conda-"
+"forge, but this is a task that is beyond the scope of this workshop due "
+"to its complexity."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1286
+msgid ""
+"However, the tools used to publish packages in conda are usually based on"
+" the packages published in PyPI. So let's see how to publish our plugin "
+"there."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1293
+msgid "PyPI and TestPyPI"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1295
+msgid ""
+"The first thing we have to do is to create an account on the `PyPI`_ and "
+"`TestPyPI`_ websites. Although our package will be finally published in "
+"PyPI, it is advisable to use TestPyPI to test that our package can be "
+"published properly without generating additional load to the PyPI servers"
+" or affecting their logs."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1297
+msgid ""
+"Next, we need edit the ``setup.py`` file at the root of our project with "
+"our own data. Fortunately, cookiecutter created one for us."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1299
+msgid ""
+"To upload our package to PyPI we have to use a tool called `Twine`_ that "
+"makes this task much easier. And we can install it in our conda "
+"environment using:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1306
+msgid "Build and check the package"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1308
+msgid ""
+"Before publishing our plugin we must package it. To do it we must write "
+"the following from the root folder of our project (where ``setup.py`` is "
+"placed):"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1314
+msgid ""
+"After that we will see that the following files are generated in the "
+"``dist`` folder:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1323
+msgid ""
+"On Linux and macOS we can check that the newly built distribution "
+"packages contain the expected files by inspecting the contents of the "
+"``tar`` file:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1329
+msgid ""
+"You can also use ``twine`` to run a check on the created files in "
+"``dist``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1338
+msgid "Upload to PyPI"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1340
+msgid ""
+"Now we can use twine to upload the distribution packages we have built. "
+"First, we will upload them to TestPyPI to make sure everything works:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1346
+msgid ""
+"This command will prompt you for the username and password with which you"
+" registered in TestPyPI."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1348
+msgid ""
+"If we open https://test.pypi.org/project/spyder-pomodoro-timer/ in the "
+"browser we will be able to see the package we have just published."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1350
+msgid ""
+"There we'll see that some details are missing, like the package "
+"description, and that our package is marked as ``Development Status "
+"5-Stable``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1352
+msgid ""
+"To fix the first one, we can follow the instructions in `Making a PyPI-"
+"friendly README`_. Since we already have a README file, we simply add the"
+" following lines to the beginning of our ``setup.py`` file:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1368
+msgid ""
+"We can also change the classifiers of our package using the following "
+"site as a guide: https://pypi.org/classifiers. Here we can simply copy "
+"the classifiers we consider appropriate and then paste them into our "
+"code. Specifically in ``setup.py``, within the list that enters as the "
+"``classifier`` argument in the call to function ``setup``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1371
+msgid ""
+"With these changes, and by bumping our plugin's version in the "
+"``__init__.py`` file inside the ``spyder_pomodoro_timer`` folder, we can "
+"repeat the cycle of building a new version of our package, loading it "
+"into TestPyPI for checking, and finally loading it into PyPI by using:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1377
+msgid "And check the result in https://pypi.org/project/spyder-pomodoro-timer/"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1379
+msgid ""
+"Once this is done, anyone can install our plugin in their environments "
+"simply by running:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1396
+msgid ""
+"The possibility of making a tool extensible through plugins, extensions "
+"or addons, as they are usually called, is a fundamental feature that "
+"allows taking advantage of the talent of third-party developers to "
+"respond to needs and enhancements that are beyond the scope of the "
+"application's core development team."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1398
+msgid ""
+"Similarly, a plugin-based system makes the application much easier to "
+"maintain. Eventually, the ability to enable and disable plugins makes it "
+"more adaptable to different use cases. For instance, at present it would "
+"be inconceivable to think of a web browser that does not have extensions "
+"to block advertising or organize links, even if those features don't come"
+" by default on them."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1400
+msgid ""
+"In Spyder we have put special interest in consolidating an API that "
+"allows the development of plugins in a consistent way. The main focus of "
+"the development effort between versions 4 and 5 was in this direction and"
+" we are at a key moment where we expect to capitalize on all this work."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1404
+msgid "Identify the basic building blocks in Spyder development."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1405
+msgid "Identify the different types of plugins that can be implemented in Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1406
+msgid "Recognize the types of plugins that are part of Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1407
+msgid "Plan the development of a new Spyder plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1408
+msgid "Build a development environment for Spyder plugin development."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1409
+msgid "Generate the basic structure of a Spyder plugin using Cookiecutter."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1410
+msgid "Understand the file structure of a Spyder plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1411
+msgid "Add and register Qt widgets in the Spyder status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1412
+msgid "Add and register Qt widgets in the Spyder toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1413
+msgid "Add a menu with actions in the toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1414
+msgid ""
+"Add configuration options to our plugin and display them appear in the "
+"Preferences window."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1415
+msgid ""
+"Edit the description and classifiers of the installable package of our "
+"plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1416
+msgid "Publish our plugin to TestPyPI and PyPI."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1418
+msgid ""
+"With these skills we hope to ease the way for you to develop your own "
+"Spyder plugins."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1420
+msgid ""
+"If you have ideas for plugin development feel free to contact us through "
+"the `Spyder-IDE`_ Github organization space."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1424
+#: ../../workshops/scientific-computing.rst:776
+msgid ""
+"If you are interested in an introduction to financial analysis with "
+"Spyder, you can visit the workshop :doc:`Financial Data Analysis with "
+"Spyder<../workshops/financial>`."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1431
+msgid ""
+"As you may have noticed, there were some features left to implement such "
+"as notifications when pomodoros are completed. Try to implement them and "
+"do not hesitate to contact us if you have any doubts."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1438
+msgid ""
+"In the `plugin-examples`_ repository you can find additional examples "
+"that will surely be useful for you to further understand Spyder plugin "
+"development."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1440
+msgid ""
+"A more in-depth review of the Spyder repository itself, especially its "
+"simpler plugins, such as History, Plots or Working directory, may help "
+"you understand it better. As well as a review of the various helper "
+"functions, widgets and mixins present in ``spyder.api``."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:5
+msgid "Qt Fundamentals"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:9
+msgid ""
+"**Qt** is a multiplatform widget toolkit for creating native graphical "
+"user interfaces. Qt is also a very complete development framework that "
+"offers utilities for building applications, and libraries of extensions "
+"for Networking, Bluetooth, Charts, 3D rendering, Navigation (as GPS), "
+"among others."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:14
+msgid "Basic Qt Components"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:16
+msgid ""
+"As mentioned before, Spyder's plugin development consists of extending "
+"the functionality of its Qt-based graphical interface."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:18
+msgid ""
+"To develop a GUI we will add graphical elements of interaction known as "
+"widgets, arrange them using layouts. Then, we interconnect those widgets "
+"using customized procedures implemented as functions or methods, allowing"
+" to trigger behavior from user interaction. In the following, we will "
+"develop these ideas in more detail."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:20
+msgid ""
+"Each type of Qt component is a class starting with the letter ``Q`` "
+"followed by a name related to its functionality."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:22
+msgid ""
+"The core component of Qt is the ``QApplication`` class. Every Qt "
+"application needs a single instance of this class as the base, from where"
+" the Qt *event loop* is controlled. Spyder itself is an instance of "
+"``QApplication``, its starting point is in the following two lines of "
+"code (spyder/spyder/app/mainwindow.py):"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:30
+msgid ""
+"``QMainWindow`` is a pre-built widget that provides many standard window "
+"features as toolbars, menus, a status bar, dockable widgets and more, "
+"which serves as the basis for the application."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:34
+msgid "Signals & Slots"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:36
+msgid ""
+"**Signals** are notifications emitted by widgets when something happens. "
+"That something could be different things, from pressing a button, to "
+"changing text in an input box, to changing text in the window. Many "
+"signals are initiated by user action, but this is not a rule."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:39
+msgid ""
+"**Slots** are signal receivers. Functions or methods could be used as "
+"slots, by connecting a signal to them. If a signal sends data, the "
+"receiver callable will also receive it. Many Qt widgets also have their "
+"own built-in slots, so the corresponding widgets are notified "
+"automatically."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:47
+msgid ""
+"In computer science a *Widget* is a shortened form of “window gadget”. A "
+"widget is an element of interaction, such as a button, or a container for"
+" other widgets, as panels or tabs. The ``QWidget`` class is the "
+"fundamental class for creating interfaces in Qt, it receives events from "
+"the window system, and renders its representation on the screen. A widget"
+" can provide a container for grouping other widgets, and if it is not "
+"embedded in a parent widget, it becomes a window."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:52
+msgid "Layouts"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:54
+msgid ""
+"Interfaces are built by embedding widgets inside widgets, and since they "
+"are visual components they are visually organized by means of *layouts*. "
+"A layout indicates how the widgets fill their container, either as "
+"columns, rows, cells in a matrix or stacked so that only one is visible "
+"at a time. Those are the 4 basic layouts available in Qt: "
+"``QHBoxLayout``, ``QVBoxLayout``, ``QGridLayout``, and "
+"``QStackedLayout``."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:61
+msgid "Actions, Toolbars & Menus"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:63
+msgid ""
+"User interfaces of desktop applications usually use ``QToolbar`` and "
+"``QMenu``. Since these are alternative ways to access the same "
+"functionality, Qt provides ``QAction`` as a way to avoid duplication of "
+"functions. Thus, each time a menu option or a toolbar button gives access"
+" to the same function, they point to the same action."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:67
+msgid "Dialogs"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:69
+msgid ""
+"A *Dialog* is a GUI component that communicates with the user. Dialogs "
+"are commonly used for functions that do not fit into the main interface. "
+"In Qt, by design ``QDialog`` is a modal (or blocking) window that show in"
+" front of the main Window until it is dismissed."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:72
+msgid ""
+"Qt provides some *special dialogs* for the most common use-cases as *file"
+" Open/Save*, *font selection*, *error messages*, *color choosing*, "
+"*printing*, among others."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:76
+msgid "Windows"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:78
+msgid ""
+"If an application requires additional windows that do not block the main "
+"window, these are generated as non-parent ``QWidget`` instances. These "
+"are used for tasks that happen in parallel over long-running processes "
+"such as displaying graphs or document editing."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:83
+msgid "Events"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:85
+msgid ""
+"An *Event* denote every interaction the user has with a Qt application. "
+"There are several types of events designed to address different types of "
+"interactions. In Qt they are represented by ``QEvent`` instances that "
+"contain information about what prompted them, and are passed to specific "
+"handlers that are responsible for triggering further actions."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:3
+msgid "Scientific Computing and Visualization with Spyder"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:5
+msgid ""
+"This workshop allows you to explore some of Spyder's features that make "
+"Spyder an ideal IDE for using the scientific tools offered by Python. "
+"Throughout the workshop, we will apply the scientific method to answer "
+"some questions related to our preferences and cognitive abilities. By the"
+" end of this workshop participants will be able to use Spyder to explore "
+"data, analyze it with some statistical tools and plot the relationship "
+"between variables."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:23
+msgid ""
+"Some knowledge of Statistics (`hypothesis testing`_ , `ANOVA`_, "
+"`p-value`_)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:38
+msgid ""
+"Apply the scientific method to answer questions related to psychometric "
+"variables"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:39
+msgid "Understand how to use Spyder's built-in scientific computing tools"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:47
+msgid ""
+"This workshop is intended for people who want to learn how to answer "
+"questions scientifically from a dataset. We have also designed it to "
+"serve as a tutorial for learning how to use Spyder as a research tool."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:55
+msgid ""
+"In this workshop we will explore a data set and use it to answer some "
+"questions using the scientific method."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:59
+msgid "Why do scientific research with Python?"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:61
+msgid ""
+"Python is a mature programming language that has been chosen by much of "
+"the scientific community to support the research process. There are a few"
+" reasons for this:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:63
+msgid "It is versatile and easy to learn and use"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:64
+msgid ""
+"It allows for multiple ways to handle inputs and outputs. No matter what "
+"format your data is in, in Python there is always a way to import it (and"
+" export it in the format of your choice)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:65
+msgid ""
+"It is interpreted. You don't have to write code from start to finish to "
+"see partial results. This makes it especially easy and fast to explore "
+"data"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:66
+msgid ""
+"It has built-in support for scientific computing tasks: `SciPy "
+"<https://scipy.org>`_, `NumPy <https://numpy.org>`_, `Pandas "
+"<https://pandas.pydata.org>`_, and a vast number of other libraries "
+"created by and for scientists"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:67
+msgid ""
+"It is the most widely used programming language for Machine Learning "
+"(including Keras and TensorFlow)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:69
+msgid ""
+"It can be integrated with `Jupyter Notebooks <https://jupyter.org>`_ and "
+"implementations of these in the cloud (`Google Colab "
+"<https://colab.research.google.com>`_ or `Binder "
+"<https://mybinder.org>`_)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:73
+msgid "How can Spyder help me in my scientific research?"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:75
+msgid ""
+"Spyder is a Scientific Integrated Development Environment written in "
+"Python, and designed by and for scientists, engineers, and data analysts."
+" It features a unique combination of the advanced editing, analysis, "
+"debugging, and profiling functionality of a comprehensive development "
+"tool with the data exploration, interactive execution, deep inspection, "
+"and beautiful visualization capabilities of a scientific package. "
+"Together with Python, it provides a very complete set of tools for "
+"scientific computing."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:79
+msgid "The basic steps of the scientific method"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:81
+msgid ""
+"The `scientific method "
+"<https://en.wikipedia.org/wiki/Scientific_method>`_ is a set of good "
+"practices used to achieve new knowledge in a valid way. Broadly speaking,"
+" the stages of the scientific method are as follows:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:83
+msgid "Observation: first find something that needs an explanation"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:84
+msgid ""
+"Search/generate theory: say a thing or two about the state of the world "
+"or how it works (an abstract thought about a phenomenon)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:85
+msgid "Hypothesis: identify variables and make predictions"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:86
+msgid ""
+"Testing/Experiment/More observation: measure relationship between "
+"variables"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:87
+msgid "Analysis: fit a model/graph data"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:88
+msgid "Reporting: share new findings"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:90
+msgid ""
+"Throughout this workshop, we will be developing each of these steps in a "
+"practical way. We will use Spyder as a research tool and psychometric "
+"data from an online dating site to make it easy and fun."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:94
+msgid "Introduction to scientific research with Spyder"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:100
+msgid ""
+"If you already have experience with Spyder, you can skip to `Preparation "
+"work`_ section."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:122
+msgid ""
+"The Variable Explorer is one of the most frequently used components in "
+"this workshop. **This is the pane where we will observe the data and most"
+" of the results of the scientific analysis, except for the plots**."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:128
+msgid ""
+"The :doc:`Plots pane <../panes/plots>` shows all the static graphs and "
+"images created in your IPython Console session. **All plots generated by "
+"the code will appear in this component**. You will also be able to save "
+"each graphic in a local file or copy it to the clipboard to share it with"
+" other researchers."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:132
+msgid "Code Analysis (share a stylish code!)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:134
+msgid ""
+"Wouldn't it be great to have a tool to be able to detect code errors, "
+"stylistic problems, bad practices, inconsistencies and other issues? This"
+" is precisely the task of the  :doc:`Code Analysis<../panes/pylint>`. "
+"Your code can run, but if you are going to share it with other "
+"researchers it would be great if it is both readable and neat as well."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:146
+msgid "Setting up the Conda environment"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:154
+msgid ""
+"We recommend creating the virtual environment with `Anaconda "
+"<https://www.anaconda.com/products/individual>`_ (or `Miniconda "
+"<https://docs.conda.io/en/latest/miniconda.html>`_) as it integrates "
+"seamlessly with Spyder. You can find installation instructions in "
+"`Anaconda documentation`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:160
+msgid "1. With commands"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:162
+msgid ""
+"Just run the following command in your Anaconda Prompt (Windows) or "
+"terminal (other platforms), for a minimal install of Spyder into a new "
+"environment called ``scientific-computing``:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:168
+msgid ""
+"To install Spyder's optional dependencies as well for full functionality,"
+" use the following command instead:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:176
+msgid ""
+"Spyder now offers :ref:`install-standalone` for Windows and macOS, making"
+" it easier to get up and running with the application without having to "
+"download Anaconda or manually install it in your existing environment. If"
+" you use the standalone installer, there is no need to install "
+"``spyder=5`` with conda."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:180
+msgid "2. From an environment.yml file"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:182
+msgid ""
+"You can also install the virtual environment easily using the environment"
+" file (``scientific-computing.yml``) that we share with you. Just run the"
+" following command in the terminal (you must have the environment file in"
+" the current directory):"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:190
+msgid "Activate environment"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:192
+msgid "You can now enter the newly created virtual environment in this way:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:200
+msgid "Downloading the dataset"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:202
+msgid ""
+"We are going to work with a public dataset called OKCupid, collected by "
+"Kirkegaard and Bjerrekaer. The dataset is composed of 68,371 records and "
+"2,626 variables."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:204
+msgid "Download the `OKCupid dataset`_ to a directory of your choice."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:210
+msgid "Setting up the working directory"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:212
+msgid ""
+"The virtual environment and the data file are now ready. The only thing "
+"that remains is to create a directory to work in. In your operating "
+"system, create a new directory with the name of your choice. Then copy "
+"and unzip the dataset file there."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:214
+msgid "Here is an example (on Linux or macOS):"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:221
+msgid ""
+"Keep in mind that in this new directory you must have the data file "
+"unzipped."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:223
+msgid "Launch Spyder:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:229
+msgid ""
+"Let's make sure Spyder is ready. First, check that the working directory "
+"is correct. You should see in the upper right corner the path to the "
+"directory where you have the dataset. Something like this:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:234
+msgid ""
+"Second, let's check that the virtual environment we created is enabled in"
+" Spyder. Go to :guilabel:`Preferences` > :guilabel:`Python interpreter`, "
+"and use the dropdown under :guilabel:`Use the following Python "
+"interpreter` to select the path to your virtual environment. You should "
+"see something like this:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:245
+msgid ""
+"Although the workshop is designed for you to write the code in the "
+"IPython Console, we have created a file that you can :download:`download "
+"<scientific-computing.py>`. This script provides all the code you will "
+"write in this workshop, and you can use it as a guide if you get lost."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:251
+msgid "The dataset"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:253
+msgid ""
+"OKCupid is a dataset that gathers information obtained from the online "
+"dating site OKCupid. It consists of 68,371 records collected "
+"automatically employing a scraper that extracted public information."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:255
+msgid ""
+"The dataset contains demographic data (e.g., gender, sexual orientation "
+"and age). It also includes answers to general questions used by the "
+"website's algorithm to calculate some personality indicators to help find"
+" compatible matches."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:257
+msgid ""
+"If you want more information about how this dataset was collected and "
+"what kind of information it contains you can get it in this paper: `The "
+"OKCupid dataset`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:266
+msgid ""
+"You can also write your code or in the Editor (the pane that occupies the"
+" entire left side of Spyder). If you use the Editor, you can run the code"
+" by selecting it and pressing the :guilabel:`Run selection or current "
+"line` button in the :guilabel:`Run toolbar` or by pressing the F9 button."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:280
+msgid ""
+"The data you downloaded earlier is in `parquet "
+"<https://arrow.apache.org/docs/python/parquet.html>`_ format. This format"
+" is very convenient because it is smaller and faster than CSV or JSON "
+"files."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:282
+msgid "Load data:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:288
+msgid ""
+"You should now be able to see the data you have imported in the Variable "
+"Explorer."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:293
+msgid ""
+"You can see that the object is of type DataFrame and the number of rows "
+"and columns of the object."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:299
+msgid "Explore the dataset"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:303
+msgid "Age"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:305
+msgid ""
+"Now, let's explore one of the variables, in this case, the numeric "
+"variable age (``d_age``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:309
+msgid ""
+"In the OKCupid dataset, all demographic variables are prefixed with "
+"\"d\\_\" and profile variables with \"p\\_\"."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:318
+msgid ""
+"What happened? We called the ``data`` object and used Python's dot "
+"notation to pick the ``d_age`` column. This has a `Pandas Series "
+"<https://pandas.pydata.org/pandas-"
+"docs/stable/reference/api/pandas.Series.html>`_ type object. To this "
+"object we pass the ``describe()`` method that shows a summary of some "
+"indicators: count of values, mean, standard deviation, maximum value, "
+"minimum value, among others. With these figures we can see that the "
+"sample is mainly constituted of young people (the average is 31.65 years "
+"old)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:320
+msgid ""
+"The return of a function, method or the attribute of an object can be "
+"stored as a variable to have it at hand in the Variable Explorer:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:330
+msgid ""
+"The values are floats. The lowest age is 18.0 years and the highest is "
+"100.0 years."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:334
+msgid ""
+"Notice also that each type of variable has a different color to quickly "
+"distinguish them."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:336
+msgid ""
+"We already know the minimum and maximum age, and that the mean is around "
+"32 years old. A good way to further explore this variable is to plot a "
+"histogram, a type of graph that shows the frequency distributions. In "
+"this way we can see if the groups of young people on the platform are "
+"more numerous than the older ones."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:338
+msgid ""
+"We can plot a histogram directly from the dataframe. To do this we select"
+" the variable (as we did with the ``.describe()``) and invoke the "
+"``.plot.hist()`` method. In this method we will pass as arguments the "
+"number of bins and the transparency of the plot (``alpha``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:348
+msgid ""
+"Another way to generate a simple histogram in Spyder is to use a context "
+"menu on an array in the Variable Explorer. But first we must store these "
+"values in a list and call that variable ``age``."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:360
+msgid ""
+"Frequency distributions come in different sizes and shapes. The shape of "
+"a histogram reveals very interesting things about the data. A "
+"symmetrical, bell-shaped histogram might indicate that the distribution "
+"is normal (most of the scores are close to the center of the "
+"distribution). In the age histogram, you can see that it has a \"tail\" "
+"to the right (towards the older ages). Technically this is called "
+"\"positively `skewed`_\". It is also noticeable that it is somewhat "
+"pointy (positive `kurtosis`_ or leptokurtic). These two things could "
+"suggest that age is not a random variable."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:365
+msgid ""
+"Although we can create the histogram directly from the dataframe, we are "
+"going to use a Python library called Seaborn to do the same, because this"
+" library will allow us to do more interesting things later."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:372
+msgid ""
+"We call ``sns.histplot()`` with three arguments. The first one "
+"(``data.d_age``) is a Pandas Series with the **quantitative** variable we"
+" want to plot. The second (``kde=True``) adds a curve showing an ideal "
+"model of the age distribution (using a method called *Kernel Density "
+"Estimator*). And the third one (``bins=25``) indicates that we want 25 "
+"bins in the graph."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:377
+msgid ""
+"The second line (``plt.show()``) is intended to show all the figures not "
+"displayed so far. If you have any doubts about how to utilize an object, "
+"method or function, you can use the ``help()`` tool in the console. For "
+"example:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:383
+msgid ""
+"Or you can also take advantage of the Help pane included in Spyder to get"
+" on-screen help:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:388
+msgid ""
+"With Seaborn, we can add a line representing the mean of the histogram. "
+"To do this we will use the ``axvline()`` method and add a text with the "
+"value of the mean where ``text()``, ``min_ylim`` and ``max_ylim`` are "
+"used to mark the position of the text."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:405
+msgid "Religion seriosity"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:407
+msgid ""
+"We know the extent of the dataframe and we have seen how to explore a "
+"quantitative variable. Now let's move on to a qualitative variable. The "
+"``columns`` attribute shows a list of column names in the dataframe. We "
+"also know that demographic variables are prefixed with \"d\\_\", so we "
+"can look for variable names that correspond to this prefix."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:413
+msgid ""
+"In the Variable Explorer you will see a new variable ``demograph``. If "
+"you double click on it you will see a list of the demographic variables "
+"in the dataset. At the end of the list you will see a value "
+"``d_religion_seriosity``. If you right click on it, several options will "
+"appear on the screen. You can rename the column, delete it or insert a "
+"new one. Let's click on :guilabel:`Copy` to copy the column name into "
+"memory."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:415
+msgid ""
+"In the IPython Console, type ``data.`` and then copy the column name. "
+"Type a period at the end (no spaces) and hit tab. You should see "
+"something like the following:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:420
+msgid ""
+"You can then see a list of all relevant methods and attributes of the "
+"class. Right at the end you will see ``value_counts`` that could be used "
+"to summarize the variable. It is a method so it must end in parentheses:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:432
+msgid ""
+"In addition to demographic and profile variables, the dataset includes "
+"responses to questions on a variety of topics. These questions are coded "
+"with a prefix \"q\" followed by an integer. The text of the questions is "
+"stored in a file called :file:`question_data.csv` (which you can download"
+" as part of the `OKCupid dataset`_)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:434
+msgid "We can examine this file in the Variable Explorer:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:440
+msgid ""
+"Double click on \"question_data\" in the Variable Explorer to display "
+"each question aligned with its code (\"q\" + number)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:442
+msgid ""
+"Now that we have learned how to explore the data we can ask interesting "
+"questions and try to answer them with the help of the dataset and Spyder."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:448
+msgid "Think of a theory and write a hypothesis"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:450
+msgid ""
+"A theory is nothing more than an explanation of something. For example, "
+"we could get involved in the eternal conflict between cats and dogs. I, "
+"as a dog person, might have a theory (unscientific, of course) that those"
+" who prefer to have the companionship of a dog are smarter people than "
+"those who prefer a wicked (but lovable) kitty. To test the support of a "
+"theory, one can make a prediction based on it and see how this prediction"
+" behaves in an experiment or a concrete situation. We call this "
+"prediction a hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:452
+msgid ""
+"A hypothesis is a statement that can be tested employing the scientific "
+"method. They must be verifiable using empirical evidence or data. For "
+"example, *green is the best color* is not a hypothesis since it cannot be"
+" proven or disproven."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:454
+msgid ""
+"Concerning the above theory of a person's pet preferences, to explore it "
+"we should find two variables to relate. The first variable would be "
+"related to a **self-identification as a cat person or dog person**. The "
+"second variable would be related to a person's **ability to solve "
+"problems and situations**."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:456
+msgid ""
+"The OKCupid dataset has useful variables that we can use to investigate "
+"this theory. For example, question **q997** (*Are you a cat person or a "
+"dog person?* ) provides information about a person's pet preferences. The"
+" second variable is slightly more difficult to come up with, as it is "
+"somewhat more complex. Fortunately, the researchers who collected the "
+"dataset have also selected 14 questions that can serve as a proxy for a "
+"cognitive ability test. This selection of questions can be found in the "
+"file :file:`test_items.csv` in the `OKCupid dataset`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:462
+msgid ""
+"So, let's try to see if there is any evidence in the OKCupid dataset to "
+"support the following hypothesis:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:464
+msgid ""
+"*People who prefer dogs to cats would score higher on tests of cognitive "
+"ability*."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:468
+msgid ""
+"SPOILER ALERT: If you are a cat person, and feel you should immediately "
+"leave this workshop, I suggest you stay. If you're not a cat person, stay"
+" too."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:474
+msgid "Build the test"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:476
+msgid ""
+"We already know which questions will be part of the cognitive ability "
+"test. Now we are going to process this data to obtain the scores for each"
+" person."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:478
+msgid "First, we make a copy of the original dataset:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:484
+msgid ""
+"Then, we find the correct answer to each test question (these answers are"
+" in ``test_items``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:493
+msgid "The correct answers have been stored in the ``test_items`` dataframe."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:495
+msgid ""
+"Next, we will indicate, in the ``ca_test`` dataframe, whether the person "
+"answered correctly to each question selected in the cognitive ability "
+"test. These answers will be entered as a boolean in new variables with "
+"the prefix \"resp\\_\" followed by the corresponding question code. The "
+"Boolean is calculated with the function ``lambda row: row[q] == a, "
+"axis=1``."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:510
+msgid ""
+"Some ``test_items`` questions are not in the data but don't worry about "
+"that. We use a ``try... except`` block to ignore these errors. Answering "
+"these questions was optional, so many OkCupid site users did not answer "
+"all of them. So we have removed from the records the users who did not "
+"answer the 14 questions we have chosen for the cognitive ability test. "
+"This reduced the sample size considerably. There are other ways to avoid "
+"this reduction, but they are outside the scope of this workshop."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:512
+msgid ""
+"We want to sum the correct answers for each person, but some integer "
+"results were stored as strings, so let's fix that:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:524
+msgid ""
+"Now that we have the correct answer for each test question, let's add up "
+"each correct answer for each person. There are 14 questions, so the "
+"maximum score will also be 14:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:531
+msgid ""
+"How do we add up these responses? Remember that each answer was stored as"
+" a boolean (True or False) with the prefix \"resp\\_\". So we search in "
+"the ``ca_test`` dataframe for the answers of each column starting with "
+"\"resp\" (we use the regular expression ``regex=\"^resp\"`` and the "
+"method ``filter``) and sum the True values of each row with "
+"``sum(axis=1)``. Then we store these results in the \"cognitive_score\" "
+"column of the ``ca_test`` dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:533
+msgid ""
+"You can see the results of these operations by typing in the IPython "
+"Console ``ca_test.cognitive_score.describe()``. If you do so, in *count* "
+"you will see that the new number of records has been reduced to 479 (the "
+"rest of the 68,371 users did not answer all of these questions)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:537
+msgid "Cognitive ability distribution"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:539
+msgid "Let's draw a histogram of this variable to see the frequency distribution."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:549
+msgid ""
+"As you can see, in this case, the distribution is not symmetrical but has"
+" a long \"tail\" on the left (negatively skewed). This means that most of"
+" the users who answered all the questions did quite well and that only a "
+"few users answered most of the questions in the wrong way."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:553
+msgid ""
+"The values we have calculated in this section were already in the data "
+"(``data.CA_items``). However, we have chosen to obtain these results "
+"again using code because it is a good way to learn how to use the tools "
+"provided by Python and Pandas for data manipulation."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:559
+msgid "Relate variables"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:561
+msgid ""
+"Remember that the hypothesis relates two variables: which pet do you "
+"prefer and cognitive ability. The measurement of pet preferences will be "
+"made from question **q997** (categorical or qualitative variable) and "
+"cognitive ability will be measured from the sum of the correct answers on"
+" the test (quantitative interval variable). With this type of variable we"
+" can make some box plots to see if there are differences between the "
+"means."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:563
+msgid ""
+"But first, let's change the standard Seaborn palette, to get prettier "
+"plots."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:573
+msgid ""
+"Seaborn allows you to choose from different styles of graphics and color "
+"palettes. More information is available at "
+"https://seaborn.pydata.org/tutorial/color_palettes.html"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:575
+msgid ""
+"Now, we are going to create box plots to observe the relationship between"
+" variables. To do this, we will use the ``catplot`` class of Seaborn. The"
+" first argument will be the x-axis, which in this case will be the "
+"qualitative variable (question **q997**). The second argument will be the"
+" y-axis, where we will place the quantitative variable (cognitive score)."
+" With the parameter ``kind`` we indicate that it is a box plot. The "
+"parameters ``height`` and ``aspect`` regulate the appearance of the "
+"graph. The last parameter, ``data``, indicates where the data comes from."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:586
+#, python-format
+msgid ""
+"Box plots or box-whisker diagrams display, near the center of the box, "
+"the **mean** of the data as a horizontal line. The lines bordering the "
+"box represent **50% of the observations** (*interquartile range* ). "
+"Outside the box, upwards and downwards, we find two whiskers: the lower "
+"one represents the **mean of the values in the lower part of the "
+"dataset**, and the upper one represents the **mean of the values in the "
+"upper part of the dataset**. The points beyond the whiskers are "
+"**outliers**."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:590
+msgid ""
+"An outlier is a value that is very different from the rest of the data "
+"values. They must be taken into account because they can often create a "
+"bias in the model we are trying to fit to the data."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:592
+msgid ""
+"The graph shows four boxes measuring cognitive ability for the following "
+"groups:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:594
+msgid "Those who prefer dogs"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:595
+msgid "Those who define themselves as cat people and dog people indistinctly."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:596
+msgid "Those who prefer cats"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:597
+msgid "Those who like neither cats nor dogs."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:599
+msgid ""
+"The lowest mean is that of those who prefer dogs only, but by very "
+"little. The box (and boundaries) representing dog lovers is also "
+"\"wider,\" implying a larger variability in the individual test results "
+"for this group. But this is not a very different dispersion from that of "
+"those who prefer cats. All the means are within the limits of the other "
+"boxes (interquartiles), which seems to indicate that, in fact, there are "
+"not really important differences in the intelligence test scores for "
+"these groups. This seems to undermine support for the initial hypothesis "
+"we posed above."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:603
+msgid ""
+"If you want to see the figures, enter ``dog_or_cat = "
+"ca_test.groupby(\"q997\")[\"cognitive_score\"].describe()`` in the "
+"IPython Console and look at the results in the Variable Explorer. This "
+"way you can see how many people prefer cats or dogs, and the means and "
+"standard deviation of the cognitive ability test results for each group."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:605
+msgid ""
+"To appreciate in context the real difference in the averages, let's "
+"create some bar charts. We are now going to use Seaborn's barplot class. "
+"On the x-axis we put again the qualitative variable (**q997**) and on the"
+" y-axis the quantitative variable (cognitive_score). The data parameter "
+"takes as argument the entire dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:620
+msgid ""
+"If the box plots indicated that the means did not show significant "
+"differences (possibly due to chance), the bar plot confirms that these "
+"differences are, in proportion, quite modest."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:626
+msgid "ANOVA test"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:628
+msgid ""
+"To make sure that the differences between the means are statistically "
+"significant, we will perform an ANOVA (analysis of variance) because we "
+"are going to compare the means of more than two groups."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:630
+msgid ""
+"How does ANOVA work? This analysis tells us whether three or more means "
+"are equal. If so, this would support the null hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:634
+msgid ""
+"The *null hypothesis* is an alternative prediction to the one we have "
+"stated in our hypothesis. The null hypothesis simply states that the "
+"observed differences in means are due to random variations that occur "
+"when samples are collected."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:636
+msgid ""
+"An ANOVA produces an *F-ratio* (also called F-statistic) that compares "
+"the amount of systematic variation in the data (variation that can be "
+"explained by the model or hypothesis) with the amount of unsystematic "
+"variance (variation that cannot be explained by our hypothesis or model)."
+" This means that F is the ratio of the model to its error. ANOVA also "
+"produces a *p-value* that indicates the probability that the variation "
+"can be attributed to the null hypothesis. The smaller the p-value, the "
+"less likely it is that the observed variation is due to chance."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:640
+msgid "Formatting the data"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:642
+msgid ""
+"To perform an ANOVA, let's start by pivoting the dataset with the "
+"cognitive ability test results. The pet preferences values will now be "
+"the column names, and each row will represent a person."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:646
+msgid ""
+"To perform an ANOVA, certain requirements or assumptions must be met. For"
+" example, the distributions of the residuals must be normal. This is not "
+"the case here. There are more appropriate statistical tests for this "
+"example, and the possibility of performing certain transformations on the"
+" data in order to apply ANOVA in this case. However, we use ANOVA because"
+" it is a fairly popular test, and because the purpose of this workshop is"
+" to serve as an introduction to scientific computing with Spyder. We do "
+"not intend here to obtain scientific results for publication."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:652
+msgid ""
+"You will see that one of the columns includes the answers to the test "
+"made by people who did not specify their preferences towards pets. Let's "
+"delete that column."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:661
+msgid ""
+"Now let's rename the column names (for simplicity) and remove the records"
+" that have missing values (with ``dropna``). The argument "
+"``inplace=True`` allows you to directly modify a dataframe without having"
+" to create a new one."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:671
+msgid ""
+"In the variable ``dog_or_cat_col_names`` we have stored the names of the "
+"values in order. This implies that: A = Both, B = Cats, C = Dogs, and D ="
+" Neither."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:673
+msgid ""
+"To perform ANOVA, we are going to use a Python library called \"stats\", "
+"in particular the ``f_oneway`` function. You can find more information "
+"about this library by typing ``stats`` in the Help Pane or learn more "
+"about the function by typing ``stats.f_oneway``."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:678
+msgid ""
+"The help notes that this function requires an array-like with the "
+"measurements for each group as an input (in our case, one sample for A, "
+"one for B, one for C, and one for D). Since we have empty cells in each "
+"column, let's remove them from each column (the ``f_oneway`` function "
+"does not support missing values)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:684
+msgid ""
+"In the above line of code we are creating a list with 4 elements: the "
+"test results of each column A, B, C, and D, without the missing values "
+"(they are removed with ``dropna()``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:688
+msgid "Run ANOVA"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:690
+msgid ""
+"Now, let's run ANOVA and store the output in two variables: ``f_value`` "
+"and ``p_value``. Notice that since ``dog_or_cat_samples`` is a list, we "
+"must pass the argument with an asterisk (``*dog_or_cat_samples``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:696
+msgid ""
+"With the help of ``stats.f_oneway`` in the Help Pane you can read a "
+"description of the output of this function, some interesting notes about "
+"the test, and some references that you can use to better understand the "
+"nature of this analysis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:700
+msgid ""
+"In the Help pane you will read that ANOVA requires certain assumptions to"
+" be satisfied. In this workshop we have not checked those assumptions "
+"because our goal is merely to show some Spyder functions that make the "
+"research work easier. Thus, the results obtained in this example with "
+"ANOVA should not be taken too rigorously."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:702
+msgid ""
+"In the Variable Explorer you can find these two new variables: "
+"``f_value`` and ``p_value``. ``p_value`` (0.6275) is well over 0.05, "
+"which gives support to the null hypothesis (detracting support from our "
+"hypothesis). To know if the F value obtained is greater than the "
+"theoretically expected value, a **F critical value** must be calculated. "
+"This can be estimated using the ``stats`` library, a significance level "
+"(*q* ), and the degrees of freedom (*df* ) for the number of groups and "
+"the number of observations:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:713
+msgid ""
+"The value of ``f_critical`` (2.6241) is larger than that of ``f_value`` "
+"(0.5813). This means that the variance between the means of these groups "
+"is not significantly different. Since the *p* value indicates that we "
+"cannot rule out random variations, then we have to discard our "
+"hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:715
+msgid ""
+"What is the conclusion of all this? There seems to be little or no "
+"evidence in our data to think that there is indeed a correlation between "
+"a person's pet preferences and his or her ability to solve practical or "
+"abstract problems. Cat and dog owners, rejoice!"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:721
+msgid "Report and share"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:723
+msgid ""
+"In science, sharing results, good and bad, is critical. Today, in "
+"scientific computing, it is also crucial to share data, and the code used"
+" to process and analyze it. To help with this, we will use Spyder's Code "
+"Analysis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:727
+msgid "Code Analysis"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:729
+msgid ""
+"When you share code, you want it to be readable, clean, and not overly "
+"complex. The Code Analysis component can help us detect these issues and "
+"even bugs that can affect the performance of our code."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:731
+msgid ""
+"To see an example, you can open the :download:`scientific-computing-"
+"astro.py <scientific-computing-astro.py>` file and run the "
+":guilabel:`Code Analysis` (open the file in the pane and click on the "
+"green triangular button in the upper right corner)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:736
+msgid "You can see four categories that can help you improve your code:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:738
+msgid "Convention: programming standard violations"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:739
+msgid "Refactor: refactoring related checks"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:740
+msgid "Warning: Python-specific problems"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:741
+msgid "Error: probable bugs in the code"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:743
+msgid ""
+"Each of these categories indicates the type of alert and the line on "
+"which the potential issue occurs. For example, it tells us that line 129 "
+"is too long, or that we imported numpy but did not use it at all in the "
+"code."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:745
+msgid ""
+"These suggestions can contribute to sharing clean code. We recommend "
+"using this panel to polish your code before publishing it."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:753
+msgid ""
+"In this workshop we have taken the first steps to use Spyder for "
+"scientific computing. We have seen how from a question or doubt a "
+"hypothesis is raised. This question can also emerge from the exploration "
+"of some data, which can be done by calculating some measures (such as "
+"mean, median, standard deviation) or by drawing some plots."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:755
+msgid ""
+"Often, in order to answer the question, we must process some data (for "
+"example, for the construction of a cognitive ability test)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:757
+msgid ""
+"Finally, we try to establish a relationship between variables with some "
+"statistical tests. The results of these tests will support or not our "
+"initial hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:762
+msgid "Write and test code with the IPython Console and Editor."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:763
+msgid "Download a dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:765
+msgid "Graphically explore a dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:767
+msgid "Explore data and relate it to a hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:769
+msgid "Perform a statistical test with a specialized library on the data."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:770
+msgid "Improve code readability with Code Analysis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:772
+msgid ""
+"Spyder has many features that can help you do data analysis. You can find"
+" more information in our `official documentation <https://docs.spyder-"
+"ide.org/5/index.html>`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:782
+msgid ""
+"If you want to check what you have learned, we suggest you analyze the "
+"data to try to answer the following question: *Do the different zodiac "
+"signs influence the results of a cognitive ability test?,* you can check "
+"the Python script :download:`scientific-computing-astro.py <scientific-"
+"computing-astro.py>` if you have any doubts."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:790
+msgid ""
+"For a description of the dataset used, see the following `paper "
+"<https://openpsych.net/paper/46/>`__:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:792
+msgid ""
+"Kirkegaard, E. O. W., & Bjerrekær, J. D. (2016). *The OKCupid dataset: A "
+"very large public dataset of dating site users*. Open Differential "
+"Psychology. doi:10.26775/odp.2016.11.03*"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:794
+msgid "A very fun book for learning statistics with R is the following:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:796
+msgid ""
+"Field, A., Miles, J., & Field, Z. (2012). *Discovering statistics using "
+"R*. SAGE Publications."
+msgstr ""
+

--- a/doc/locales/es/LC_MESSAGES/faq.po
+++ b/doc/locales/es/LC_MESSAGES/faq.po
@@ -1,0 +1,299 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: spyder-documentation\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: 2024-09-10 00:48\n"
+"Last-Translator: \n"
+"Language: es\n"
+"Language-Team: Spanish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+"X-Crowdin-Project: spyder-documentation\n"
+"X-Crowdin-Project-ID: 641502\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /doc/locales/en/LC_MESSAGES/faq.po\n"
+"X-Crowdin-File-ID: 16\n"
+
+#: ../../faq.rst:3
+msgid "Frequently Asked Questions"
+msgstr "Preguntas frecuentes (FAQ)"
+
+#: ../../faq.rst:7
+msgid "Installing and updating"
+msgstr "Instalar y actualizar"
+
+#: ../../faq.rst:12
+msgid "The easiest way to install Spyder is with the Anaconda Python distribution, which comes with everything you need to get started in an all-in-one package. Download it from its `webpage`_."
+msgstr "La forma más fácil de instalar Spyder es con la distribución de Anaconda Python, que viene con todo lo que necesitas para empezar con un paquete todo en uno. Descárgalo de su `página web`_."
+
+#: ../../faq.rst:17
+msgid "For more information, visit our :doc:`/installation`."
+msgstr "Para más información, visita nuestro :doc:`/installation`."
+
+#: ../../faq.rst:23
+msgid "If you already installed Spyder on your Windows machine, you do not need to reinstall it on a WSL2-based Linux environment if your code must run there."
+msgstr "Si ya has instalado Spyder en tu equipo Windows, no necesitas reinstalarlo en un entorno Linux basado en WSL2 si el código debe ejecutarse allí."
+
+#: ../../faq.rst:25
+msgid "Instead, just install `Miniconda`_ inside WSL2 and create a new conda environment (or use an existing conda- or virtualenv), then install Spyder-Kernels into that environment with e.g. ``conda install spyder-kernels``. You must manually install ``ipython_genutils`` with e.g. ``conda install ipython_genutils``."
+msgstr "En su lugar, simplemente instala `Miniconda`_ dentro de WSL2 y crea un nuevo entorno conda o también puedes usar un conda o virtualenv existente. Luego instala Spyder-Kernels en ese entorno con, por ejemplo, ``conda install spyder-kernels``. Debes instalar manualmente ``ipython_genutils`` con, por ejemplo, ``conda install ipython_genutils``."
+
+#: ../../faq.rst:30
+msgid "Windows creates a network path located at ``\\\\wsl$`` that points to the partitions of your WSL2 machines, e.g. ``\\\\wsl$\\Ubuntu-20.04``. You **must** map a network drive letter to your machine path, e.g. ``W:``, for Spyder to correctly see its files and folders."
+msgstr "Windows crea una ruta de red ubicada en ``\\\\wsl$`` que apunta a las particiones de sus máquinas WSL2, por ejemplo, ``\\\\wsl$\\Ubuntu-20. 4``. **Debes** mapear una letra de unidad de red a la ruta de su máquina, por ejemplo ``W:``, para que Spyder vea correctamente sus archivos y carpetas."
+
+#: ../../faq.rst:33
+msgid "To start a Spyder kernel, from your Linux terminal run"
+msgstr "Para iniciar un kernel de Spyder, desde tu terminal Linux ejecuta"
+
+#: ../../faq.rst:39
+msgid "It will run the kernel as a subprocess and create a file named :file:`remotemachine.json` in your WSL home folder."
+msgstr "Esto ejecutará el kernel como un subproceso y creará un archivo llamado :file:`remotemachine.json` en su carpeta de inicio WSL."
+
+#: ../../faq.rst:41
+msgid "Finally, under the options menu of Spyder's :doc:`panes/ipythonconsole`, select :guilabel:`Connect to an existing kernel` as described in :ref:`connecting-external-kernel`. Insert the absolute path of :file:`remotemachine.json` into the :guilabel:`Connection file` field. If you mapped ``W:`` as mentioned in above note, the path should be :file:`W:/home/{username}/remotemachine.json`. A new console will open in Spyder, running in the Linux environment. Try running ``os.system('ls -la')`` and see if it lists your WSL home folder. If you run ``exit()`` from Spyder, the kernel running on Linux will be stopped."
+msgstr "Finalmente, bajo el menú de opciones de Spyder :doc:`panes/ipythonconsole`, selecciona :guilabel:`Conectarse a un núcleo existente` como se describe en :ref:`connecting-external-kernel`. Inserta la ruta absoluta de :file:`remotemachine.json` en el campo de :guilabel:`Archivo de conexión`. Si has mapeado ``W:``, como se menciona en la nota anterior, la ruta debería ser :file:`W:/home/{username}/remotemachine.json`. Una nueva consola se abrirá en Spyder, corriendo en el entorno Linux. Intenta ejecutar ``os.system('ls -la')`` y observa si se lista tu carpeta de inicio WSL. Si ejecutas ``exit()`` desde Spyder, se detendrá el núcleo corriendo en Linux."
+
+#: ../../faq.rst:52
+msgid "From the command line (or Anaconda prompt on Windows), run:"
+msgstr "Desde la línea de comandos (o el prompt de Anaconda en Windows), ejecuta:"
+
+#: ../../faq.rst:59
+msgid "If this results in an error or does not update Spyder to the latest version, try:"
+msgstr "Si esto da como resultado un error o no actualiza Spyder a la última versión, intenta:"
+
+#: ../../faq.rst:69
+msgid "Open the \"gear\" menu in Spyder's section under :guilabel:`Home` in Navigator. Go to :guilabel:`Install specific version` and select the version of Spyder you want to use. We strongly recommend the latest available, to benefit from new features, bug fixes, performance improvements and usability enhancements."
+msgstr "Abre el menú \"engranaje\" en la sección de Spyder bajo :guilabel:`Home` en Navigator. Ve a :guilabel:`Install specific version` y selecciona la versión de Spyder que quieres usar. Recomendamos encarecidamente que uses las últimas disponibles, para beneficiarte de nuevas características, correcciones de errores, mejoras de rendimiento y de usabilidad."
+
+#: ../../faq.rst:80
+msgid "Running Spyder"
+msgstr "Lanzar Spyder"
+
+#: ../../faq.rst:85
+msgid "You can launch it in any of the following ways:"
+msgstr "Puedes lanzarlo de cualquiera de las siguientes formas:"
+
+#: ../../faq.rst:87
+msgid "**From the command line**: Type ``spyder`` in your terminal (or Anaconda prompt on Windows)."
+msgstr "**Desde la línea de comandos**: Escribe ``spyder`` en tu terminal (o en el Anaconda prompt en Windows)."
+
+#: ../../faq.rst:89
+msgid "**From Anaconda Navigator**: Scroll to :guilabel:`Spyder` under :guilabel:`Home`, and click :guilabel:`Launch`."
+msgstr "**Desde Anaconda Navigator**: desplázete hasta :guilabel:`Spyder` en :guilabel:`Home`, y haz clic en :guilabel:`Launch`."
+
+#: ../../faq.rst:94
+msgid "***Windows Only***: Launch it via the Start menu shortcut."
+msgstr "***Solo para Windows***: Lánzalo a través del acceso directo al menú Inicio."
+
+#: ../../faq.rst:103
+msgid "Yes! With `Binder`_, you can work with a fully functional copy of Spyder that runs right in your web browser. Try it `here`_."
+msgstr "¡Sí! Con `Binder`_ puedes trabajar con una copia totalmente funcional de Spyder que se ejecuta en tu navegador web. Pruébalo `aquí`_."
+
+#: ../../faq.rst:114
+msgid "Spyder works on modern versions of Windows, macOS and Linux (see the table below for recommended versions) via Anaconda, as well as other methods. It typically uses relatively minimal CPU when idle, and 0.5 GB - 1 GB of RAM, depending on how long you've been using it and how many files, projects, panes and consoles you have open. It should work on any system with a dual-core or better x64 processor and at least 4 GB of RAM, although 8 GB is *strongly* recommended for best performance when running other applications. However, the code you run, such as scientific computation and deep learning models, may require additional resources beyond this baseline for Spyder itself."
+msgstr "Spyder funciona con versiones modernas de Windows, macOS y Linux (ver la tabla de abajo para ver las versiones recomendadas) mediante Anaconda, así como con otros métodos. Normalmente usa una CPU relativamente mínima cuando está inactiva, y 0.5 GB - 1 GB de RAM, dependiendo del tiempo que lo has estado usando y cuántos archivos, proyectos, paneles y consolas que has abierto. Debería funcionar en cualquier sistema con un procesador de núcleo dual o mejor con x64, y al menos 4 GB de RAM, aunque 8 GB es *altamente* recomendado para un mejor rendimiento al ejecutar otras aplicaciones. Sin embargo, el código que ejecutas, como la computación científica y los modelos de aprendizaje profundo, puede requerir recursos adicionales más allá de esta línea base para Spyder mismo."
+
+#: ../../faq.rst:122
+msgid "Operating system"
+msgstr "Sistema operativo"
+
+#: ../../faq.rst:122
+msgid "Version"
+msgstr "Versión"
+
+#: ../../faq.rst:124
+msgid "Windows"
+msgstr "Windows"
+
+#: ../../faq.rst:124
+msgid "Windows 8.1"
+msgstr "Windows 8.1"
+
+#: ../../faq.rst:125
+msgid "macOS"
+msgstr "macOS"
+
+#: ../../faq.rst:125
+msgid "High Sierra (10.13)"
+msgstr "High Sierra (10.13)"
+
+#: ../../faq.rst:126
+msgid "Linux"
+msgstr "Linux"
+
+#: ../../faq.rst:126
+msgid "Ubuntu 16.04"
+msgstr "Ubuntu 16.04"
+
+#: ../../faq.rst:133
+msgid "Select the environment you want to launch Spyder from under :guilabel:`Applications on`. If Spyder is installed in this environment, you will see it in Navigator's :guilabel:`Home` window. Click :guilabel:`Launch` to start Spyder in your selected environment."
+msgstr "Selecciona el entorno en el que quieres lanzar Spyder desde :guilabel:`Applications on. Si Spyder está instalado en este entorno, lo verás en la ventana :guilabel:`Home` del Navigator. Haz clic en :guilabel:`Launch` para iniciar Spyder en el entorno seleccionado."
+
+#: ../../faq.rst:144
+msgid "Activate your conda environment by typing the following in your terminal (or Anaconda Prompt on Windows):"
+msgstr "Activa tu entorno conda escribiendo lo siguiente en tu terminal (o en el Anaconda Prompt en Windows):"
+
+#: ../../faq.rst:150
+msgid "Then, type ``spyder`` to launch the version installed in that environment."
+msgstr "Luego, escribe ``spyder`` para lanzar la versión instalada en ese entorno."
+
+#: ../../faq.rst:158
+msgid "Using Spyder"
+msgstr "Usar Spyder"
+
+#: ../../faq.rst:163
+msgid "The first approach for installing a package should be using conda. In your system terminal (or Anaconda Prompt on Windows), type:"
+msgstr "El primer método para instalar un paquete debería ser usar conda. En tu terminal del sistema (o en el Anaconda Prompt en Windows), escribe:"
+
+#: ../../faq.rst:170
+msgid "If your installation is not successful, follow steps 3 through 5 of Part 2 in our video on solving and avoiding problems with pip, Conda and Conda-Forge."
+msgstr "Si la instalación no se ha realizado correctamente, sigue los pasos 3 a 5 de la Parte 2 en nuestro vídeo sobre la resolución y prevención de problemas con pip, Conda y Conda-Forge."
+
+#: ../../faq.rst:184
+msgid "To work with an existing environment in Spyder, change the default Python interpreter for new :doc:`/panes/ipythonconsole`\\s to point to this environment."
+msgstr "Para trabajar con un entorno existente en Spyder, cambia el intérprete predeterminado de Python para las nuevas :doc:`/panes/ipythonconsole` para que apunten a este entorno."
+
+#: ../../faq.rst:186
+msgid "To do so, open the :guilabel:`Python interpreter` section of Spyder's preferences (:menuselection:`Tools --> Preferences`, or :menuselection:`Spyder --> Preferences` on macOS). Here, select the option :guilabel:`Use the following Python interpreter`, and use the dropdown below to select your preferred environment. If it's not listed, see :ref:`the note below <faq-env-not-listed>`."
+msgstr "Para hacerlo, abre la sección :guilabel:`intérprete de Python` de las preferencias de Spyder (:menuselection:`Herramientas --> Preferencias`, o :menuselection:`Spyder --> Preferences` en macOS). Aquí, selecciona la opción :guilabel:`Usar el siguiente intérprete`, y utiliza el menú desplegable de abajo para seleccionar tu entorno preferido. Si no está listado, consulta :ref:`la nota debajo de <faq-env-not-listed>`."
+
+#: ../../faq.rst:197
+msgid "If you installed Miniconda (or another Conda-based distribution) to a non-default path, or are using a virtual environment managed by a tool other than ``pyenv``, your environments likely won't be listed."
+msgstr "Si instalaste Miniconda (u otra distribución basada en Conda) en una ruta no predeterminada, o estás usando un entorno virtual administrado por una herramienta que no sea ``pyenv``, es probable que los entornos no aparezcan en la lista."
+
+#: ../../faq.rst:199
+msgid "Instead, use the text box or the :guilabel:`Select file` button to enter the path to the Python interpreter you want to use. You can find this path by activating the venv or Conda env you want to use in your terminal (Anaconda Prompt on Windows), and running the command:"
+msgstr "En su lugar, utiliza el cuadro de texto o el botón :guilabel:`Seleccionar archivo` para ingresar la ruta al intérprete de Python que deseas utilizar. Puedes encontrar esta ruta activando el env o la env de Conda que deseas usar en tu terminal (Anaconda Prompt en Windows), y ejecutando el comando:"
+
+#: ../../faq.rst:206
+msgid "Finally, click :guilabel:`Restart kernel` in the :guilabel:`Consoles` menu for this change to take effect. If ``spyder-kernels`` is not already installed, the :doc:`/panes/ipythonconsole` will display instructions on how to install the right version. Execute the given command in your terminal (the Anaconda Prompt on Windows) with the environment activated, and finally restart the kernel once more."
+msgstr "Finalmente, haz clic en :guilabel:`Reiniciar el núcleo` en el menú :guilabel:`Consolas` para que este cambio surta efecto. Si ``spyder-kernels`` no está instalado, el :doc:`/panes/ipythonconsole` te mostrará instrucciones sobre cómo instalar la versión correcta. Ejecuta el comando dado en tu terminal (Anaconda Prompt en Windows) con el entorno activado, y finalmente reinicia el núcleo una vez más."
+
+#: ../../faq.rst:216
+msgid "Watch our video on using additional packages or follow the instructions below."
+msgstr "Ve nuestro vídeo sobre el uso de paquetes adicionales o sigue las instrucciones que aparecen a continuación."
+
+#: ../../faq.rst:224
+msgid "If you want to use other packages in Spyder that don't come with our installer, you need to have your own Python distribution installed; we recommend `Miniconda`_ or another Conda-based option. For Spyder to recognize it automatically, you should use a Conda-based distribution with its default install path."
+msgstr "Si quieres usar otros paquetes en Spyder que no vienen con nuestro instalador, necesitas tener tu propia distribución de Python instalada; recomendamos `Miniconda`_ u otra opción basada en Conda. Para que Spyder lo reconozca automáticamente, debes utilizar una distribución basada en Conda con su ruta de instalación predeterminada."
+
+#: ../../faq.rst:229
+msgid "Create a new conda environment containing ``spyder-kernels`` and the packages that you want to use. For example, if you want to use ``scikit-learn``, open your terminal (or Anaconda prompt on Windows) and run the following command:"
+msgstr "Crea un nuevo entorno conda que contenga ``spyder-kernels`` y los paquetes que quieres usar. Por ejemplo, si deseas usar ``scikit-learn``, abre tu terminal (o Anaconda Prompt en Windows) y ejecuta el siguiente comando:"
+
+#: ../../faq.rst:236
+msgid "Finally, connect Spyder to this ``my-env`` environment by changing Spyder's default Python interpreter, following the instructions in :ref:`the above answer <using-existing-environment>`."
+msgstr "Finalmente, conecta Spyder al entorno ``my-env`` cambiando el intérprete predeterminado de Python de Spyder, siguiendo las instrucciones en :ref:`la respuesta anterior <using-existing-environment>`."
+
+#: ../../faq.rst:242
+msgid "Either use the :guilabel:`Reset Spyder to factory defaults` under :guilabel:`Tools` in Spyder's menu bar, the :guilabel:`Reset Spyder settings` Start menu shortcut (Windows), or run ``spyder --reset`` in your system terminal (Anaconda prompt on Windows)."
+msgstr "Puedes usar el :guilabel:`Restablecer Spyder a su configuración por defecto` bajo :guilabel:`Herramientas` en la barra de menú de Spyder; el acceso directo del menú de inicio :guilabel:`Reset Spyder settings` (Windows), o ejecuta ``spyder --reset`` en tu terminal del sistema (Anaconda Prompt en Windows)."
+
+#: ../../faq.rst:251
+msgid "Under :guilabel:`General` in Spyder's :guilabel:`Preferences`, go to the :guilabel:`Advanced settings` tab and select your language from the options displayed under :guilabel:`Language`."
+msgstr "En :guilabel:`Aplicación` en las :guilabel:`Preferencias` de Spyder, ve a la pestaña :guilabel:`Opciones avanzadas` y selecciona tu idioma de las opciones que se muestran en :guilabel:`Lenguaje`."
+
+#: ../../faq.rst:260
+#, python-format
+msgid "To create a cell in Spyder's :doc:`/panes/editor`, type ``#%%`` in your script. Each ``#%%`` will make a new cell. To run a cell, press :kbd:`Shift-Enter` (while your cursor is focused on it) or use the :guilabel:`Run current cell` button in Spyder's toolbar."
+msgstr "Para crear una celda en el :doc:`/panes/editor` de Spyder, escribe ``#%%`` en tu script. Cada ``#%%`` hará una nueva celda. Para ejecutar una celda, presiona :kbd:`Shift-Enter` (mientras tu cursor está centrado en la celda) o usa el botón :guilabel:`Ejecutar la celda actual` en la barra de herramientas de Spyder."
+
+#: ../../faq.rst:271
+msgid "Spyder plugins are available in the ``conda-forge`` conda channel. To install one, type on the command line (or Anaconda Prompt on Windows):"
+msgstr "Los plugins de Spyder están disponibles en el canal conda ``conda-forge``. Para instalar uno, escribe en la línea de comandos (o en el Anaconda Prompt en Windows):"
+
+#: ../../faq.rst:278
+msgid "Replace ``<PLUGIN>`` with the name of the plugin you want to use. For more information on a specific plugin, go to the its repository:"
+msgstr "Reemplaza ``<PLUGIN>`` con el nombre del plugin que quieres usar. Para más información sobre un plugin específico, ve a su repositorio:"
+
+#: ../../faq.rst:281
+msgid "`spyder-unittest`_"
+msgstr "`spyder-unittest`_"
+
+#: ../../faq.rst:282
+msgid "`spyder-terminal`_"
+msgstr "`spyder-terminal`_"
+
+#: ../../faq.rst:283
+msgid "`spyder-notebook`_"
+msgstr "`spyder-notebook`_"
+
+#: ../../faq.rst:284
+msgid "`spyder-memory-profiler`_"
+msgstr "`spyder-memory-profiler`_"
+
+#: ../../faq.rst:285
+msgid "`spyder-line-profiler`_"
+msgstr "`spyder-line-profiler`_"
+
+#: ../../faq.rst:297
+msgid "Check the option :guilabel:`Remove all variables before execution` in the :guilabel:`Configuration per file...` dialog under the :guilabel:`Run` menu."
+msgstr "Revisa la opción :guilabel:`Eliminar todas las variables antes de la ejecución` en el diálogo :guilabel:`Configuración por archivo...` bajo el menú :guilabel:`Ejecutar`."
+
+#: ../../faq.rst:306
+msgid "Select the appropriate option in the :guilabel:`Configuration per file...` dialog under the :guilabel:`Run` menu."
+msgstr "Seleccione la opción apropiada en el diálogo :guilabel:`Configuración por archivo...` bajo el menú :guilabel:`Ejecutar`."
+
+#: ../../faq.rst:315
+msgid "Go to :guilabel:`Preferences` and select the theme you want under :guilabel:`Syntax highlighting theme` in the :guilabel:`Appearance` section."
+msgstr "Ve a :guilabel:`Preferencias` y selecciona el tema que quieras bajo el tema :guilabel:`Tema de coloreado de sintaxis` en la sección :guilabel:`Apariencia`."
+
+#: ../../faq.rst:324
+msgid "Troubleshooting"
+msgstr "Solución de problemas"
+
+#: ../../faq.rst:329
+msgid "You should first follow the steps in our :doc:`troubleshooting guide</troubleshooting/first-steps>`. If you can't solve your problem, open an issue by following the instructions in our :doc:`/troubleshooting/submit-a-report` section."
+msgstr "Primero debes seguir los pasos en nuestra guía :doc:`solución de problemas</troubleshooting/first-steps>`. Si no puedes resolver tu problema, abre un \"issue\" siguiendo las instrucciones de nuestra sección :doc:`/troubleshooting/submit-a-report`."
+
+#: ../../faq.rst:336
+msgid "First, make sure the error you are seeing is not a bug in your code. To confirm this, try running it in any standard Python interpreter. If the error still occurs, the problem is likely with your code and a site like `Stack Overflow`_ might be the best place to start. Otherwise, start at the :doc:`/troubleshooting/basic-first-aid` section of our troubleshooting guide."
+msgstr "Primero, asegúrate de que el error que estás viendo no es un error en tu código. Para confirmar esto, intenta ejecutarlo en cualquier intérprete estándar de Python. Si el error persiste, es probable que el problema esté en el código y un sitio como `Stack Overflow`_ podría ser el mejor lugar para empezar. De lo contrario, empieza por la sección :doc:`/troubleshooting/basic-first-aid` de nuestra guía de solución de problemas."
+
+#: ../../faq.rst:347
+msgid "If nothing is displayed in the calltip, hover hint or :doc:`/panes/help` pane, make sure the object you are inspecting has a docstring, and try executing your code in the :doc:`/panes/ipythonconsole` to get help and completions there. If this doesn't work, try restarting PyLS by right-clicking the :guilabel:`LSP Python` label item in the statusbar at the bottom of Spyder's main window, and selecting the :guilabel:`Restart Python Language Server` option."
+msgstr "Si no se muestra nada en el calltip, pase el cursor o usa el panel :doc:`/panes/help`, asegúrate de que el objeto que estás inspeccionando tiene un docstring, y prueba a ejecutar tu código en el :doc:`/panes/ipythonconsole` para obtener ayuda y completar el código allí. Si esto no funciona, prueba a reiniciar PyLS haciendo clic derecho en la etiqueta :guilabel:`LSP Python` en la barra de estado en la parte inferior de la ventana principal de Spyder, y seleccionando la opción :guilabel:`Reiniciar el Servidor de lenguaje de Python`."
+
+#: ../../faq.rst:350
+msgid "For more information, go to the :ref:`code-completion-problems-ref` section in the :doc:`/troubleshooting/common-illnesses` page of our troubleshooting guide."
+msgstr "Para obtener más información, ve a la sección :ref:`code-completion-problems-ref` en la página :doc:`/troubleshooting/common-illnesses` de nuestra solución de problemas."
+
+#: ../../faq.rst:356
+msgid "First, make sure your version of Spyder-Kernels is compatible with that of Spyder. See the table in the :ref:`spyder-kernels-version-ref` section of the troubleshooting guide to check."
+msgstr "Primero, asegúrate de que tu versión de Spyder-Kernels es compatible con la de Spyder. Revisa la tabla en la sección :ref:`spyder-kernels-version-ref` de la guía de solución de problemas para comprobar."
+
+#: ../../faq.rst:359
+msgid "To install the right version, type the following on the command line (or Anaconda Prompt on Windows)"
+msgstr "Para instalar la versión correcta, escribe lo siguiente en la línea de comandos (o Anaconda Prompt en Windows)"
+
+#: ../../faq.rst:365
+msgid "For more information, go to the :ref:`starting-kernel-problems-ref` section in the :doc:`/troubleshooting/common-illnesses` page of our troubleshooting guide."
+msgstr "Para obtener más información, ve a la sección :ref:`starting-kernel-problems-ref` en la página :doc:`/troubleshooting/common-illnesses` de nuestra solución de problemas."
+
+#: ../../faq.rst:371
+msgid "Spyder is in the final stages of being updated for full compatibility with macOS 11 Big Sur, which will be released by the end of 2020 as part of version 4.2.1. However, you can get it working right now with the workaround below. Make sure you have the Anaconda or Miniconda distribution installed, and run the following commands in the Terminal to install Spyder from Conda-Forge in a clean environment:"
+msgstr "Spyder está en las etapas finales de ser actualizado para total compatibilidad con macOS 11 Big Sur, que se publicará a finales de 2020 como parte de la versión 4.2.1. Sin embargo, puedes ponerlo en marcha ahora mismo con la solución a continuación. Asegúrate de tener la distribución Anaconda o Miniconda instalada, y ejecutar los siguientes comandos en la Terminal para instalar Spyder desde Conda-Forge en un entorno limpio:"
+
+#: ../../faq.rst:381
+msgid "Then, whenever you want to start Spyder, run the following from the Terminal:"
+msgstr "Entonces, cada vez que quieras iniciar Spyder, ejecuta lo siguiente desde la Terminal:"
+
+#: ../../faq.rst:393
+msgid "About Spyder"
+msgstr "Acerca de Spyder"
+
+#: ../../faq.rst:398
+#, python-format
+msgid "Spyder is 100% free and open source; there is no paid version or prohibition on commercial use. It is developed by its international user community, and supported by its users through `OpenCollective`_ and by its generous sponsoring organizations, including `Quansight`_ and `NumFOCUS`_. Our source code, standalone installers and most of our distribution methods (Pip/PyPI, Linux distros, MacPorts, WinPython, etc) can be freely redistributed, used and modified by anyone, for any purpose, including commercial use. For more details about the situation with Anaconda, see `that question`_."
+msgstr "Spyder es 100% gratuito y de código abierto; no hay ninguna versión de pago ni prohibición sobre el uso comercial. Es desarrollado por su comunidad internacional de usuarios, y soportado por sus usuarios a través de `OpenCollective`_ y por sus generosas organizaciones patrocinadoras, incluyendo `Quansight`_ y `NumFOCUS`_. Nuestro código fuente, instaladores independientes y la mayoría de nuestros métodos de distribución (Pip/PyPI, distribuciones Linux, MacPorts, WinPython, etc) pueden ser libremente redistribuidos, utilizados y modificados por cualquier persona, para cualquier propósito, incluyendo uso comercial. Para más detalles sobre la situación con Anaconda, vea `esa pregunta`_."
+
+#: ../../faq.rst:412
+#, python-format
+msgid "If you use Spyder with the Anaconda distribution, they `recently changed`_ their `Terms of Service`_ to add restrictions on large (> 200 employee) for-profit companies using Anaconda on a large scale. However, these terms only apply to the package infrastructure (the full Anaconda distribution and the ``defaults`` conda channel). Instead, you can simply download the similar `Miniforge distribution`_, which is 100% open source and identical to full Anaconda (aside from not bundling the Python packages installed by default in the Anaconda ``base`` environment, which we recommend you avoid using anyway given any problems here can break your whole installation). Then, simply install the packages you need (including Spyder, if you aren't using our recommended :ref:`install-standalone`) with ``conda`` as you usually do. Miniforge will automatically use the community-maintained Conda-Forge repository, which has a much wider variety of packages and is generally more up to date than the Anaconda equivalent, in addition to being free of any commercial restrictions. For more, see our :doc:`/installation`."
+msgstr "Si usas Spyder con la distribución Anaconda, ellos recientemente cambiaron (`recently changed`_) sus términos de servicio (`Terms of Service`_) para añadir restricciones a grandes empresas (> 200 empleados) con fines de lucro que utilizan Anaconda a gran escala. Sin embargo, estos términos solo aplican a la infraestructura de paquetes (la distribución completa de Anaconda y el canal conda ``defaults``). En su lugar, puedes descargar la distribución Miniforge (`Miniforge distribution`_) que es 100% de código abierto e idéntica a Anaconda (aparte de no incluir los paquetes de Python instalados por defecto en el entorno ``base`` de Anaconda, que recomendamos que evites usar de todos modos dado que cualquier problema puede romper tu instalación). Luego, simplemente instala los paquetes que necesitas (incluyendo Spyder, si no estás usando nuestro :ref:`install-standalone` recomendado) con ``conda`` como lo haces normalmente. Miniforge utilizará automáticamente el repositorio Conda-Forge mantenido por la comunidad, que tiene una variedad de paquetes mucho más amplia y generalmente está más actualizada que el equivalente de Anaconda, además de estar libre de cualquier restricción comercial. Para más información, visita nuestra :doc:`/installation`."
+

--- a/doc/locales/es/LC_MESSAGES/index.po
+++ b/doc/locales/es/LC_MESSAGES/index.po
@@ -1,0 +1,112 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: spyder-documentation\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: 2024-09-10 00:48\n"
+"Last-Translator: \n"
+"Language: es\n"
+"Language-Team: Spanish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+"X-Crowdin-Project: spyder-documentation\n"
+"X-Crowdin-Project-ID: 641502\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /doc/locales/en/LC_MESSAGES/index.po\n"
+"X-Crowdin-File-ID: 10\n"
+
+#: ../../index.rst:137
+msgid "Welcome"
+msgstr "Bienvenidos"
+
+#: ../../index.rst:137
+msgid "FAQ"
+msgstr ""
+
+#: ../../index.rst:3
+msgid "Welcome to Spyder's Documentation"
+msgstr ""
+
+#: ../../index.rst:9
+msgid "Spyder is a powerful scientific environment written in Python, for Python, and designed by and for scientists, engineers and data analysts. It features a unique combination of the advanced editing, analysis, debugging, and profiling functionality of a comprehensive development tool with the data exploration, interactive execution, deep inspection, and beautiful visualization capabilities of a scientific package."
+msgstr ""
+
+#: ../../index.rst:18
+msgid "Where to go now?"
+msgstr ""
+
+#: ../../index.rst:20
+msgid "Spyder's documentation provides a variety of resources that will help you learn how to use the application and explore each one of its panes. These include video tutorials, in-depth descriptions and how-to guides covering a wide range of needs and experience levels with Spyder."
+msgstr ""
+
+#: ../../index.rst:33
+msgid "If you are looking for a summary of its features and interface, check out the :doc:`quickstart`."
+msgstr ""
+
+#: ../../index.rst:41
+msgid "If you don't have Spyder installed and want to get started, follow the :doc:`/installation`."
+msgstr ""
+
+#: ../../index.rst:49
+msgid "If you are completely new to Spyder, watch our basic tutorial series, :doc:`videos/first-steps-with-spyder`."
+msgstr ""
+
+#: ../../index.rst:57
+msgid "If you are familiar with Spyder and want to explore the functionality of its panes in more detail, go to :doc:`panes/index`."
+msgstr ""
+
+#: ../../index.rst:65
+msgid "If you've run into a Spyder problem and need help solving it, take a look at our :doc:`troubleshooting guide<troubleshooting/first-steps>`."
+msgstr ""
+
+#: ../../index.rst:73
+msgid "If you have a question about Spyder, visit the :doc:`faq` section."
+msgstr ""
+
+#: ../../index.rst:81
+msgid "Join our community"
+msgstr ""
+
+#: ../../index.rst:83
+msgid "Spyder is open source software, which means that is free for everyone to use and anyone can contribute to it. We encourage everyone to become a part of our community and help develop Spyder!"
+msgstr ""
+
+#: ../../index.rst:90
+msgid "Looking to contribute your code?"
+msgstr ""
+
+#: ../../index.rst:92
+msgid "Spyder is written in the same Python language that you use it to develop, so its easy to get started contributing to it. You can follow our `contributing guide`_ to set up a development environment, and you can get involved with the project through our `Github repository`_. The easiest way to get started is helping us resolve items on our `issue tracker`_, either by fixing bugs in Spyder, or helping users troubleshoot their problems (which doesn't require writing any code)."
+msgstr ""
+
+#: ../../index.rst:106
+msgid "Want to help writing docs?"
+msgstr ""
+
+#: ../../index.rst:108
+msgid "We welcome your contributions of corrections, additions and enhancements to these docs. Check out the `docs contributing guide`_ to learn how to submit a PR with your changes on our `docs repo`_."
+msgstr ""
+
+#: ../../index.rst:119
+msgid "Interested in translating Spyder?"
+msgstr ""
+
+#: ../../index.rst:121
+msgid "In order to reach more users around the world in need of a powerful scientific Python environment, we welcome your help translating the documentation and the interface into different languages."
+msgstr ""
+
+#: ../../index.rst:123
+msgid "For this purpose we use `Crowdin`_, which provides a simple web based interface for translators, proofreaders and managers, so everyone can help us translate Spyder into any language."
+msgstr ""
+
+#: ../../index.rst:131
+msgid "Want to be part of our social media?"
+msgstr ""
+
+#: ../../index.rst:133
+msgid "Connect with Spyder through our social media channels to stay up to date with our current developments!"
+msgstr ""
+

--- a/doc/locales/es/LC_MESSAGES/installation.po
+++ b/doc/locales/es/LC_MESSAGES/installation.po
@@ -1,0 +1,396 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: spyder-documentation\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: 2024-09-10 00:48\n"
+"Last-Translator: \n"
+"Language: es\n"
+"Language-Team: Spanish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+"X-Crowdin-Project: spyder-documentation\n"
+"X-Crowdin-Project-ID: 641502\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /doc/locales/en/LC_MESSAGES/installation.po\n"
+"X-Crowdin-File-ID: 22\n"
+
+#: ../../installation.rst:5
+msgid "Installation Guide"
+msgstr "Guía de instalación"
+
+#: ../../installation.rst:7
+msgid "Spyder is relatively easy to install on Windows, Linux and macOS. Just make sure to read and follow these instructions with care."
+msgstr "Spyder es relativamente fácil de instalar en Windows, Linux y macOS. Solo asegúrate de leer y seguir estas instrucciones con cuidado."
+
+#: ../../installation.rst:10
+msgid "If you run into problems, before posting a report, *please* consult our comprehensive :doc:`troubleshooting guide</troubleshooting/first-steps>` and search the `issue tracker`_ for your error message and problem description. These methods generally fix or isolate the great majority of install-related difficulties. Thanks!"
+msgstr "Si tienes problemas antes de publicar un informe *por favor* consulta nuestra guía completa :doc:`guía de solución de problemas</troubleshooting/first-steps>` y busca en el `seguimiento de incidencias`_ tu mensaje de error y descripción de problema. Estos métodos generalmente arreglan o aislan la gran mayoría de las dificultades relacionadas con la instalación. ¡Gracias!"
+
+#: ../../installation.rst:18
+msgid "For most users on Windows and macOS, we recommend our :ref:`install-standalone` as the most straightforward and robust option to obtain Spyder. For users needing Linux support, third-party Spyder plugins or Variable Explorer compatibility with custom-installed packages—all capabilities which the standalone installers currently do not yet provide—we advise using a :ref:`install-conda`. Linux, plugin and package/environment management support in the standalone installers are currently under active development for future Spyder versions."
+msgstr "Para la mayoría de los usuarios en Windows y macOS, recomendamos nuestra :ref:`install-standalone` como la opción más sencilla y robusta para obtener Spyder. Para los usuarios que necesitan soporte para Linux, plugins Spyder de terceros o compatibilidad con Variable Explorer con paquetes instalados a medida, todas las capacidades que los instaladores independientes aún no proporcionan, recomendamos usar :ref:`install-conda`. Linux, plugin y soporte de gestión de paquetes/entorno en los instaladores independientes están actualmente en activo desarrollo para las futuras versiones de Spyder."
+
+#: ../../installation.rst:27
+msgid "Try Spyder online"
+msgstr "Probar Spyder en línea"
+
+#: ../../installation.rst:29
+msgid "Want to try out Spyder without installing it? With `Binder`_ you can work with a fully functional copy of Spyder online that runs right in your web browser, no installation needed. Visit the `Spyder Binder`_ to get started using Spyder."
+msgstr "¿Quieres probar Spyder sin instalarlo? Con `Binder`_ puedes trabajar con una copia completamente funcional de Spyder online que se ejecuta directamente en tu navegador web, sin necesidad de instalación. Visita el `Spyder Binder`_ para comenzar a usar Spyder."
+
+#: ../../installation.rst:45
+msgid "Standalone installers"
+msgstr "Instaladores independientes"
+
+#: ../../installation.rst:47
+msgid "The standalone installers are our recommended method for most users on Windows and macOS, with experimental Linux support under active development. They work like any other IDE, where Spyder can be installed and updated independently of the Python environments you use to run your code. This avoids the problems with incompatible packages and broken installations users often face when mixing Spyder with the (Conda, etc) environments they use to run their code."
+msgstr "Los instaladores independientes son nuestro método recomendado para la mayoría de los usuarios en Windows y macOS, con soporte experimental para Linux bajo activo desarrollo. Estos funcionan como cualquier otro IDE, donde Spyder puede ser instalado y actualizado independientemente de los entornos Python que utilices para ejecutar tu código. Esto evita los problemas con paquetes incompatibles e instalaciones rotas que los usuarios suelen enfrentar cuando mezclan Spyder con los entornos (Conda, etc) que usan para ejecutar su código."
+
+#: ../../installation.rst:51
+msgid "The installers include a built-in Python environment with the most common scientific libraries (e.g. NumPy, Pandas, Matpotlib, etc), which can be used out of the box for basic data analysis tasks. However, to manage your own packages and environments, you'll currently need to connect an external Python distribution (such as `Anaconda`_, `Miniconda`_, `Miniforge/Mambaforge`_, `WinPython`_ or `Python.org <Python_>`__) to your standalone copy of Spyder. For more information on this, see our :ref:`FAQ entry on the subject <using-packages-installer>`."
+msgstr "Los instaladores incluyen un entorno Python integrado con las librerías científicas más comunes (NumPy, Pandas, Matpotlib, etc), que se puede utilizar de forma automática para las tareas básicas de análisis de datos. Sin embargo, para gestionar tus propios paquetes y entornos, actualmente necesitarás conectar una distribución externa de Python (como `Anaconda`_, `Miniconda`_, `Miniforge/Mambaforge`_, `WinPython`_ o `Python.org <Python_>`__) a tu copia independiente de Spyder. Para más información sobre esto, ve nuestra entrada :ref:`FAQ sobre el asunto <using-packages-installer>`."
+
+#: ../../installation.rst:57
+msgid "The standalone installers do not yet support installing third-party Spyder plugins not already bundled with them, though this feature is currently under development. For now, if you need this capability, we recommend a :ref:`install-conda`."
+msgstr "Los instaladores independientes todavía no soportan la instalación de complementos Spyder de terceros que no están ya empaquetados con ellos, aunque esta característica está actualmente en desarrollo. Por ahora, si necesitas esta capacidad, recomendamos un :ref:`install-conda`."
+
+#: ../../installation.rst:64
+msgid "Downloading and installing"
+msgstr "Descargar e instalar"
+
+#: ../../installation.rst:66
+msgid "To download the supported Spyder installer for your platform, simply click the appropriate link below (for Linux, see the :ref:`install-conda` section). Then, double-click the downloaded file to open the installer. If a security warning pops up, you may need to click :guilabel:`Yes`, :guilabel:`OK`, :guilabel:`Open`, :guilabel:`Allow` or similar."
+msgstr "Para descargar el instalador Spyder soportado para tu plataforma, simplemente haz clic en el enlace apropiado de abajo (para Linux, consulta la sección :ref:`install-conda`). Luego, haz doble clic en el archivo descargado para abrir el instalador. Si aparece una advertencia de seguridad, puede que necesites hacer clic en :guilabel:`Sí`, :guilabel:`OK`, :guilabel:`Abrir`, :guilabel:`Permitir` o similares."
+
+#: ../../installation.rst:70
+msgid "On Windows, if a \"SmartScreen\" dialog appears, click :guilabel:`More info` followed by :guilabel:`Run anyway`, and then proceed through the steps in the installer."
+msgstr "En Windows, si aparece un diálogo \"SmartScreen\", haz clic en :guilabel:`Más información` seguido por :guilabel:`Ejecutar de todos modos`, y luego procede a través de los pasos del instalador."
+
+#: ../../installation.rst:72
+msgid "On macOS, open the disk image and drag Spyder to your :guilabel:`Applications` folder."
+msgstr "En macOS, abre la imagen del disco y arrastra Spyder a tu carpeta de :guilabel:`Aplicaciones`."
+
+#: ../../installation.rst:79
+msgid "`Windows Installer`_"
+msgstr "`Windows installer`_"
+
+#: ../../installation.rst:79
+msgid "`macOS Installer`_"
+msgstr "`macOS Installer`_"
+
+#: ../../installation.rst:87
+msgid "\"Lite\" versions of both installers are also available from the `releases page`_, which are somewhat smaller than the full installers. These lack a number of optional but recommended dependencies, such as NumPy, SciPy and Pandas, meaning that a few :doc:`/panes/variableexplorer` features, including graphical data import wizards and support for rich display and editing of NumPy arrays and Pandas DataFrames, will not be available. Given this only saves a modest amount of space while missing out on significant features, we recommend using the full installers unless minimizing download/install size and memory usage is a priority."
+msgstr "Las versiones \"Lite\" de ambos instaladores también están disponibles en `releases page`_, que son algo más pequeñas que los instaladores completos. Estas carecen de un número de dependencias opcionales pero recomendadas, como NumPy, SciPy y Pandas, lo que significa que algunas características de :doc:`/panes/variableexplorer`, incluyendo asistentes gráficos de importación de datos y soporte para la visualización y edición enriquecida de matrices NumPy y Pandas DataFrames, no estarán disponibles. Dado que esto solo ahorra una modesta cantidad de espacio mientras se pierden características significativas, recomendamos usar los instaladores completos a menos que minimizar el tamaño de descarga/instalación y el uso de memoria sea una prioridad."
+
+#: ../../installation.rst:97
+msgid "Running from a standalone install"
+msgstr "Ejecutar desde una instalación independiente"
+
+#: ../../installation.rst:99
+msgid "To run Spyder when installed standalone, you can simply use your operating system's typical method of launching applications, such as opening it from the :guilabel:`Start` menu on Windows (or the Taskbar, if you've pinned it there), or from Launchpad, Spotlight or the :guilabel:`Applications` folder on macOS (or the Dock, if you've added it there)."
+msgstr "Para ejecutar Spyder cuando se instala de forma autónoma, simplemente puedes utilizar el método típico de tu sistema operativo para iniciar aplicaciones, tal como abrirlo desde el menú :guilabel:`Inicio` en Windows (o la barra de tareas, si lo has anclado ahí), o desde Launchpad, Spotlight o la carpeta :guilabel:`Aplicaciones` en macOS (o el Dock, si lo has añadido allí)."
+
+#: ../../installation.rst:105
+msgid "Updating a standalone install"
+msgstr "Actualizar una instalación independiente"
+
+#: ../../installation.rst:107
+msgid "By default, Spyder checks for updates automatically on startup, and you can also check manually with :menuselection:`Help --> Check for updates`. The standalone installers for Spyder 5.4.0+ include update functionality built right into Spyder, which after checking for updates will display a prompt to automatically download and install the current version. On earlier versions, you'll need to manually download and install the latest release (if on Windows, make sure to remove the old version first from Control Panel/System Settings)."
+msgstr "Por defecto, Spyder comprueba las actualizaciones automáticamente al iniciar, y también puede comprobar manualmente con :menuselection:`Ayuda --> Buscar actualizaciones`. Los instaladores autónomos para Spyder 5.4.0+ incluyen la funcionalidad de actualización incorporada directamente en Spyder, que después de comprobar si hay actualizaciones, mostrará un mensaje para descargar e instalar automáticamente la versión actual. En versiones anteriores, necesitarás descargar e instalar manualmente la última versión (en Windows, asegúrate de eliminar la versión antigua primero en la Configuración del Panel de Control/Sistema)."
+
+#: ../../installation.rst:117
+msgid "Conda-based distributions"
+msgstr "Distribuciones basadas en Conda"
+
+#: ../../installation.rst:119
+msgid "Spyder is included by default in the `Anaconda`_ Python distribution, which comes with everything you need to get started in an all-in-one package. It can also be easily installed in the much lighter-weight `Miniconda`_ and `Miniforge/Mambaforge`_, which include just Python and the Conda/Mamba package and environment manager by default (with Miniforge defaulting to the Conda-Forge channel, and Mambaforge using Mamba, a much faster alternative to Conda). This is our recommended installation method on Linux and for users with third-party Spyder plugins, as support for both of these in our standalone installers is still under active development."
+msgstr "Spyder se incluye por defecto en la distribución `Anaconda`_ de Python, que viene con todo lo que necesitas para empezar con un paquete todo en uno. También puede instalarse fácilmente en el mucho más ligero `Miniconda`_ y `Miniforge/Mambaforge`_, que solamente incluyen Python y el paquete y gestor de entorno Conda/Mamba por defecto (con Miniforge por defecto en el canal Conda-Forge, y Mambaforge utilizando Mamba, una alternativa mucho más rápida a Conda). Este es nuestro método de instalación recomendado en Linux y para usuarios con plugins Spyder de terceros, ya que el soporte para ambos en nuestros instaladores independientes todavía está en proceso de desarrollo."
+
+#: ../../installation.rst:131
+msgid "Conda environment"
+msgstr "Entorno Conda"
+
+#: ../../installation.rst:133
+msgid "With Miniconda/Miniforge/Mambaforge, or to get a more reliable and up-to-date Spyder version with Anaconda, we strongly recommend installing Spyder into its own dedicated Conda environment."
+msgstr "Con Miniconda/Miniforge/Mambaforge, o para obtener una versión más fiable y actualizada de Spyder con Anaconda, te recomendamos encarecidamente instalar Spyder en tu propio entorno Conda."
+
+#: ../../installation.rst:137
+msgid "If using Mamba/Mambaforge, substitute ``mamba`` for ``conda`` in the following commands."
+msgstr "Si usas Mamba/Mambaforge, sustituye ``mamba`` por ``conda`` en los siguientes comandos."
+
+#: ../../installation.rst:143
+msgid "Installing with Conda"
+msgstr "Instalar con Conda"
+
+#: ../../installation.rst:145
+msgid "For a full install of Spyder and all optional dependencies, run the following command in your Anaconda Prompt (Windows) or terminal:"
+msgstr "Para una instalación completa de Spyder y todas las dependencias opcionales, ejecuta el siguiente comando en tu Anaconda Prompt (Windows) o terminal:"
+
+#: ../../installation.rst:151
+msgid "For a minimal install without the optional functionality and integration with the above packages, you can instead run:"
+msgstr "Para una instalación mínima sin la funcionalidad opcional y la integración con los paquetes anteriores, puedes ejecutar:"
+
+#: ../../installation.rst:157
+msgid "This installs Spyder into a new environment called ``spyder-env``, using the more up-to-date, community-run Conda-Forge channel. To make sure future installs/updates in this environment also use Conda-Forge and are faster and more reliable, make sure to set it as your environment's default channel with strict channel priority enabled, if this isn't the case already (as it is with Miniforge/Mambaforge or if you've manually configured it):"
+msgstr "Esto instala Spyder en un nuevo ambiente llamado ``spyder-env``, usando el canal Conda-Forge más actualizado, ejecutado por la comunidad. Para asegurarse de que futuras instalaciones/actualizaciones en este entorno también utilizan Conda-Forge y que sean más rápidas y confiables, asegúrate de establecerlo como el canal predeterminado de tu entorno con la prioridad estricta de canal activada, si este no es el caso (como lo es con Miniforge/Mambaforge o si lo has configurado manualmente):"
+
+#: ../../installation.rst:166
+msgid "Here's a summary of the main steps."
+msgstr "Aquí tienes un resumen de los pasos principales."
+
+#: ../../installation.rst:175
+msgid "Running with Conda"
+msgstr "Ejecutar con Conda"
+
+#: ../../installation.rst:177
+msgid "You can then run Spyder by the same methods :ref:`as with Anaconda <install-anaconda-running>`, except that you need to make sure to launch the Start menu shortcut with ``(spyder-env)`` in the name, select the ``spyder-env`` environment on the left before launching it with Navigator, or type ``conda activate spyder-env`` before launching it on the command line."
+msgstr "Luego puedes ejecutar Spyder por los mismos métodos :ref:`que con Anaconda <install-anaconda-running>`, excepto que necesitas asegurarte de iniciar el acceso directo del menú Inicio con ``(spyder-env)`` en el nombre, selecciona el entorno ``spyder-env`` a la izquierda antes de lanzarlo con Navigator, o escribe ``conda activate spyder-env`` antes de lanzarlo en la línea de comandos."
+
+#: ../../installation.rst:179
+msgid "See :ref:`our FAQ question <using-existing-environment>` for more information about how to use Spyder with your existing Conda environments."
+msgstr "Ve a :ref:`nuestras preguntas frecuentes FAQ <using-existing-environment>` para más información sobre cómo usar Spyder con sus entornos Conda existentes."
+
+#: ../../installation.rst:185
+msgid "Updating with Conda"
+msgstr "Ejecutar con Conda"
+
+#: ../../installation.rst:187
+msgid "With any Conda-based distribution and Spyder installed in its own environment (recommended), update Conda itself, active the environment, and finally update Spyder. In your system terminal (or Anaconda Prompt if on Windows), run:"
+msgstr "Con cualquier distribución basada en Conda y Spyder instalados en su propio entorno (recomendado), actualiza Conda en sí mismo, activa el entorno y finalmente actualiza Spyder. En tu terminal del sistema, o en el Anaconda Prompt si estás en Windows, ejecuta:"
+
+#: ../../installation.rst:196
+msgid "In case you get an error trying to update, just remove the existing environment (if using one other than ``base``):"
+msgstr "En caso de que se produzca un error al intentar actualizar, simplemente elimina el entorno existente (si se utiliza otro que no sea ``base``):"
+
+#: ../../installation.rst:202
+msgid "And then :ref:`recreate a fresh one <install-conda-installing>`."
+msgstr "Y luego :ref:`recrea uno nuevo <install-conda-installing>`."
+
+#: ../../installation.rst:208
+msgid "Anaconda base"
+msgstr "Anaconda base"
+
+#: ../../installation.rst:210
+msgid "While we recommend always using a dedicated environment, with Anaconda you can also run the bundled copy of Spyder from the built-in ``base`` environment."
+msgstr "Aunque recomendamos utilizar siempre un entorno dedicado, con Anaconda también puede ejecutar la copia empaquetada de Spyder desde el entorno ``base`` incorporado."
+
+#: ../../installation.rst:214
+msgid "The bundled Spyder version can often be quite out of date, missing new features and bug fixes from the latest version, and if you install, change or remove other packages, there is a significant chance of dependency conflicts or a broken Spyder installation. Therefore, we recommend :ref:`installing Spyder into a new Conda environment <install-conda-installing>` to avoid all these issues."
+msgstr "La versión empaquetada de Spyder a menudo puede estar bastante desactualizada, faltando nuevas características y correcciones de errores que están en la última versión, y si instalas, cambias o eliminar otros paquetes, hay una gran probabilidad de conflictos de dependencias o de una instalación rota de Spyder. Por lo tanto, recomendamos que :ref:`instales Spyder en un nuevo entorno Conda <install-conda-installing>` para evitar todos estos problemas."
+
+#: ../../installation.rst:221
+msgid "Running with Anaconda"
+msgstr "Ejecutar con Anaconda"
+
+#: ../../installation.rst:223
+msgid "To run the bundled version of Spyder after installing it with Anaconda, the recommended method on Windows is to launch it via the Start menu shortcut. On other platforms, open Anaconda Navigator, scroll to Spyder under :guilabel:`Home` and click :guilabel:`Launch`."
+msgstr "Para ejecutar la versión empaquetada de Spyder después de instalarla con Anaconda, el método recomendado en Windows es lanzarlo a través del acceso directo al menú Inicio. En otras plataformas, abre Anaconda Navigator, desplázate a Spyder bajo :guilabel:`Home` y haz clic en :guilabel:`Launch`."
+
+#: ../../installation.rst:229
+msgid "If Spyder does not start via this method or you prefer to use the command line, open Anaconda Prompt (Windows) or your terminal (other platforms), type ``conda activate base`` then ``spyder``."
+msgstr "Si Spyder no se inicia a través de este método o prefieres utilizar la línea de comandos, abre el Anaconda Prompt (Windows) o tu terminal (otras plataformas), escribe ``conda activate base`` y luego ``spyder``."
+
+#: ../../installation.rst:235
+msgid "Updating with Anaconda"
+msgstr "Actualizar con Anaconda"
+
+#: ../../installation.rst:237
+msgid "With Spyder installed in Anaconda's ``base`` environment, first update the ``anaconda`` meta-package, and then Spyder itself (in case there is a newer version than that pinned to the ``anaconda`` metapackage). In your system terminal (or Anaconda Prompt if on Windows), run:"
+msgstr "Con Spyder instalado en el entorno Anaconda ``base``, primero actualiza el meta-paquete ``anaconda``, y luego Spyder en sí, en caso de que haya una versión más reciente que la fijada al metapaquete ``anaconda``. En tu terminal de sistema (o Anaconda Prompt si en Windows), ejecutar:"
+
+#: ../../installation.rst:247
+msgid "These commands also update all your other packages, which is one reason we strongly recommend you use an isolated conda environment to avoid any potential unintended effects on other installed packages."
+msgstr "Estos comandos también actualizan todos los demás paquetes, es una de las razones por las que recomendamos que utilices un entorno conda aislado para evitar posibles efectos no intencionados en otros paquetes instalados."
+
+#: ../../installation.rst:249
+msgid "In case you get an error resolving dependencies, try uninstalling Spyder and re-installing it:"
+msgstr "En caso de que obtengas un error resolviendo las dependencias, intenta desinstalar Spyder y reinstalarlo:"
+
+#: ../../installation.rst:262
+msgid "Using pip"
+msgstr "Usar Pip"
+
+#: ../../installation.rst:266
+msgid "While this installation method is a viable option for experienced users, installing Spyder (and other PyData-stack packages) with pip can sometimes lead to tricky issues, particularly on Windows and macOS. While you are welcome to try it on your own, we are typically not able to provide individual support for installation problems with pip, except to recommend our :ref:`install-standalone` (Windows and macOS) or a :ref:`install-conda`."
+msgstr "Si bien este método de instalación es una opción viable para usuarios experimentados, instalar Spyder (y otros paquetes de PyData-stack) con pip a veces puede llevar a problemas complicados, particularmente en Windows y macOS. Aunque eres bienvenido a probarlo por tu cuenta, normalmente no somos capaces de proporcionar soporte individual para problemas de instalación con pip excepto para recomendar nuestro :ref:`install-standalone` (Windows y macOS) o un :ref:`install-conda`."
+
+#: ../../installation.rst:269
+msgid "You can install Spyder with the pip package manager, which is included by default with most Python installations. Before installing Spyder itself by this method, you need to download the `Python`_ programming language."
+msgstr "Puedes instalar Spyder con el gestor de paquetes pip, que se incluye por defecto en la mayoría de las instalaciones de Python. Antes de instalar Spyder en sí mismo mediante este método, necesitas descargar el lenguaje de programación `Python`_."
+
+#: ../../installation.rst:276
+msgid "Due to a known issue with some DEB-based Linux distributions (Debian, Ubuntu, Mint), you might also need to install the ``pyqt5-dev-tools`` package first, with ``sudo apt install pyqt5-dev-tools``."
+msgstr "Debido a un problema conocido con algunas distribuciones Linux basadas en DEB (Debian, Ubuntu, Mint), podrías necesitar instalar primero el paquete ``pyqt5-dev-tools`` con ``sudo apt install pyqt5-dev-tools``."
+
+#: ../../installation.rst:278
+msgid "You'll first want to create and activate a virtual environment in which to install Spyder, via one of the following methods."
+msgstr "Primero querrás crear y activar un entorno virtual en el cual instalar Spyder, mediante uno de los siguientes métodos."
+
+#: ../../installation.rst:280
+msgid "With ``virtualenvwrapper``:"
+msgstr "Con ``virtualenvapper``:"
+
+#: ../../installation.rst:287
+msgid "Otherwise, on macOS/Linux/Unix:"
+msgstr "De lo contrario, en macOS/Linux/Unix:"
+
+#: ../../installation.rst:294
+msgid "or on Windows:"
+msgstr "o en Windows:"
+
+#: ../../installation.rst:301
+msgid "After activating your environment, to install Spyder and its optional dependencies, run:"
+msgstr "Después de activar tu entorno, para instalar Spyder y sus dependencias opcionales, ejecuta:"
+
+#: ../../installation.rst:307
+msgid "Or for a minimal installation, run:"
+msgstr "O para una instalación mínima, ejecuta:"
+
+#: ../../installation.rst:316
+msgid "To launch Spyder after installing it, ensure your environment is activated and run the ``spyder`` or ``spyder3`` command."
+msgstr "Para iniciar Spyder después de instalarlo, asegúrate de que tu entorno está activado y ejecuta el comando ``spyder`` o ``spyder3``."
+
+#: ../../installation.rst:318
+msgid "And to update Spyder, with your Spyder environment activated, run:"
+msgstr "Y para actualizar Spyder, con tu entorno Spyder activado, ejecuta:"
+
+#: ../../installation.rst:330
+msgid "Alternative methods"
+msgstr "Métodos alternativos"
+
+#: ../../installation.rst:334
+msgid "While we describe alternative Spyder installation options for users who prefer them, as these are third-party distributions that we have no direct involvement in, we are usually not able to offer useful individual assistance for problems specific to installing via these alternative methods."
+msgstr "Mientras describimos opciones alternativas de instalación de Spyder para los usuarios que las prefieren, ya que se trata de distribuciones de terceros en las que no tenemos ninguna implicación directa, normalmente no podemos ofrecer asistencia individual útil para problemas específicos de instalación a través de estos métodos alternativos."
+
+#: ../../installation.rst:336
+msgid "Also, the Spyder versions they install may be out of date relative to the current release, and thus be missing the latest features and bug fixes."
+msgstr "Además, las versiones de Spyder que instalan pueden estar desactualizadas respecto a la versión actual, y por lo tanto faltan las últimas características y correcciones de errores."
+
+#: ../../installation.rst:338
+msgid "Therefore, we recommend you switch to our :ref:`install-standalone` (Windows and macOS) or a :ref:`install-conda` if you encounter installation issues you are unable to solve on your own."
+msgstr "Por lo tanto, te recomendamos cambiar a nuestro :ref:`install-standalone` (Windows y macOS) o a un :ref:`install-conda` si encuentras problemas de instalación que no puedes resolver por ti mismo."
+
+#: ../../installation.rst:344
+msgid "Windows"
+msgstr "Windows"
+
+#: ../../installation.rst:346
+msgid "Spyder is included in the `WinPython`_ scientific Python distribution, along with many other common numerical computing and data analysis packages. You can use Spyder immediately after installing, similar to Anaconda."
+msgstr "Spyder está incluido en la distribución científica de Python `WinPython`_, junto con muchos otros paquetes comunes de cálculo y análisis de datos. Puedes usar Spyder inmediatamente después de la instalación, similar a Anaconda."
+
+#: ../../installation.rst:355
+msgid "macOS"
+msgstr "macOS"
+
+#: ../../installation.rst:357
+msgid "Spyder is available as `a cask`_ through `Homebrew`_."
+msgstr "Spyder está disponible como un `cask`_ a través de `Homebrew`_."
+
+#: ../../installation.rst:362
+msgid "To install it using the ``brew`` package manager, run:"
+msgstr "Para instalarlo usando el gestor de paquetes ``brew``, ejecuta:"
+
+#: ../../installation.rst:368
+msgid "It is also available as a `a port`_ through `MacPorts`_."
+msgstr "También está disponible como un `port`_ a través de `MacPorts`_."
+
+#: ../../installation.rst:373
+msgid "To install it using the ``port`` package manager, run:"
+msgstr "Para instalarlo usando el gestor de paquetes ``port``, ejecuta:"
+
+#: ../../installation.rst:383
+msgid "Linux"
+msgstr "Linux"
+
+#: ../../installation.rst:385
+msgid "Spyder can be installed via third-party distro packages on most common Linux distributions."
+msgstr "Spyder se puede instalar a través de paquetes de distribución de terceros en las distribuciones de Linux más comunes."
+
+#: ../../installation.rst:387
+msgid "Running Spyder installed this way will generally be the same as any other distro-installed application. Alternatively, it can be launched from the terminal with ``spyder`` (or ``spyder3``, on older versions of some distros)."
+msgstr "Al instalar Spyder de esta forma, puede ser ejecutado al igual que cualquier otra aplicación obtenida a través de tu distribución. Alternativamente, puede ser lanzado desde la terminal con ``spyder`` (o ``spyder3``, en versiones antiguas de algunas distribuciones)."
+
+#: ../../installation.rst:394
+msgid "Ubuntu/Debian"
+msgstr "Ubuntu/Debian"
+
+#: ../../installation.rst:396
+msgid "Spyder is available as `a Ubuntu package`_ and `a Debian package`_."
+msgstr "Spyder está disponible como `un paquete Ubuntu`_ y `un paquete Debian`_."
+
+#: ../../installation.rst:401
+msgid "To install it using the ``apt`` package manager, run:"
+msgstr "Para instalarlo usando el gestor de paquetes ``apt``, ejecuta:"
+
+#: ../../installation.rst:411
+msgid "Other distributions"
+msgstr "Otras distribuciones"
+
+#: ../../installation.rst:413
+msgid "Spyder is also available in other GNU/Linux distributions, including:"
+msgstr "Spyder también está disponible en otras distribuciones GNU/Linux, incluyendo:"
+
+#: ../../installation.rst:415
+msgid "`Arch Linux`_"
+msgstr "`Arch Linux`_"
+
+#: ../../installation.rst:416
+msgid "`Fedora`_"
+msgstr "`Fedora`_"
+
+#: ../../installation.rst:417
+msgid "`Gentoo`_"
+msgstr "`Gentoo`_"
+
+#: ../../installation.rst:418
+msgid "`openSUSE`_"
+msgstr "`openSUSE`_"
+
+#: ../../installation.rst:425
+msgid "Please refer to the links or your distribution's documentation for how to install Spyder."
+msgstr "Por favor, consulta los enlaces o la documentación de tu distribución sobre cómo instalar Spyder."
+
+#: ../../installation.rst:433
+msgid "Development builds"
+msgstr "Versiones de desarrollo"
+
+#: ../../installation.rst:435
+msgid "If you want to try the next Spyder version before it is released, you can! You may want to do this for fixing bugs in Spyder, adding new features, learning how Spyder works or just getting a taste of what the IDE can do. For more information, please see the `Contributing Guide`_ included with the Spyder source or on Github, and for further detail consult the `Spyder development wiki`_."
+msgstr "Si quieres probar la siguiente versión de Spyder antes de que sea lanzada, ¡puedes hacerlo! Es posible que quieras hacer esto para corregir errores en Spyder, añadir nuevas características, aprender cómo funciona Spyder o simplemente probar lo que el IDE puede hacer. Para más información, por favor vea la `Guía de Contribución`_ incluida con el código fuente de Spyder o en Github, y para más detalles consulte la `Guía de Desarrollo de Spyder`_."
+
+#: ../../installation.rst:450
+msgid "Additional help"
+msgstr "Ayuda adicional"
+
+#: ../../installation.rst:454
+msgid "*Run in to a problem installing or running Spyder?* Read our `Troubleshooting Guide and FAQ`_."
+msgstr "*¿Problemas al instalar o ejecutar Spyder?* Lea nuestra `Guía de solución de problemas y FAQ`_."
+
+#: ../../installation.rst:458
+msgid "*Looking for general information about Spyder and its ecosystem?* See our `main website`_."
+msgstr "*¿Buscas información general sobre Spyder y su ecosistema?* Ve a nuestro `sitio web principal`_."
+
+#: ../../installation.rst:462
+msgid "*Need to submit a bug report or feature request?* Check out our `Github repository`_."
+msgstr "*¿Necesitas enviar un informe de error o solicitud de características?* Revisa nuestro `repositorio de Github`_."
+
+#: ../../installation.rst:466
+msgid "*Want development-oriented help and information?* Consult our `Github wiki`_."
+msgstr "*¿Quieres ayuda e información orientada al desarrollo?* Consulta nuestro `Github wiki`_."
+
+#: ../../installation.rst:470
+msgid "*Have a help request or discussion topic?* Subscribe to our `Google Group`_."
+msgstr "*¿Tienes una solicitud de ayuda o un tema de discusión?* Suscríbete a nuestro `Grupo de Google`_."
+
+#: ../../installation.rst:474
+msgid "*Asking a quick question or want to chat with the dev team?* Stop by our `Gitter chatroom`_."
+msgstr "*¿Hacer una pregunta rápida o quieres chatear con el equipo de desarrolladores?* Pásate por nuestro `chat de Gitter`_."
+
+#: ../../installation.rst:478
+msgid "*Seeking personalized help from expert Spyder consultants?* Visit `OpenTeams`_."
+msgstr "*¿Buscando ayuda personalizada de consultores expertos de Spyder?* Visita `OpenTeams`_."
+

--- a/doc/locales/es/LC_MESSAGES/panes.po
+++ b/doc/locales/es/LC_MESSAGES/panes.po
@@ -1,0 +1,1353 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: spyder-documentation\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: 2024-09-11 23:09\n"
+"Last-Translator: \n"
+"Language: es\n"
+"Language-Team: Spanish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+"X-Crowdin-Project: spyder-documentation\n"
+"X-Crowdin-Project-ID: 641502\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /doc/locales/en/LC_MESSAGES/panes.po\n"
+"X-Crowdin-File-ID: 26\n"
+
+#: ../../panes/debugging.rst:3
+msgid "Debugger"
+msgstr "Depurador (Debugger)"
+
+#: ../../panes/debugging.rst:5
+msgid "**Debugging** in Spyder is supported through integration with the enhanced ``ipdb`` debugger in the :doc:`ipythonconsole`. This allows breakpoints and the execution flow to be viewed and controlled right from the Spyder GUI, as well as with all the familiar IPython console commands."
+msgstr "La **depuración** en Spyder es compatible a través de la integración con el depurador mejorado de ``ipdb`` en la consola :doc:`ipythonconsole`. Esto permite que los puntos de interrupción y el flujo de ejecución sean vistos y controlados directamente desde el Spyder GUI, así como con todos los comandos conocidos de la consola IPython."
+
+#: ../../panes/debugging.rst:15
+msgid "Debugging with ipdb"
+msgstr "Depurando con ipdb"
+
+#: ../../panes/debugging.rst:17
+msgid "You can fully control debugger execution from the :guilabel:`Debug` menu, :guilabel:`Debug toolbar` and via configurable keyboard shortcuts, along with the standard ``ipdb`` `console commands`_."
+msgstr "Puedes controlar completamente la ejecución del depurador desde el menú `Depurar` de la :guilabel:`Barra de herramientas de depuración` y a través de atajos de teclado configurables, junto con el estándar ``ipdb`` `comandos de consola`_."
+
+#: ../../panes/debugging.rst:22
+msgid "Additionally, the  :doc:`editor` shows the line of code the debugger is currently stopped on with an arrow."
+msgstr "Además, el :doc:`editor` muestra la línea de código en la que el depurador se detiene con una flecha."
+
+#: ../../panes/debugging.rst:29
+msgid "Spyder's debugger offers syntax highlighting, code completion and command history, which work exactly like they do in the normal interactive interpreter."
+msgstr "El depurador de Spyder ofrece resaltado de sintaxis, terminación de código e historial de comandos, que funcionan exactamente como lo hacen en el intérprete interactivo normal."
+
+#: ../../panes/debugging.rst:31
+msgid "Use the up and down arrows to recall previous commands, and press :kbd:`Tab` to trigger autocomplete suggestions."
+msgstr "Usa las flechas arriba y abajo para recordar comandos anteriores, y pulsa :kbd:`Tab` para activar sugerencias de autocompletado."
+
+#: ../../panes/debugging.rst:36
+#, python-format
+msgid "Furthermore, IPython's `magic functions`_ are available in debugging mode. You can, for example, run ``%ls`` to list the contents of your current working directory or ``%timeit`` to check how fast a given snippet of code is."
+msgstr "Además, las `funciones mágicas`_ de IPython están disponibles en modo de depuración. Puedes, por ejemplo, ejecutar ``%ls`` para listar los contenidos de tu directorio de trabajo actual o ``%timeit`` para comprobar cuán rápido es un fragmento de código dado."
+
+#: ../../panes/debugging.rst:44
+msgid "Finally, you can enter and execute multiline statements in Spyder's debugger just like with the regular IPython prompt, to easily run complex code."
+msgstr "Por último, puedes introducir y ejecutar sentencias multilíneas en el depurador de Spyder de la misma forma que con la petición IPython habitual, para ejecutar fácilmente código complejo."
+
+#: ../../panes/debugging.rst:54
+msgid "Breakpoints"
+msgstr "Puntos de interrupción"
+
+#: ../../panes/debugging.rst:56
+msgid "Spyder's debugger is integrated with the :guilabel:`Breakpoints` pane, which lists the file, line, and condition (if any) of every breakpoint defined. To open it, select :menuselection:`Debug --> List breakpoints`, or press :kbd:`Ctrl-Shift-B` (:kbd:`Cmd-Shift-B` on macOS)."
+msgstr "El depurador de Spyder está integrado con el panel de :guilabel:`Breakpoints`, el cual muestra el archivo, la línea y la condición (si existe) de cada punto de interrupción definido. Para abrirlo, selecciona :menuselection:`Depurar --> Listar puntos de interrupción`, o pulsa :kbd:`Ctrl-Shift-B` (:kbd:`Cmd-Shift-B` en macOS)."
+
+#: ../../panes/debugging.rst:62
+msgid "There are several different ways to set and clear breakpoints:"
+msgstr "Hay varias maneras diferentes de establecer y limpiar los puntos de interrupción:"
+
+#: ../../panes/debugging.rst:64
+msgid "With the :guilabel:`Set/clear breakpoint` option in the Debug menu."
+msgstr "Con la opción :guilabel:`Añadir o eliminar un punto de interrupción` en el menú depuración."
+
+#: ../../panes/debugging.rst:65
+msgid "Through pressing the configurable keyboard shortcut (:kbd:`F12` for normal, or :kbd:`Shift-F12` for conditional breakpoints by default)."
+msgstr "Presionando el atajo de teclado configurable (:kbd:`F12` para normal, o :kbd:`Shift-F12` para puntos de interrupción condicional por defecto)."
+
+#: ../../panes/debugging.rst:66
+msgid "By clicking to the left of the line number in an open file in the Editor (adding :kbd:`Shift` for a conditional breakpoint)."
+msgstr "Al hacer clic a la izquierda del número de línea en un archivo abierto en el Editor (agregando :kbd:`Shift` para un punto de interrupción condicional)."
+
+#: ../../panes/debugging.rst:67
+msgid "With the ``breakpoint()`` builtin function in your code."
+msgstr "Con la función incorporada ``breakpoint()`` en tu código."
+
+#: ../../panes/debugging.rst:68
+msgid "Interactively, using the ``b`` command in a debugging session."
+msgstr "Interactivamente, usando el comando ``b`` en una sesión de depuración."
+
+#: ../../panes/debugging.rst:73
+msgid "You can access and edit local and global variables at each breakpoint through the :doc:`variableexplorer`."
+msgstr "Puedes acceder y editar variables locales y globales en cada punto de interrupción a través del :doc:`variableexplorer`."
+
+#: ../../panes/debugging.rst:82
+msgid "Advanced features"
+msgstr "Funcionalidades avanzadas"
+
+#: ../../panes/debugging.rst:84
+msgid "You can avoid stepping through other Python packages while debugging by enabling the new :guilabel:`Ignore Python libraries while debugging` option in Spyder's preferences, under :menuselection:`IPython Console --> Debugger --> Debug`. This will skip all the built-in and third-party Python modules you have installed."
+msgstr "Puedes evitar pasar por otros paquetes de Python mientras depuras activando :guilabel:`Ignorar las librerías de Python mientras se depura` en las preferencias de Spyder, bajo :menuselection:`Terminal de IPython --> Depurador --> Depurar`. Esto omitirá todos los módulos Python integrados y de terceros que haya instalado."
+
+#: ../../panes/debugging.rst:90
+msgid "If your code has variables with the same names as Pdb commands (e.g. ``b`` or ``step``), you can still refer to them as normal while debugging. To call the respective Pdb command, just add an exclamation point before it (e.g. ``!b`` or ``!step``)."
+msgstr "Si tu código tiene variables con los mismos nombres que los comandos Pdb (por ejemplo, ``b`` o ``step``), todavía puedes referirte a ellos como normales mientras depuras. Para llamar al comando Pdb correspondiente, simplemente agrega un punto de exclamación antes de él (por ejemplo, ``!b`` o ``!step``)."
+
+#: ../../panes/debugging.rst:96
+msgid "You can have Spyder automatically execute a custom snippet of code every time the debugger stops. For example, you can use this to set specific variables, or import commonly-used modules so they are always available while debugging. To set this up, go to :menuselection:`Preferences --> IPython Console --> Debugger --> Run code while debugging`, and enter the code that you want to be executed with each step."
+msgstr "Puedes hacer que Spyder ejecute automáticamente un fragmento de código personalizado cada vez que el depurador se detiene. Por ejemplo, puedes usar esto para establecer variables específicas, o importar módulos usados comúnmente para que estén siempre disponibles durante la depuración. Para configurar esto, vaya a :menuselection:`Preferencias --> Terminal de IPython --> Depurador --> Ejecutar código al depurar`, e introduce el código que deseas que se ejecute con cada paso."
+
+#: ../../panes/debugging.rst:107
+msgid "Matplotlib support"
+msgstr "Soporte Matplotlib"
+
+#: ../../panes/debugging.rst:109
+msgid "Generating Matplotlib figures is fully supported while the debugger is active, including all the different graphics backends. Use the ``%matplotlib`` magic to change to an interactive backend (e.g. ``%matplotlib qt5``) to pan, zoom and adjust your plots in a separate window, or switch back to the default ``inline`` (``%matplotlib inline``) to see them displayed right in the :doc:`plots` pane."
+msgstr "La generación de figuras de Matplotlib está totalmente soportada mientras el depurador está activo, incluyendo todos los diferentes backends gráficos. Utilice la magia ``%matplotlib`` para cambiar a un backend interactivo (por ejemplo, ``%matplotlib qt5``) para anclar, acercar y ajustar tus gráficas en una ventana separada, o vuelve al ``inline`` predeterminado (``%matplotlib inline``) para verlos mostrados directamente en el panel :doc:`plots`."
+
+#: ../../panes/debugging.rst:116
+msgid "To avoid showing plots while debugging, deactivate the :guilabel:`Process execute events while debugging` option in :menuselection:`Preferences --> IPython console --> Debugger`."
+msgstr "Para evitar mostrar gráficos mientras se depura, desactiva la opción :guilabel:`Procesar ejecución de eventos al depurar` en :menuselection:`Preferencias --> Terminal de IPython --> Depurador`."
+
+#: ../../panes/debugging.rst:122 ../../panes/editor.rst:313
+#: ../../panes/fileexplorer.rst:99 ../../panes/findinfiles.rst:65
+#: ../../panes/help.rst:80 ../../panes/historylog.rst:51
+#: ../../panes/ipythonconsole.rst:185 ../../panes/onlinehelp.rst:86
+#: ../../panes/outline.rst:54 ../../panes/plots.rst:85
+#: ../../panes/profiler.rst:99 ../../panes/projects.rst:62
+#: ../../panes/pylint.rst:91 ../../panes/variableexplorer.rst:194
+msgid "Related panes"
+msgstr "Paneles relacionados"
+
+#: ../../panes/debugging.rst:124 ../../panes/fileexplorer.rst:101
+#: ../../panes/findinfiles.rst:67 ../../panes/help.rst:82
+#: ../../panes/ipythonconsole.rst:188 ../../panes/outline.rst:56
+#: ../../panes/projects.rst:64 ../../panes/pylint.rst:93
+msgid ":doc:`editor`"
+msgstr ":doc:`editor`"
+
+#: ../../panes/debugging.rst:125 ../../panes/editor.rst:317
+#: ../../panes/help.rst:83 ../../panes/historylog.rst:53
+#: ../../panes/plots.rst:87 ../../panes/profiler.rst:101
+#: ../../panes/variableexplorer.rst:197
+msgid ":doc:`ipythonconsole`"
+msgstr ":doc:`ipythonconsole`"
+
+#: ../../panes/debugging.rst:126 ../../panes/ipythonconsole.rst:191
+#: ../../panes/plots.rst:88
+msgid ":doc:`variableexplorer`"
+msgstr ":doc:`variableexplorer`"
+
+#: ../../panes/editor.rst:3
+msgid "Editor"
+msgstr "Editor"
+
+#: ../../panes/editor.rst:5
+msgid "Spyder's multi-language **Editor** pane is the key element of the IDE, where you can create, open, and modify source files. The Editor offers a variety of core features, such as autocompletion, real-time analysis, syntax highlighting, horizontal and vertical splitting, and much more. In addition, it integrates a number of powerful tools for an easy to use, efficient editing experience."
+msgstr "El panel del **Editor** de varios lenguajes de Spyder es el elemento clave del IDE, donde puedes crear, abrir y modificar los archivos de origen. El editor ofrece una variedad de características básicas, tales como autocompletado, análisis en tiempo real, resaltado de sintaxis, división horizontal y vertical, y mucho más. Además, integra una serie de poderosas herramientas para una experiencia de edición fácil y eficiente."
+
+#: ../../panes/editor.rst:16
+msgid "Key components"
+msgstr "Componentes clave"
+
+#: ../../panes/editor.rst:18
+msgid "The Editor pane consists of the following areas:"
+msgstr "El panel del Editor consta de las siguientes áreas:"
+
+#: ../../panes/editor.rst:23
+msgid "The left sidebar shows line numbers and displays any code analysis warnings that exist in the current file. Clicking a line number selects the text on that line, and clicking to the right of it sets a :ref:`breakpoint <debugging-breakpoints>`."
+msgstr "La barra lateral izquierda muestra los números de línea y muestra las advertencias de análisis de código que existen en el archivo actual. Al hacer clic en un número de línea selecciona el texto en esa recta, y haciendo clic a la derecha se establece un :ref:`punto de interrupción<debugging-breakpoints>`."
+
+#: ../../panes/editor.rst:25
+msgid "The scrollbars allow vertical and horizontal navigation in a file."
+msgstr "Las barras de desplazamiento permiten la navegación vertical y horizontal en un archivo."
+
+#: ../../panes/editor.rst:26
+msgid "The context (right-click) menu displays actions relevant to whatever was clicked."
+msgstr "El menú contextual (clic derecho) muestra acciones relevantes a cualquier cosa que se haya seleccionado."
+
+#: ../../panes/editor.rst:27
+msgid "The options menu (\"Hamburger\" icon at top right) includes useful settings and actions relevant to the Editor."
+msgstr "El menú de opciones (icono \"Hamburguesa\" en la parte superior derecha) incluye opciones útiles y acciones relevantes para el Editor."
+
+#: ../../panes/editor.rst:28
+msgid "The location bar at the top of the Editor pane shows the full path of the current file."
+msgstr "La barra de ubicación en la parte superior del panel del Editor muestra la ruta completa del archivo actual."
+
+#: ../../panes/editor.rst:29
+msgid "The tab bar displays the names of all opened files. It also has a :guilabel:`Browse tabs` button (at left) to show every open tab and switch between them—which comes in handy if many are open."
+msgstr "La barra de pestañas muestra los nombres de todos los archivos abiertos. También tiene un botón :guilabel:`Navegar por las pestañas` (a la izquierda) para mostrar cada pestaña abierta y cambiar entre ellas, que es útil si muchas están abiertas."
+
+#: ../../panes/editor.rst:36
+msgid "Interface"
+msgstr "Interfaz"
+
+#: ../../panes/editor.rst:39
+msgid "Tabs"
+msgstr "Pestañas"
+
+#: ../../panes/editor.rst:41
+msgid "You can browse and navigate between open files in the Editor with tabs. Click the :guilabel:`Browse tabs` button on the left of the tab bar to display a list of open files, with the active tab checked."
+msgstr "Puedes explorar y navegar entre archivos abiertos en el Editor con pestañas. Haz clic en el botón :guilabel:`Navegar por las pestañas` a la izquierda de la barra de pestañas para mostrar una lista de archivos abiertos, con la pestaña activa seleccionada."
+
+#: ../../panes/editor.rst:47
+msgid "Reorder files by dragging and dropping, or with :guilabel:`Sort tabs alphabetically` in the options menu, which also allows closing all tabs to the right of, or all tabs but the active one."
+msgstr "Reordenar archivos arrastrando y soltando, o con :guilabel:`Ordenar las pestañas alfabéticamente` en el menú de opciones, que también permite cerrar todas las pestañas a la derecha de, o todas las pestañas excepto la activa."
+
+#: ../../panes/editor.rst:54
+msgid "File switcher"
+msgstr "Cambiador de archivos"
+
+#: ../../panes/editor.rst:56
+msgid "The Editor features a file switcher, which enables you to navigate and switch between multiple open files. The file switcher is helpful for locating any file when there are several files opened."
+msgstr "El Editor incluye un cambiador de archivos, que te permite navegar y cambiar entre varios archivos abiertos. El cambiador de archivos es útil para localizar cualquier archivo cuando hay varios archivos abiertos."
+
+#: ../../panes/editor.rst:62
+msgid "It can be accessed from the :menuselection:`File --> File Switcher` menu or :kbd:`Ctrl-P`, and includes a search function. You can type in any part of an open file's name and—if exists—it can be switched to by pressing :kbd:`Enter`."
+msgstr "Se puede acceder desde el menú :menuselection:`Archivo --> Cambiador de archivos` o :kbd:`Ctrl-P`, e incluye una función de búsqueda. Puedes escribir cualquier parte del nombre de un archivo abierto y, si existe, puede ser cambiado pulsando :kbd:`Enter`."
+
+#: ../../panes/editor.rst:70
+msgid "Split panels"
+msgstr "Dividir paneles"
+
+#: ../../panes/editor.rst:72
+msgid "The Editor can be split horizontally and vertically into as many distinct panels as desired. This allows viewing and editing the contents of several files (or different parts of the same file) at the same time."
+msgstr "El Editor puede dividirse horizontal y verticalmente en tantos paneles distintos como se desee. Esto permite visualizar y editar el contenido de varios archivos (o partes diferentes del mismo archivo) al mismo tiempo."
+
+#: ../../panes/editor.rst:78
+msgid "Split the Editor with the :guilabel:`Split vertically` (:kbd:`Ctrl-Shift-{`) and :guilabel:`Split horizontally` (:kbd:`Ctrl-Shift--`) commands in the options menu, and use :guilabel:`Close this panel` (:kbd:`Alt-Shift-W`) to close the selected split panel."
+msgstr "Divide el Editor con los comandos en el menú de opciones :guilabel:`Dividir verticalmente` (:kbd:`Ctrl-Shift-{`) y :guilabel:`Dividir horizontalmente` (:kbd:`Ctrl-Shift--`), y utiliza :guilabel:`Cerrar este panel` (:kbd:`Alt-Shift-W`) para cerrar el panel de división seleccionado."
+
+#: ../../panes/editor.rst:80
+msgid ":menuselection:`Close this panel` closes a split panel, while :menuselection:`Close` hides the entire Editor *pane* (including all splits, which are restored when the Editor is re-opened)."
+msgstr ":menuselection:`Cerrar este panel` cierra un panel dividido, mientras que :menuselection:`Cerrar` oculta todo el *panel* del editor (incluyendo todas las divisiones, que se restauran cuando se vuelve a abrir el Editor)."
+
+#: ../../panes/editor.rst:86
+msgid "Editing features"
+msgstr "Editar características"
+
+#: ../../panes/editor.rst:89
+msgid "Syntax highlighting"
+msgstr "Coloreado de sintaxis"
+
+#: ../../panes/editor.rst:91
+msgid "To improve the readability of your code, Spyder has a syntax highlighting feature that determines the color and style of text in the Editor, as well as in the :doc:`ipythonconsole`."
+msgstr "Para mejorar la legibilidad de tu código, Spyder tiene una función de resaltado de sintaxis que determina el color y el estilo del texto en el editor, así como en el :doc:`ipythonconsole`."
+
+#: ../../panes/editor.rst:93
+msgid "You can configure and preview syntax highlighting themes and fonts under :menuselection:`Preferences --> Appearance`. The :guilabel:`Syntax highlighting theme` section allows you to change the color and style of the syntax elements and background to match your preferences. You can switch between available themes in the drop-down menu, modify the selected theme, create a new theme, and more. The :guilabel:`Fonts` section lets you change the text font and size."
+msgstr "Puedes configurar y previsualizar los temas y fuentes de resaltado de sintaxis bajo :menuselection:`Preferencias --> Apariencia`. La sección :guilabel:'Tema de coloreado de sintaxis' te permite cambiar el color y el estilo de los elementos de sintaxis y el fondo para que coincida con tus preferencias. Puedes cambiar entre los temas disponibles en el menú desplegable, modificar el tema seleccionado, crear un nuevo tema y más. La sección :guilabel:`Tipo de letra` te permite cambiar el tamaño y la fuente de texto."
+
+#: ../../panes/editor.rst:101
+msgid "Changes made to the syntax highlighting theme and font settings are common to all source files, regardless of their language."
+msgstr "Los cambios realizados al tema de resaltado de sintaxis y a la configuración de fuentes son comunes a todos los archivos de fuente, independientemente de su idioma."
+
+#: ../../panes/editor.rst:105
+msgid "Code cells"
+msgstr "Celdas de código"
+
+#: ../../panes/editor.rst:107
+msgid "A \"code cell\" in Spyder is a block of lines, typically in a script, that can be easily executed all at once in the current :doc:`ipythonconsole`. This is similar to \"cell\" behavior in Jupyter Notebook and MATLAB. You can divide your scripts into as many cells as needed, or none at all—the choice is yours."
+msgstr "Una \"celda de código\" en Spyder es un bloque de líneas, normalmente un script, que puede ser fácilmente ejecutado todo a la vez en el :doc:`ipythonconsole`. Esto es similar al comportamiento de \"celda\" en Jupyter Notebook y MATLAB. Puedes dividir tus scripts en tantas celdas como necesites o ninguna en absoluto, la elección es tuya."
+
+#: ../../panes/editor.rst:114
+msgid "You can separate cells by lines starting with either:"
+msgstr "Puedes separar las celdas por líneas comenzando por:"
+
+#: ../../panes/editor.rst:116
+#, python-format
+msgid "``# %%`` (standard cell separator), or"
+msgstr "``# %%`` (separador estándar de celda), o"
+
+#: ../../panes/editor.rst:117
+msgid "``# <codecell>`` (IPython notebook cell separator)"
+msgstr "``# <codecell>`` (separador de celdas de notebook IPython)"
+
+#: ../../panes/editor.rst:119
+#, python-format
+msgid "Providing a description to the right of the separator will give that cell its own name in the :doc:`outline`. You can also create \"subsections\" by adding more ``%`` signs to the cell separator, e.g. ``# %%%`` to create a level 2 subsection, ``# %%%%`` for level 3, etc. This displays multiple levels in the :doc:`outline` pane."
+msgstr "Proporcionar una descripción a la derecha del separador dará a esa celda su propio nombre en el :doc:`outline`. También puedes crear \"subsecciones\" añadiendo más signos de ``%`` al separador de celda, por ejemplo ``# %%%`` para crear una subsección de nivel 2, ``# %%%%`` para el nivel 3, etc. Esto muestra varios niveles en el panel :doc:`outline`."
+
+#: ../../panes/editor.rst:126
+msgid "This only affects how the cell is displayed in the :doc:`outline`, and doesn't affect running it in the Editor."
+msgstr "Esto solo afecta a cómo se muestra la celda en el :doc:`outline`, y no afecta a ejecutarla en el Editor."
+
+#: ../../panes/editor.rst:128
+msgid "To run the code in a cell, use :menuselection:`Run --> Run cell`, the :guilabel:`Run cell` button in the toolbar or the keyboard shortcut (:kbd:`Ctrl-Enter`/:kbd:`Cmd-Return` by default). You can also run a cell and then jump to the next one, letting you quickly step through multiple cells, using :menuselection:`Run --> Run cell and advance` (:kbd:`Shift-Enter` by default)."
+msgstr "Para ejecutar el código en una celda, usa :menuselection:`Ejecutar --> Ejecutar la celda`, el botón :guilabel:`Ejecutar la celda` actual en la barra de herramientas o el atajo de teclado (:kbd:`Ctrl-Enter`/:kbd:`Cmd-Return` por defecto). También puedes ejecutar una celda y luego saltar a la siguiente, permitiéndote pasar rápidamente por varias células, usando :menuselection:`Ejecutar --> Ejecutar la celda y avanzar` (:kbd:`Shift-Enter` por defecto)."
+
+#: ../../panes/editor.rst:133
+msgid "Automatic formatting"
+msgstr "Formato automático"
+
+#: ../../panes/editor.rst:135
+msgid "The Editor has built-in support for automatically formatting your code using several popular tools, including `Autopep8 <https://github.com/hhatto/autopep8>`_ and `Black <https://black.readthedocs.io/en/stable/>`_. The :guilabel:`Format file or selection with {tool}` command in the :guilabel:`Source` or context menu will format either the selected fragment (if text is selected) or the entire active file."
+msgstr "El editor tiene soporte integrado para formatear automáticamente tu código usando varias herramientas populares, incluyendo `Autopep8 <https://github.com/hhatto/autopep8>`_ y `Black <https://black.readthedocs.io/en/stable/>`_. El comando :guilabel:`Formatear archivo o selección con {tool}`, en el :guilabel:`Source` o en el menú contextual, formatearán el fragmento seleccionado (si se selecciona el texto) o todo el archivo activo."
+
+#: ../../panes/editor.rst:141
+msgid "You can have the Editor automatically autoformat a file every time you save your work. To set this up, go to :menuselection:`Preferences --> Completion and linting --> Code style and formatting --> Code formatting` and check the :guilabel:`Autoformat files on save` option."
+msgstr "Puedes tener el Editor automáticamente para autoformatear un archivo cada vez que guardes tu trabajo. Para configurarlo, ve a :menuselection:`Preferencias --> Completado y análisis del código --> Estilo y formato de código --> Formato de código` y activa la opción :guilabel:`Autoformatear archivos al guardar`."
+
+#: ../../panes/editor.rst:151
+msgid "Running code"
+msgstr "Ejecutar código"
+
+#: ../../panes/editor.rst:153
+msgid "The Editor lets you run an entire file as well as specific lines, selections or cells."
+msgstr "El Editor te permite ejecutar un archivo completo, así como líneas específicas, selecciones o celdas."
+
+#: ../../panes/editor.rst:155
+msgid "As your code is running,"
+msgstr "Mientras tu código se ejecuta,"
+
+#: ../../panes/editor.rst:157
+msgid "The :doc:`ipythonconsole` will display output and errors."
+msgstr "La :doc:`ipythonconsole` mostrará salida y errores."
+
+#: ../../panes/editor.rst:158
+msgid "The :doc:`variableexplorer` allows you to browse and interact with the objects generated."
+msgstr "El :doc:`variableexplorer` te permite navegar e interactuar con los objetos generados."
+
+#: ../../panes/editor.rst:159
+msgid "The :doc:`plots` pane renders the figures and images created."
+msgstr "El panel :doc:`plots` muestra las figuras e imágenes creadas."
+
+#: ../../panes/editor.rst:163
+msgid "Run file"
+msgstr "Ejecutar archivo"
+
+#: ../../panes/editor.rst:165
+msgid "Run an entire Editor file using the :menuselection:`Run --> Run` menu item, the :guilabel:`Run file` toolbar button or the :kbd:`F5` key. Use :menuselection:`Run --> Re-Run last script` to re-run the most recent file executed with the above."
+msgstr "Ejecuta un archivo completo del Editor usando el elemento del menú :menuselection:`Ejecutar --> Ejecutar`, el botón de la barra de herramientas :guilabel:`Ejecutar archivo` o la tecla :kbd:`F5`. Usa :menuselection:`Ejecutar --> Ejecutar de nuevo el último archivo` para volver a ejecutar el archivo más reciente ejecutado con el anterior."
+
+#: ../../panes/editor.rst:170
+msgid "Run line/selection"
+msgstr "Ejecutar línea/selección"
+
+#: ../../panes/editor.rst:172
+msgid "You can execute the current line—or multiple selected lines—using the :guilabel:`Run selection or current line` option from the toolbar or the :menuselection:`Run` menu, as well as with the :kbd:`F9` key. After running the current line, the cursor automatically advances to the next one, so you can step through your code line by line. Unlike :guilabel:`Run file`, the executed lines are shown in the :doc:`ipythonconsole`."
+msgstr "Puedes ejecutar la línea actual o varias líneas seleccionadas usando la opción :guilabel:`Ejecutar selección o línea actual` desde la barra de herramientas o en el menú :menuselection:`Ejecutar`, así como con la tecla :kbd:`F9`. Después de ejecutar la línea actual, el cursor avanza automáticamente a la siguiente, así que puedes pasar a través de tu código línea por línea. A diferencia de :guilabel:`Ejecutar archivo`, las líneas ejecutadas se muestran en la :doc:`ipythonconsole`."
+
+#: ../../panes/editor.rst:178
+msgid "Run cell"
+msgstr "Ejecutar celda"
+
+#: ../../panes/editor.rst:180
+msgid "To run a cell, place your cursor inside it and use the :menuselection:`Run --> Run cell` menu item, the :guilabel:`Run current cell` toolbar button or the :kbd:`Ctrl-Enter` / :kbd:`Cmd-Return` keyboard shortcut. Use :guilabel:`Run cell and advance` in the :guilabel:`Run` menu/toolbar or :kbd:`Shift-Enter` to jump to the next cell after running, useful for stepping through cells quickly."
+msgstr "Para ejecutar una celda, coloca tu cursor dentro de ella y usa el elemento de menú :menuselection:`Ejecutar --> Ejecutar la celda`, el botón de la barra de herramientas :guilabel:`Ejecutar la celda actual` o el atajo de teclado :kbd:`Ctrl-Enter` / :kbd:`Cmd-Return`. Usa :guilabel:`Ejecutar la celda y avanzar a la siguiente` en el menú/barra de herramientas :guilabel:`Ejecutar` o :kbd:`Shift-Enter` para saltar a la siguiente celda después de ejecutar, esto es útil para atravesar rápidamente las celdas."
+
+#: ../../panes/editor.rst:185
+msgid "Run configuration"
+msgstr "Configuración de ejecución"
+
+#: ../../panes/editor.rst:187
+msgid "You can use the :guilabel:`Run configuration per file` dialog to set each file's working directory, console mode (current, dedicated or external), command line arguments, execution options (clear all variables, run in an existing/empty namespace, debug on error), and more."
+msgstr "Puedes utilizar el cuadro de diálogo :guilabel:`Configuración de ejecución por archivo` para establecer el directorio de trabajo de cada archivo, el modo de consola (actual, dedicada o terminal de comandos del sistema), argumentos de línea de comandos, opciones de ejecución (borrar todas las variables, ejecutar en un espacio de nombres existente/vacío, depurar en un error) y más."
+
+#: ../../panes/editor.rst:192
+msgid "To access it, click :menuselection:`Run --> Configuration per file...` or press :kbd:`Ctrl-F6` / :kbd:`Cmd-F6`."
+msgstr "Para acceder a él, haz clic en :menuselection:`Ejecutar --> Configuración por archivo...` o pulsa :kbd:`Ctrl-F6` / :kbd:`Cmd-F6`."
+
+#: ../../panes/editor.rst:198
+msgid "Code navigation"
+msgstr "Navegación por código"
+
+#: ../../panes/editor.rst:201
+msgid "Find and replace"
+msgstr "Buscar y reemplazar"
+
+#: ../../panes/editor.rst:203
+msgid "To search for text in the current file, use :menuselection:`Search --> Find text` or :kbd:`Ctrl-F` / :kbd:`Cmd-F`, and to replace it, use :menuselection:`Search --> Replace text` or :kbd:`Ctrl-R` / :kbd:`Cmd-R`. Typing your search string in the resulting panel below the Editor highlights each result and counts the total. Navigate between matches with the :guilabel:`Find Previous` and :guilabel:`Find Next` buttons in the find/replace panel, their corresponding entries in the :guilabel:`Search` menu, or use the :kbd:`F2` and :kbd:`F3` keys. Use the :guilabel:`.*` button to process search text as a `regular expression <https://docs.python.org/3/library/re.html>`_, :guilabel:`Aa` to treat it as case-sensitive and :guilabel:`[–]` to only match whole words (e.g. for ``data``, match ``data()`` but not ``dataframe``)."
+msgstr "Para buscar texto en el archivo actual, usa :menuselection:`Buscar --> Buscar texto` o :kbd:`Ctrl-F` / :kbd:`Cmd-F`, y para reemplazarlo, usa :menuselection:`Buscar --> Reemplazar texto` o :kbd:`Ctrl-R` / :kbd:`Cmd-R`. Escribiendo la cadena de búsqueda en el panel resultante debajo del Editor resalta cada resultado y cuenta el total. Navega entre los resultados con los botones :guilabel:`Buscar anterior` y :guilabel:`Buscar siguiente` en el panel de buscar/reemplazar, sus correspondientes entradas en el menú :guilabel:`Buscar`, o utiliza las teclas :kbd:`F2` y :kbd:`F3`. Usa :guilabel:`. *` para procesar texto de búsqueda como una `expresión regular <https://docs.python.org/3/library/re.html>`_, :guilabel:`Aa` para tratarlo como sensible a mayúsculas y :guilabel:`[–]` para que solo coincida con palabras enteras (por ejemplo, para ``data``, coincide con ``data()`` pero no con ``dataframe``)."
+
+#: ../../panes/editor.rst:213
+msgid "Go to line"
+msgstr "Ir a la línea"
+
+#: ../../panes/editor.rst:215
+msgid "The :guilabel:`Go to line` dialog allows jumping to a specific line in the active file. Open it with :menuselection:`Search --> Go to line` or :kbd:`Ctrl-L` / :kbd:`Cmd-L`, type the line number you want to scroll to and press :kbd:`Enter` (or click :guilabel:`OK`)."
+msgstr "El diálogo :guilabel:`Ir a la línea` permite saltar a una línea específica en el archivo activo. Abrelo con :menuselection:`Buscar --> Ir a la línea` o :kbd:`Ctrl-L` / :kbd:`Cmd-L`, escribe el número de línea al que quieres desplazarte y pulsa :kbd:`Enter` (o haz clic en :guilabel:`OK`)."
+
+#: ../../panes/editor.rst:221
+msgid "It also shows the current line number and total line count in the file."
+msgstr "También muestra el número de línea actual y el recuento total de líneas en el archivo."
+
+#: ../../panes/editor.rst:225
+msgid "Class/function selector"
+msgstr "Selector de clase/función"
+
+#: ../../panes/editor.rst:227
+msgid "This panel, activated under :menuselection:`Source --> Show selector for classes and functions`, displays (as applicable) the name of the cell, function/method and class the Editor cursor is located inside. Use its dropdowns to view and jump to the functions, methods and classes in the current file."
+msgstr "Este panel, activado bajo :menuselection:`Código fuente--> Mostrar selector para clases y funciones`, muestra (como aplicable) el nombre de la celda, la función/método y la clase en la que el cursor del Editor se encuentra dentro. Utiliza el menú desplegable para ver y saltar a las funciones, métodos y clases del archivo actual."
+
+#: ../../panes/editor.rst:237
+msgid "Code analysis and completions"
+msgstr "Completado y análisis del código"
+
+#: ../../panes/editor.rst:239
+msgid "Spyder uses the `Language Server Protocol <https://microsoft.github.io/language-server-protocol/>`_ (LSP) to provide code completion and linting for the Editor, similar to VSCode, Neovim, and other popular editors/IDEs."
+msgstr "Spyder utiliza el `Protocolo de Servidor de Idioma <https://microsoft.github.io/language-server-protocol/>`_ (LSP) para proporcionar el completado de código y linting para el Editor, similar a VSCode, Neovim, y otros editores/IDE populares."
+
+#: ../../panes/editor.rst:243
+msgid "Many issues with completion and linting are outside of Spyder's control, and are either limitations with the LSP or the code that is being introspected, but some can be worked around. See :ref:`code-completion-problems-ref` for troubleshooting steps."
+msgstr "Muchos problemas con el completado y el linting están fuera del control de Spyder y son o bien limitaciones con el LSP o el código que se está introduciendo, pero algunas pueden ser trabajadas. Vea :ref:`code-completion-problems-ref` para los pasos de solución de problemas."
+
+#: ../../panes/editor.rst:246
+msgid "Python is supported out of the box, and advanced users can add completion and linting support for other languages by setting up LSP servers for them under :menuselection:`Preferences --> Completion and Linting --> Other languages`."
+msgstr "Python está soportado por defecto, y los usuarios avanzados pueden añadir soporte de completado y linting para otros idiomas configurando los servidores LSP en :menuselection:`Preferencias --> Completado y análisis de código --> Otros idiomas`."
+
+#: ../../panes/editor.rst:250
+msgid "Code completion"
+msgstr "Completado de código"
+
+#: ../../panes/editor.rst:252
+msgid "Automatic code completion as you type is enabled by default in the Editor, and can also be triggered manually with :kbd:`Ctrl-Space`/:kbd:`Cmd-Space`, showing you possible completions (with pop-up help for each) and available code snippets. For example, typing ``cla`` will display the keyword ``class``, the decorator ``classmethod`` and two built-in snippets with class templates. Select the desired completion with the arrow keys and :kbd:`Enter`, or by double clicking."
+msgstr "El completado automático de código está activado de forma predeterminada en el Editor mientras escribes, pero también puede ser activado manualmente con :kbd:`Ctrl-Space`/:kbd:`Cmd-Space`, el cual muestra las posibles formas de completar (con una ayuda emergente para cada una) y los fragmentos de código disponibles. Por ejemplo, escribir ``cla`` mostrará la palabra clave ``class``, el decorador ``classmethod`` y dos fragmentos incorporados con plantillas de clases. Selecciona la terminación deseada con las teclas de flecha y :kbd:`Enter`, o haciendo doble clic."
+
+#: ../../panes/editor.rst:259
+msgid "You can enable or disable on-the-fly code completion, as well as modify when it is triggered and what results are shown, under :menuselection:`Preferences --> Completion and Linting --> General --> Completions`. Spyder also allows you to define custom completion snippets to use, in addition to the ones offered by the LSP, under :menuselection:`Preferences --> Completion and Linting --> Advanced`."
+msgstr "Puedes activar o desactivar el completado de código sobre la marcha, así como modificar cuando se activa y qué resultados se muestran, bajo :menuselection:`Preferencias --> Completado y análisis del código --> General --> Completado`. Spyder también te permite definir fragmentos de completado personalizados a utilizar, además de los ofrecidos por el LSP, bajo :menuselection:`Preferencias --> Completado y análisis del código --> Opciones avanzadas`."
+
+#: ../../panes/editor.rst:264
+msgid "Linting and code style"
+msgstr "Linting y estilo de código"
+
+#: ../../panes/editor.rst:266
+msgid "Spyder can optionally highlight syntax errors, style issues, and other potential problems with your code in the Editor, which can help you spot bugs quickly and make your code easier to read and understand."
+msgstr "Spyder puede resaltar opcionalmente errores de sintaxis, problemas de estilo y otros problemas potenciales con tu código en el Editor, lo que puede ayudarte a detectar errores rápidamente y hacer que tu código sea más fácil de leer y entender."
+
+#: ../../panes/editor.rst:271
+msgid "The Editor's basic linting, powered by `Pyflakes <https://github.com/PyCQA/pyflakes>`_, warns of syntax errors and likely bugs in your code. It is on by default, and can be disabled or customized under :menuselection:`Preferences --> Completion and Linting --> Linting`."
+msgstr "El linting básico del Editor, desarrollado por `Pyflakes <https://github.com/PyCQA/pyflakes>`_, advierte los errores de sintaxis y posibles errores en tu código. Está activado por defecto, y puede ser deshabilitado o personalizado bajo :menuselection:`Preferencias --> Completado y análisis de código --> Análisis de código`."
+
+#: ../../panes/editor.rst:277
+msgid "Code style analysis, powered by `Pycodestyle <https://pycodestyle.pycqa.org/en/stable/>`_, flags deviations from the style conventions in :pep:`8`. It is not active by default, but you can enable it and customize the `Pycodestyle error codes <https://pycodestyle.pycqa.org/en/stable/intro.html#error-codes>`_ shown with the options under :menuselection:`Preferences --> Completion and Linting --> Code style and formatting --> Code Style`."
+msgstr "El análisis de estilo de código, desarrollado por `Pycodestyle <https://pycodestyle.pycqa.org/en/stable/>`_, señala las desviaciones de las convenciones de estilo en :pep:`8`. No está activo por defecto, pero puedes activarlo y personalizar los `códigos de error Pycodestyle <https://pycodestyle.pycqa.org/en/stable/intro.html#error-codes>`_ mostrados con las opciones :menuselection:`Preferencias --> Completado y análisis de código --> Estilo y formato de código --> Estilo del código`."
+
+#: ../../panes/editor.rst:285
+msgid "Introspection features"
+msgstr "Características de introspección"
+
+#: ../../panes/editor.rst:287
+msgid "If there's a function, class or variable for which you would like to check its definition, you need to :kbd:`Ctrl`/:kbd:`Cmd`-click its name in the Editor (or click its name and press :kbd:`Ctrl-G` / :kbd:`Cmd-G` to jump to the file and line where it is declared."
+msgstr "Si hay una función, clase o variable para la que desea comprobar su definición, necesitas hacer :kbd:`Ctrl`/:kbd:`Cmd`-clic en su nombre en el Editor (o haz clic en su nombre y pulsa :kbd:`Ctrl-G` / :kbd:`Cmd-G` para saltar al archivo y línea donde se declara."
+
+#: ../../panes/editor.rst:292
+msgid "You can hover over the name of an object for pop-up help, as :ref:`described in the Help pane docs <help-hover-hints>`."
+msgstr "Puedes pasar por encima del nombre de un objeto para ayuda emergente, como se describió :ref:`en la documentación del panel de ayuda <help-hover-hints>`."
+
+#: ../../panes/editor.rst:297
+msgid "Finally, if you type the name of a function, method or class constructor and then an open parenthesis, a calltip will pop up which shows the function's parameters as you type them, as well as a summary of its documentation. These features can be enabled and customized under :menuselection:`Preferences --> Completion and Linting --> Introspection`."
+msgstr "Finalmente, si escribes el nombre de una función, método o constructor de clase y luego un paréntesis abierto, aparecerá un calltip que mostrará los parámetros de la función a medida que los escribas, así como un resumen de su documentación. Estas características pueden ser habilitadas y personalizadas bajo :menuselection:`Preferencias --> Completado y análisis de código --> Introspección`."
+
+#: ../../panes/editor.rst:304
+msgid "Keyboard shortcuts"
+msgstr "Atajos de teclado"
+
+#: ../../panes/editor.rst:306
+msgid "To view the Editor's primary keyboard shortcuts, consult its section under :menuselection:`Help --> Shortcuts Summary`. The full list can be browsed, searched and customized (on double-click) in :menuselection:`Preferences --> Keyboard shortcuts`."
+msgstr "Para ver los atajos de teclado primarios del Editor, consulta la sección bajo :menuselection:`Ayuda --> Resumen de atajos`. La lista completa se puede buscar, buscar y personalizar (en doble clic) en :menuselection:`Preferencias --> Atajos de teclado`."
+
+#: ../../panes/editor.rst:315 ../../panes/findinfiles.rst:68
+#: ../../panes/outline.rst:57 ../../panes/projects.rst:65
+msgid ":doc:`fileexplorer`"
+msgstr ":doc:`fileexplorer`"
+
+#: ../../panes/editor.rst:316 ../../panes/fileexplorer.rst:102
+msgid ":doc:`findinfiles`"
+msgstr ":doc:`findinfiles`"
+
+#: ../../panes/editor.rst:318 ../../panes/fileexplorer.rst:103
+#: ../../panes/outline.rst:58
+msgid ":doc:`projects`"
+msgstr ":doc:`projects`"
+
+#: ../../panes/editor.rst:319 ../../panes/profiler.rst:102
+msgid ":doc:`pylint`"
+msgstr ":doc:`pylint`"
+
+#: ../../panes/fileexplorer.rst:3
+msgid "Files"
+msgstr "Archivos"
+
+#: ../../panes/fileexplorer.rst:5
+msgid "The **Files** pane is a filesystem and directory browser built right into Spyder. You can view and filter files according to their type and extension, open them with the :doc:`editor` or an external tool, and perform many common operations."
+msgstr "El panel **Archivos** es un navegador de archivos y directorios construido directamente en Spyder. Puedes ver y filtrar archivos de acuerdo a su tipo y extensión, abrirlos con el :doc:`editor` o con una herramienta externa, y realizar muchas operaciones comunes."
+
+#: ../../panes/fileexplorer.rst:17
+msgid "File operations"
+msgstr "Operaciones de archivo"
+
+#: ../../panes/fileexplorer.rst:19
+msgid "To browse the files on your system, use the arrows at the top of the pane. You can expand/collapse the folders in the pane to display the files and subdirectories hierarchically. Double-clicking a folder will open it, showing the files inside and making it your working directory."
+msgstr "Para navegar por los archivos de tu sistema, usa las flechas en la parte superior del panel. Puedes expandir/contraer las carpetas en el panel para mostrar los archivos y subdirectorios jerárquicamente. Al hacer doble clic en una carpeta se abrirá, mostrando los archivos dentro y haciéndolos tu directorio de trabajo."
+
+#: ../../panes/fileexplorer.rst:26
+msgid "To open a file in the :guilabel:`Editor` from the :guilabel:`Files` pane, double-click its name. If you right-click over it, you will see a context menu that allows you to access a number of functions, including running scripts; creating, renaming, moving, deleting files; and opening them in your computer's file manager."
+msgstr "Para abrir un archivo en el :guilabel:`Editor` desde el panel :guilabel:`Archivos`, haz doble clic en su nombre. Si haces clic con el botón derecho sobre él, verás un menú contextual que te permite acceder a una serie de funciones, incluyendo ejecutar scripts; crear, renombrar, mover, eliminar archivos; y abrirlos en el gestor de archivos de su computadora."
+
+#: ../../panes/fileexplorer.rst:32
+msgid "You can copy and paste one or several files to and from the pane, and copy their absolute or relative paths to the clipboard as text. If copying the paths for multiple files, they will be automatically formatted so you can paste them directly into a Python list."
+msgstr "Puedes copiar y pegar uno o varios archivos desde y hacia el panel, y copiar sus rutas absolutas o relativas al portapapeles como texto. Si se copian las rutas para múltiples archivos, se formatearán automáticamente para que se puedan pegar directamente en una lista de Python."
+
+#: ../../panes/fileexplorer.rst:44
+msgid "Version control support"
+msgstr "Soporte de control de versiones"
+
+#: ../../panes/fileexplorer.rst:46
+msgid "The :guilabel:`Files` pane allows you to perform basic operations with the `Git`_ distributed version control system, like committing your changes and browsing the repository a given file or folder is part of. This is :ref:`particularly useful<vcs-section>` when you're working in Spyder :doc:`projects`."
+msgstr "El panel :guilabel:`Archivos` te permite realizar operaciones básicas con el sistema de control de versiones distribuidas `Git`_ como hacer \"commit\" a los cambios y navegar por el repositorio del que forma parte un archivo o carpeta determinado. Esto es :ref:`particularmente útil<vcs-section>` cuando estás trabajando en Spyder :doc:`projects`."
+
+#: ../../panes/fileexplorer.rst:58 ../../panes/ipythonconsole.rst:65
+#: ../../panes/outline.rst:16 ../../panes/plots.rst:20
+#: ../../panes/pylint.rst:50 ../../panes/variableexplorer.rst:103
+msgid "Options menu"
+msgstr "Menú de opciones"
+
+#: ../../panes/fileexplorer.rst:60
+msgid "The options menu in the top right of the :guilabel:`Files` pane offers several ways to customize how your files are displayed."
+msgstr "El menú de opciones en la parte superior derecha del panel :guilabel:`Archivos` ofrece varias maneras de personalizar cómo se muestran tus archivos."
+
+#: ../../panes/fileexplorer.rst:62
+msgid "By default, the pane displays the contents of your working directory without filtering. However, it can filter the list to show only files matching the patterns set under :guilabel:`Show filenames with these extensions...`, if you toggle the :guilabel:`Filter filenames` button in the pane toolbar."
+msgstr "Por defecto, el panel muestra el contenido de su directorio de trabajo sin filtrar. Sin embargo, puedes filtrar la lista para mostrar sólo archivos que coincidan con los patrones establecidos bajo :guilabel:`Mostrar nombres de archivo con estas extensiones...`, si activa el botón :guilabel:`Filtrar nombre de archivo` en la barra de herramientas del panel."
+
+#: ../../panes/fileexplorer.rst:68
+msgid "You can also activate the :guilabel:`Show hidden files` option, which will display files that are invisible by default in your operating system."
+msgstr "También puedes activar la opción :guilabel:`Mostrar archivos ocultos`, que mostrará archivos que son invisibles por defecto en su sistema operativo."
+
+#: ../../panes/fileexplorer.rst:70
+msgid "Additionally, you can change which file attributes you want to see by hiding or displaying the :guilabel:`Type`, :guilabel:`Size` and :guilabel:`Date Modified` columns using the corresponding menu options."
+msgstr "Además, puedes cambiar qué atributos de archivo deseas ver ocultando o mostrando las columnas :guilabel:`Tipo`, :guilabel:`Tamaño` y :guilabel:`Fecha de modificación` usando las opciones de menú correspondientes."
+
+#: ../../panes/fileexplorer.rst:75
+msgid "The menu also gives you the option to open files and directories with a single instead of a double click, to suit your preferences."
+msgstr "El menú también te da la opción de abrir archivos y directorios con un solo clic en lugar de un doble clic, para que se adapte a tus preferencias."
+
+#: ../../panes/fileexplorer.rst:81
+msgid "File associations"
+msgstr "Asociaciones de archivos"
+
+#: ../../panes/fileexplorer.rst:83
+msgid ":guilabel:`Files` allows you to associate different external applications with specific file extensions they can open. Under the :guilabel:`File associations` tab of the :guilabel:`Files` preferences pane, you can add file types and set the external program used to open each of them by default."
+msgstr ":guilabel:`Archivos` te permite asociar diferentes aplicaciones externas con extensiones específicas de archivo que pueden abrir. Bajo la pestaña :guilabel:'Asociaciones de archivos' del panel de preferencias :guilabel:'Archivos', puedes añadir tipos de archivo y establecer el programa externo usado para abrir cada uno de ellos por defecto."
+
+#: ../../panes/fileexplorer.rst:89
+msgid "Once you've set this up, files will automatically launch in the associated application when opened from Spyder's :guilabel:`Files` pane. Additionally, when you right-click a file, you will find an :guilabel:`Open with...` option that will allow you to select from the applications associated with this extension."
+msgstr "Una vez que lo hayas configurado, los archivos se ejecutarán automáticamente en la aplicación asociada cuando se abran desde el panel :guilabel:`Archivos` de Spyder. Además, cuando haces clic derecho en un archivo, encontrarás un :guilabel:`Abrir con...` que te permitirá seleccionar entre las aplicaciones asociadas a esta extensión."
+
+#: ../../panes/findinfiles.rst:3
+msgid "Find"
+msgstr "Buscar"
+
+#: ../../panes/findinfiles.rst:5
+msgid "The **Find** pane allows you to search the content of text files in a user-defined location, with advanced features to filter your results."
+msgstr "El panel **Buscar** te permite buscar el contenido de los archivos de texto en una ubicación definida por el usuario, con características avanzadas para filtrar tus resultados."
+
+#: ../../panes/findinfiles.rst:14
+msgid "Using the Find pane"
+msgstr "Usar el panel Buscar"
+
+#: ../../panes/findinfiles.rst:16
+msgid "To search for text in the Find pane, enter it in the field in the top left and press the search button. This will allow you to view and navigate through all the occurrences of your search text in your working directory. You can expand or collapse the search results to view the matches in each file. Clicking on a match will automatically open the file and highlight the line where the text was found."
+msgstr "Para buscar texto en el panel Buscar, ingrésalo en el campo de la parte superior izquierda y pulsa el botón de búsqueda. Esto te permitirá ver y navegar a través de todas las ocurrencias de tu texto de búsqueda en el directorio de trabajo. Puedes expandir o contraer los resultados de la búsqueda para ver los resultados en cada archivo. Al hacer clic en una coincidencia se abrirá automáticamente el archivo y se resaltará la línea donde se encontró el texto."
+
+#: ../../panes/findinfiles.rst:24
+msgid "If you want to change the scope of your search, select another directory, project or file in the :guilabel:`Search in` menu. The locations that you select for your search will be stored in the list so you can access them easily in the future. To erase all of these saved directories, select the :guilabel:`Clear the list` option from the dropdown menu in the :guilabel:`Search in` field."
+msgstr "Si quieres cambiar el alcance de tu búsqueda, selecciona otro directorio, proyecto o archivo en el menú :guilabel:`Buscar` . Las ubicaciones que selecciones para tu búsqueda se almacenarán en la lista para poder acceder fácilmente a ellas en el futuro. Para borrar todos estos directorios guardados selecciona la opción :guilabel:`Limpiar la lista` en el menú desplegable en el campo :guilabel:`Buscar en`."
+
+#: ../../panes/findinfiles.rst:35
+msgid "Choosing search options"
+msgstr "Elegir opciones de búsqueda"
+
+#: ../../panes/findinfiles.rst:37
+msgid "You can select from a number of options to enable searches as broad or refined as you need."
+msgstr "Puedes seleccionar entre una serie de opciones para permitir búsquedas tan amplias o refinadas como necesites."
+
+#: ../../panes/findinfiles.rst:39
+msgid "To enable case sensitivity, which only returns matches with identical capitalization to your search text, toggle the :guilabel:`Aa` button on."
+msgstr "Para habilitar la sensibilidad a mayúsculas, que solo devuelve coincidencias con una mayúscula idéntica al texto de búsqueda, activa el botón :guilabel:`Aa`."
+
+#: ../../panes/findinfiles.rst:44
+msgid "To parse your search string as a `regular expression`_, enable the :guilabel:`.*` button."
+msgstr "Para analizar tu cadena de búsqueda como una `expresión regular`_, activa el botón :guilabel:`.*`."
+
+#: ../../panes/findinfiles.rst:51
+msgid "To exclude certain filenames, extensions or directories from your search, click the :guilabel:`Plus` button to display the advanced options for the pane, and then enter them in the :guilabel:`Exclude` text box."
+msgstr "Para excluir ciertos nombres de archivos, extensiones o directorios de su búsqueda, haz clic en el botón :guilabel:`Plus` para mostrar las opciones avanzadas para el panel, y luego introdúcelas en el cuadro de texto :guilabel:`Exclude`."
+
+#: ../../panes/findinfiles.rst:56
+msgid "Finally, to change the number of matches displayed, select the :guilabel:`Set maximum number of results` option under the pane's Options menu in the top right."
+msgstr "Finalmente, para cambiar el número de coincidencias mostradas, selecciona la opción :guilabel:`Establecer número máximo de resultados` en el menú Opciones del panel en la parte superior derecha."
+
+#: ../../panes/help.rst:3
+msgid "Help"
+msgstr "Ayuda"
+
+#: ../../panes/help.rst:5
+msgid "You can use the **Help** pane to find, render and display rich documentation for any object with a docstring, including modules, classes, functions and methods. This allows you to access documentation easily directly from Spyder, without having to interrupt your workflow."
+msgstr "Puedes usar el panel de **Ayuda** para encontrar, renderizar y mostrar la documentación enriquecida para cualquier objeto con una cadena de documentación, incluyendo módulos, clases, funciones y métodos. Esto te permite acceder fácilmente a la documentación directamente desde Spyder, sin tener que interrumpir tu flujo de trabajo."
+
+#: ../../panes/help.rst:11
+msgid "You can also access Spyder's tutorial from here, which will guide you through some basic steps for using its key features."
+msgstr "También puedes acceder al tutorial de Spyder desde aquí, que te guiará a través de algunos pasos básicos para usar sus características clave."
+
+#: ../../panes/help.rst:21
+msgid "Getting help"
+msgstr "Obtener ayuda"
+
+#: ../../panes/help.rst:23
+msgid "Help can be retrieved both by static analysis of open files in the :doc:`editor`, or by dynamically inspecting an object in an :doc:`ipythonconsole`. You can trigger help manually by pressing the configurable help shortcut (:kbd:`Ctrl-I` by default)."
+msgstr "La ayuda se puede recuperar tanto mediante el análisis estático de los archivos abiertos en el :doc:`editor`, o inspeccionando dinámicamente un objeto en una :doc:`ipythonconsole`. Puedes activar la ayuda manualmente pulsando el atajo de ayuda configurable (:kbd:`Ctrl-I` por defecto)."
+
+#: ../../panes/help.rst:29
+msgid "You can also manually enter the object's name into the :guilabel:`Object` textbox at the top of the pane, if :guilabel:`Console` is selected as the :guilabel:`Source`."
+msgstr "También puedes introducir manualmente el nombre del objeto en el cuadro de texto :guilabel:`Objeto` en la parte superior del panel, si :guilabel:`Terminal` es seleccionado como el :guilabel:`Origen`."
+
+#: ../../panes/help.rst:34
+msgid "Automatic help can be individually enabled for both the :guilabel:`Editor` and the :guilabel:`Console` under :menuselection:`Preferences --> Help --> Automatic Connections`, and turned on and off dynamically via the lock icon in the top right corner of the :guilabel:`Help` pane. If enabled, simply typing a left parenthesis (``(``) after a function or method name will show its associated help."
+msgstr "La ayuda automática puede ser habilitada individualmente tanto para el :guilabel:`Editor` como para la :guilabel:`Terminal` bajo :menuselection:`Preferencias --> Ayuda --> Conexiones automáticas`, y se activa y desactiva dinámicamente mediante el icono de bloqueo en la esquina superior derecha del panel :guilabel:`Ayuda`. Si está habilitado, simplemente tecleando un paréntesis izquierdo (``(``) después de una función o nombre del método te mostrará su ayuda asociada."
+
+#: ../../panes/help.rst:44
+msgid "Understanding help modes"
+msgstr "Entender los modos de ayuda"
+
+#: ../../panes/help.rst:46
+msgid "You can use the options menu (:guilabel:`Hamburger` icon) in the top right of the :guilabel:`Help` pane to toggle the help display mode."
+msgstr "Puedes usar el menú de opciones ( icono :guilabel:`Hamburguesa`) en la parte superior derecha del panel :guilabel:`Ayuda` para cambiar el modo de visualización de ayuda."
+
+#: ../../panes/help.rst:48
+msgid ":guilabel:`Rich Text` mode renders the object's docstrings with ``Sphinx``, :guilabel:`Plain Text` mode displays the docstring without formatting while :guilabel:`Show Source` displays the docstring inline with the code for the selected object, or any Python portion of it (if the object is not pure Python). The latter can be useful when docstrings are not available or insufficient to document the object."
+msgstr "El modo :guilabel:`Texto enriquecido` renderiza las cadenas de documentación del objeto con ``Sphinx``, El modo :guilabel:`Texto plano` muestra la docstring sin formatear, mientras que :guilabel:`Mostrar código fuente` muestra la docstring en línea con el código para el objeto seleccionado, o cualquier porción de Python (si el objeto no es Python puro). Esto último puede ser útil cuando los docstrings no están disponibles o son insuficientes para documentar el objeto."
+
+#: ../../panes/help.rst:59
+msgid "Getting help by hovering"
+msgstr "Obtener ayuda al pasar el cursor"
+
+#: ../../panes/help.rst:61
+msgid "You can also get summary help for objects by hovering over them in the :guilabel:`Editor`. Clicking the hover popup will open the full documentation in the :guilabel:`Help` pane."
+msgstr "También puedes obtener ayuda resumida para objetos pasando el cursor sobre ellos en el :guilabel:`Editor`. Al hacer clic en la ventana emergente se abrirá la documentación completa en el panel de :guilabel:`Ayuda`."
+
+#: ../../panes/help.rst:71
+msgid "Control automatic import"
+msgstr "Controlar importación automática"
+
+#: ../../panes/help.rst:73
+msgid "When you get help in the :guilabel:`IPython Console` for an object that has not been previously imported, it is automatically loaded in Spyder's own internal interpreter so that documentation can be shown when available. This can be disabled in the :guilabel:`Help` pane's top-right options menu so that only documentation from imported objects is displayed."
+msgstr "Cuando obtienes ayuda en la :guilabel:`IPython Console` para un objeto que no ha sido importado previamente, se carga automáticamente en el intérprete interno de Spyder para que la documentación pueda mostrarse cuando esté disponible. Esto puede deshabilitarse en el menú de opciones de :guilabel:`Ayuda` en la parte superior derecha del panel para que sólo se muestre la documentación de objetos importados."
+
+#: ../../panes/help.rst:84
+msgid ":doc:`onlinehelp`"
+msgstr ":doc:`onlinehelp`"
+
+#: ../../panes/historylog.rst:3
+msgid "History"
+msgstr "Historial"
+
+#: ../../panes/historylog.rst:5
+msgid "With the **History** pane, you can view the recent code and commands you've entered into any :doc:`ipythonconsole`, along with their timestamp."
+msgstr "Con el panel **Historial** puedes ver el código y comandos recientes que has introducido en cualquier :doc:`ipythonconsole`, junto con su marca de tiempo."
+
+#: ../../panes/historylog.rst:14
+msgid "Using the History pane"
+msgstr "Usar el panel Historial"
+
+#: ../../panes/historylog.rst:16
+msgid "Navigating the :guilabel:`History` pane is very straightforward. Each Spyder session is marked by a date and timestamp, making it easy to remember when you executed a certain command. Statements can be selected and copied from the context menu or with the normal system shortcuts. Just like in the Editor, selecting a word or phrase displays all other occurrences, and full syntax highlighting is also supported. The last ≈1000 lines entered are stored in the pane."
+msgstr "Navegar por el panel :guilabel:`Historial` es muy sencillo. Cada sesión de Spyder está marcada por una fecha y una marca de tiempo, haciendo que sea fácil recordar cuando ejecutaste un determinado comando. Las sentencias pueden ser seleccionadas y copiadas desde el menú contextual o con los atajos normales del sistema. Al igual que en el Editor, seleccionar una palabra o frase muestra todas las demás incidencias, y también se admite el resaltado completo de sintaxis. En el panel se almacenan las últimas ≈1000 líneas."
+
+#: ../../panes/historylog.rst:26
+msgid "Options Menu"
+msgstr "Menú de opciones"
+
+#: ../../panes/historylog.rst:28
+msgid "The top-right options menu (:guilabel:`Hamburger` icon) allows you to toggle wrapping of long lines (:guilabel:`Wrap lines`), and whether the line number is displayed to the left of the text (:guilabel:`Show line numbers`)."
+msgstr "El menú de opciones de arriba a la derecha (icono :guilabel:`Hamburguesa`) te permite cambiar el ajuste de líneas largas (:guilabel:`Ajuste de línea automático`), y también si el número de línea se muestra a la izquierda del texto (:guilabel:`Mostrar números de línea`)."
+
+#: ../../panes/historylog.rst:37
+msgid "Advanced usage"
+msgstr "Uso avanzado"
+
+#: ../../panes/historylog.rst:39
+msgid "The list of commands shown in the :guilabel:`History` pane are stored in :file:`history.py` in the :file:`.spyder-py3` directory in your user home folder (by default, :file:`C:/Users/{username}` on Windows, :file:`/Users/{username}` for macOS, and typically :file:`/home/{username}` on GNU/Linux). You might need to show invisible files in order to see it on a non-Windows operating system."
+msgstr "La lista de comandos mostrados en el panel :guilabel:`Historial` se almacenan en :file:`history.py` en el directorio :file:`.spyder-py3` en tu carpeta de inicio del usuario (por defecto, :file:`C:/Users/{username}` en Windows, :file:`/Users/{username}` para macOS, y normalmente :file:`/home/{username}` en GNU/Linux). Puede que necesites mostrar archivos invisibles para poder verlos en un sistema operativo no Windows."
+
+#: ../../panes/historylog.rst:45
+msgid "While there is currently no built-in way to clear history from the Spyder interface aside from resetting preferences, you can do so by closing Spyder, deleting this file and restarting Spyder again."
+msgstr "Aunque actualmente no hay ninguna forma integrada de borrar el historial de la interfaz Spyder aparte de restablecer las preferencias, puedes hacerlo cerrando Spyder, eliminando este archivo y reiniciando Spyder de nuevo."
+
+#: ../../panes/index.rst:3
+msgid "Panes in Depth"
+msgstr "Paneles en profundidad"
+
+#: ../../panes/ipythonconsole.rst:3
+msgid "IPython Console"
+msgstr "Terminal de IPython"
+
+#: ../../panes/ipythonconsole.rst:5
+msgid "The **IPython Console** allows you to execute commands and interact with data inside `IPython`_ interpreters."
+msgstr "La **Terminal IPython** te permite ejecutar comandos e interactuar con datos dentro de los intérpretes `IPython`_."
+
+#: ../../panes/ipythonconsole.rst:12
+msgid "To launch a new IPython instance, go to :guilabel:`New console (default settings)` under the :guilabel:`Consoles` menu, or use the keyboard shortcut :kbd:`Ctrl-T` (:kbd:`Cmd-T` on macOS) when the console is focused."
+msgstr "Para lanzar una nueva instancia de IPython, vaya a :guilabel:`Nueva terminal (configuración por defecto)` en el menú :guilabel:`Terminales`, o usa el atajo de teclado :kbd:`Ctrl-T` (:kbd:`Cmd-T` en macOS) cuando la consola está focalizada."
+
+#: ../../panes/ipythonconsole.rst:17
+msgid "From the same menu, you can stop currently executing code with :guilabel:`Interrupt kernel`, clear a console's namespace with :guilabel:`Remove all variables`, or relaunch a fresh one with :guilabel:`Restart kernel`. As each console is executed in a separate process, this won't affect any others you've opened, and you will be able to easily test your code in a clean environment without disrupting your primary session."
+msgstr "Desde el mismo menú, puedes dejar de ejecutar código con el :guilabel:`Interrumpir el núcleo`, limpia el namespace de una consola con :guilabel:`Eliminar todas las variables`, o relanza una nueva con :guilabel:`Reiniciar el núcleo`. Como cada consola se ejecuta en un proceso separado, esto no afectará a ningún otro que hayas abierto, y podrás probar fácilmente tu código en un entorno limpio sin interrumpir tu sesión principal."
+
+#: ../../panes/ipythonconsole.rst:26
+msgid "Supported features"
+msgstr "Funciones disponibles"
+
+#: ../../panes/ipythonconsole.rst:28
+msgid "Any :guilabel:`IPython Console`, whether :ref:`external<connecting-external-kernel>` or started by Spyder, supports:"
+msgstr "Cualquier :guilabel:`Terminal de IPython`, ya sea :ref:`externa<connecting-external-kernel>` o iniciada por Spyder, soporta:"
+
+#: ../../panes/ipythonconsole.rst:30
+msgid "Automatic code completion"
+msgstr "Completado automático de código"
+
+#: ../../panes/ipythonconsole.rst:31
+msgid "Real-time function calltips"
+msgstr "Información sobre la función en tiempo real"
+
+#: ../../panes/ipythonconsole.rst:32
+msgid "Full GUI integration with the enhanced Spyder :doc:`Debugger<debugging>`."
+msgstr "Integración GUI completa con el :doc:`depurador<debugging>` mejorado de Spyder."
+
+#: ../../panes/ipythonconsole.rst:33
+msgid "The :doc:`variableexplorer`, with GUI-based editors for many built-in and third-party Python objects."
+msgstr "El :doc:`variableexplorer`, con editores gráficos para muchos objetos de Python incorporados y de terceros."
+
+#: ../../panes/ipythonconsole.rst:34
+msgid "Display of Matplotlib graphics in Spyder's :doc:`plots` pane, if the :guilabel:`Inline` backend is selected under :menuselection:`Preferences --> IPython console --> Graphics --> Graphics backend`, and inline in the console if :guilabel:`Mute inline plotting` is unchecked under the :guilabel:`Plots` pane's options menu."
+msgstr "Visualización de gráficos de Matplotlib en el panel de :doc:`plots` de Spyder, si se selecciona el backend :guilabel:`En línea` en :menuselection:`Preferencias ‣ Terminal de IPython ‣ Gráficas ‣ Salida gráfica`, y en línea en la consola si la opción :guilabel:`Silenciar los gráficos en línea` no está marcada en el menú de opciones del panel de :guilabel:`Gráficos`."
+
+#: ../../panes/ipythonconsole.rst:39
+msgid "For information on the features, commands and capabilities built into IPython itself, see the `IPython documentation`_."
+msgstr "Para obtener información sobre las características, comandos y capacidades incorporadas en IPython mismo, vea la `IPython documentation`_."
+
+#: ../../panes/ipythonconsole.rst:47
+msgid "Special consoles"
+msgstr "Consolas especiales"
+
+#: ../../panes/ipythonconsole.rst:49
+msgid "Spyder also supports several types of specialized consoles. A `Sympy console`_ enables creating and displaying symbolic math expressions right inside Spyder. A `Cython console`_ allows you to use the Cython language to speed up your code and call C functions directly from Python. Finally, a `Pylab console`_ loads common Numpy and Matplotlib functions by default; while this is deprecated and strongly discouraged for new code, it can still be used if necessary for legacy scripts that need it."
+msgstr "Spyder también soporta varios tipos de consolas especializadas. Una `Sympy console`_ permite crear y mostrar expresiones matemáticas simbólicas dentro de Spyder. Una `Cython console`_ te permite usar el lenguaje de Cython para acelerar tu código y llamar a funciones C directamente desde Python. Finalmente, una `Pylab console`_ carga las funciones comunes Numpy y Matplotlib por defecto; mientras que esto está obsoleto y fuertemente desaconsejado para el nuevo código, todavía puede ser usado si es necesario para scripts heredados que lo necesiten."
+
+#: ../../panes/ipythonconsole.rst:67
+msgid "The options menu allows you to inspect your current environment variables (:guilabel:`Show environment variables`), and the contents of your system's ``PATH`` (:guilabel:`Show sys.path contents`). In addition, you can have each console display how long it has been running with :guilabel:`Show elapsed time`."
+msgstr "El menú de opciones te permite inspeccionar tus variables de entorno actuales (:guilabel:`Mostrar las variables de entorno`), y los contenidos de su sistema ``PATH`` (:guilabel:`Contenidos del sys.path`). Además, puedes tener que cada consola muestre cuánto tiempo ha estado funcionando con :guilabel:`Mostrar el tiempo transcurrido`."
+
+#: ../../panes/ipythonconsole.rst:73
+msgid "You can also change the name of the current :guilabel:`IPython console` tab with the :guilabel:`Rename tab` option, or by simply double-clicking it."
+msgstr "También puedes cambiar el nombre de la pestaña :guilabel:`IPython console` con la opción :guilabel:`Renombrar la pestaña`, o simplemente haciendo doble clic en ella."
+
+#: ../../panes/ipythonconsole.rst:84
+msgid "Using external kernels"
+msgstr "Usar núcleos externos"
+
+#: ../../panes/ipythonconsole.rst:86
+msgid "You can connect to external local and remote kernels (including those managed by Jupyter Notebook or QtConsole) through the :guilabel:`Connect to an existing kernel` dialog under the :guilabel:`Consoles` menu. For this feature to work, a compatible version of the ``spyder-kernels`` package :ref:`must be installed <starting-kernel-problems-ref>` in the environment or machine in which the external kernel is running."
+msgstr "Puedes conectarte a los núcleos externos locales y remotos (incluidos los administrados por Jupyter Notebook o QtConsole) a través del diálogo :guilabel:`Conectarse a un núcleo existente` bajo el menú de :guilabel:`Terminales`. Para que esta característica funcione, una versión compatible del paquete ``spyder-kernels`` :ref:`debe ser instalado <starting-kernel-problems-ref>` en el entorno o máquina en la que el núcleo externo está corriendo."
+
+#: ../../panes/ipythonconsole.rst:94
+msgid "Connect to a local kernel"
+msgstr "Conectar a un núcleo local"
+
+#: ../../panes/ipythonconsole.rst:96
+msgid "To connect to a local kernel that is already running (e.g. one started by Jupyter notebook),"
+msgstr "Para conectarse a un núcleo local que ya se está ejecutando (por ejemplo, uno iniciado por Jupyter notebook):"
+
+#: ../../panes/ipythonconsole.rst:98
+#, python-format
+msgid "Run ``%connect_info`` in the notebook or console you want to connect to, and copy the name of its kernel connection file, shown after ``jupyter <app> --existing``."
+msgstr "Ejecuta ``%connect_info`` en el notebook o la consola a la que quieres conectarte, y copia el nombre de su archivo de conexión al núcleo, que se muestra después de ``jupyter <app> --existing``."
+
+#: ../../panes/ipythonconsole.rst:103
+msgid "In Spyder, click :guilabel:`Connect to an existing kernel` from the :guilabel:`Consoles` menu, and paste the name of the :guilabel:`Connection file` from the previous step."
+msgstr "En Spyder, haz clic en :guilabel:`Conectarse a un núcleo existente` desde el menú :guilabel:`Terminales`, y pega el nombre del :guilabel:`Archivo de conexión` del paso anterior."
+
+#: ../../panes/ipythonconsole.rst:105
+msgid "As a convenience, kernel ID numbers (e.g. ``1234``) entered in the connection file path field will be expanded to the full path of the file, i.e. :file:`{jupyter/runtime/dir/path}/kernal-{id}.json`."
+msgstr "Por conveniencia, los números de ID del núcleo (por ejemplo ``1234``) ingresados en el campo de ruta del archivo de conexión se ampliarán a la ruta completa del archivo, por ejemplo :file:`{jupyter/runtime/dir/path}/kernal-{id}.json`."
+
+#: ../../panes/ipythonconsole.rst:110
+msgid "Click :guilabel:`OK` to connect to the kernel."
+msgstr "Haz clic en :guilabel:`OK` para conectarte al núcleo."
+
+#: ../../panes/ipythonconsole.rst:117
+msgid "Connect to a remote kernel"
+msgstr "Conectar a un núcleo remoto"
+
+#: ../../panes/ipythonconsole.rst:119
+msgid "To connect to a kernel on a remote machine,"
+msgstr "Para conectarse a un núcleo en una máquina remota:"
+
+#: ../../panes/ipythonconsole.rst:121
+msgid "Launch a Spyder kernel on the remote host if one is not already running, with ``python -m spyder_kernels.console``."
+msgstr "Inicia un núcleo Spyder en el host remoto, si aún no se está ejecutando, con ``python -m spyder_kernels.console``."
+
+#: ../../panes/ipythonconsole.rst:126
+msgid "Copy the kernel's connection file (:file:`{jupyter/runtime/dir/path}/kernel-{pid}.json`) to the machine you're running Spyder on."
+msgstr "Copia el archivo de conexión del núcleo (:file:`{jupyter/runtime/dir/path}/kernel-{pid}.json`) a la máquina en la que estás ejecutando Spyder."
+
+#: ../../panes/ipythonconsole.rst:128
+msgid "You can get :file:`{jupyter/runtime/dir/path}` by executing ``jupyter --runtime-dir`` in the same Python environment as the kernel. Usually, the connection file you are looking for will be one of the newest in this directory, corresponding to the time you started the external kernel."
+msgstr "Puedes obtener :file:`{jupyter/runtime/dir/path}` ejecutando ``jupyter --runtime-dir`` en el mismo entorno de Python que el kernel. Generalmente, el archivo de conexión que estás buscando será uno de los más recientes en este directorio, correspondiente a la hora en que inició el núcleo externo."
+
+#: ../../panes/ipythonconsole.rst:134
+msgid "Click :guilabel:`Connect to an existing kernel` from the :guilabel:`Consoles` menu, and browse for or enter the path to the connection file from the previous step."
+msgstr "Haz clic en :guilabel:`Conectarse a un núcleo existente` desde el menú :guilabel:`Terminales`, y busca o ingresa la ruta al archivo de conexión desde el paso anterior."
+
+#: ../../panes/ipythonconsole.rst:136
+msgid "As a convenience, kernel ID numbers (e.g. ``1234``) entered in the connection file path field will be expanded to :file:`{jupyter/runtime/dir/path}/kernal-{id}.json` on your local machine, if you've copied the connection file there."
+msgstr "Por conveniencia, los números de ID del núcleo (por ejemplo, ``1234``) introducidos en el campo de ruta del archivo de conexión se expandirán a :file:`{jupyter/runtime/dir/path}/kernal-{id}.json` en tu máquina local, si has copiado el archivo de conexión allí."
+
+#: ../../panes/ipythonconsole.rst:141
+msgid "Check the :guilabel:`This is a remote kernel (via SSH)` box and enter the :guilabel:`Hostname` or IP address, username and port to connect to on the remote machine. Then, enter *either* :file:`{username}`'s password on the remote machine, or browse to an SSH keyfile (typically in the :file:`.ssh` directory in your home folder on the local machine, often called :file:`id_rsa` or similar) registered on it; only one is needed to connect. If you check :guilabel:`Save connection settings`, these details will be remembered and filled for you automatically next time you open the dialog."
+msgstr "Marca la casilla :guilabel:`Este es un núcleo remoto (via SSH)` e ingresa el :guilabel:`Servidor` o dirección IP, nombre de usuario y puerto al cual conectarse en la máquina remota. Luego, ingresa la contraseña de :file:`{nombre de usuario}` en la máquina remota, **o** selecciona un archivo de clave SSH registrado en la máquina remota, normalmente ubicado en el directorio :file:`.ssh` en tu carpeta de inicio en la máquina local y llamado a menudo :file:`id_rsa`. Si marcas :guilabel:`Guardar ajustes de conexión`, estos detalles serán recordados y rellenados automáticamente la próxima vez que abras el diálogo."
+
+#: ../../panes/ipythonconsole.rst:145
+msgid "Note that :guilabel:`Port` is the port number on your remote machine that the SSH daemon (``sshd``) is listening on, typically 22 unless you or your administrator has configured it otherwise."
+msgstr "Ten en cuenta que :guilabel:`Puerto` es el número de puerto en tu máquina remota en el que el daemon SSH (``sshd``) está escuchando, típicamente 22 a menos que tú o tu administrador lo hayan configurado de otra manera."
+
+#: ../../panes/ipythonconsole.rst:150
+msgid "Click :guilabel:`OK` to connect to the remote kernel"
+msgstr "Haz clic en :guilabel:`OK` para conectarte al núcleo"
+
+#: ../../panes/ipythonconsole.rst:155
+msgid "For more technical details about connecting to remote kernels, see the `Connecting to a remote kernel`_ page in the IPython Cookbook."
+msgstr "Para obtener más detalles técnicos sobre la conexión a los núcleos remotos, consulta la página `Connecting to a remote kernel`_ en el libro de Cookbook IPython."
+
+#: ../../panes/ipythonconsole.rst:165
+msgid "Reload changed modules"
+msgstr "Recargar módulos modificados"
+
+#: ../../panes/ipythonconsole.rst:167
+msgid "When working in an interactive session, Python only loads a module from its source file once, the first time it is imported."
+msgstr "Al trabajar en una sesión interactiva, Python sólo carga un módulo desde su archivo fuente una vez, cuando se importa por primera vez."
+
+#: ../../panes/ipythonconsole.rst:169
+msgid "Spyder's :guilabel:`User Module Reloader` (UMR) automatically reloads modules right in your existing IPython consoles whenever they are modified and re-imported. With the UMR enabled, you can test changes to your code without restarting the kernel."
+msgstr "El :guilabel:`Recargador de Módulos de usuario` (RMU) de Spyder recarga automáticamente módulos en las consolas de IPython existentes siempre que sean modificadas y reimportadas. Con la RMU activada, puedes probar los cambios en tu código sin reiniciar el núcleo."
+
+#: ../../panes/ipythonconsole.rst:175
+msgid "UMR is enabled by default, and it will provide you with a red ``Reloaded modules:`` message in the console listing the files it has refreshed when it is activated. If desired, you can turn it on or off, and prevent specific modules from being reloaded, under :menuselection:`Preferences --> Python interpreter --> User Module Reloader (UMR)`."
+msgstr "RMU está activado por defecto, y te proporcionará un mensaje en rojo ``Módulos recargados:`` en la consola listando los archivos que se han actualizado cuando está activado. Si lo deseas, puedes activarlo o desactivarlo y evitar que se recargen módulos específicos, bajo :menuselection:`Preferencias --> intérprete de Python --> Recargador de Módulos de Usuario (RMU)`."
+
+#: ../../panes/ipythonconsole.rst:187 ../../panes/variableexplorer.rst:196
+msgid ":doc:`debugging`"
+msgstr ":doc:`debugging`"
+
+#: ../../panes/ipythonconsole.rst:189 ../../panes/onlinehelp.rst:88
+msgid ":doc:`help`"
+msgstr ":doc:`help`"
+
+#: ../../panes/ipythonconsole.rst:190
+msgid ":doc:`historylog`"
+msgstr ":doc:`historylog`"
+
+#: ../../panes/onlinehelp.rst:3
+msgid "Online Help"
+msgstr "Ayuda en línea"
+
+#: ../../panes/onlinehelp.rst:5
+msgid "The **Online Help** pane provides a built-in web browser to explore dynamically generated Python documentation on installed modules—including your own—rendered by a `pydoc`_ server running in the background."
+msgstr "El panel de **Ayuda en línea** proporciona un navegador web integrado para explorar la documentación de Python generada dinámicamente en los módulos instalados, incluyendo el tuyo, renderizado por un servidor `pydoc`_ corriendo en segundo plano."
+
+#: ../../panes/onlinehelp.rst:16
+msgid "Using the Online Help"
+msgstr "Usar la Ayuda en línea"
+
+#: ../../panes/onlinehelp.rst:18
+msgid "The Online Help's home shows an index where you can browse the documentation of standard library modules, third party packages installed in your Python environment, and your own local code. Click on the name of any module to open its documentation."
+msgstr "En la página de inicio de la ayuda en línea se muestra un índice donde puedes navegar por la documentación de módulos de biblioteca estándar, paquetes de terceros instalados en tu entorno Python y tu propio código local. Haz clic en el nombre de cualquier módulo para abrir su documentación."
+
+#: ../../panes/onlinehelp.rst:24
+msgid "Enter the name of the item you'd like help on in the :guilabel:`Package` field to load its documentation directly."
+msgstr "Introduce el nombre del elemento en el que deseas ayuda en el campo :guilabel:`Paquete` para cargar su documentación directamente."
+
+#: ../../panes/onlinehelp.rst:29
+msgid "The module's file location is linked to the right of the doc's title, which you can click to view its source code."
+msgstr "La ubicación del archivo del módulo está enlazada a la derecha del título del documento, al cual puedes hacer clic para ver su código fuente."
+
+#: ../../panes/onlinehelp.rst:34
+msgid "Standard library modules also have a link to the corresponding `Python docs`_, which can be viewed right inside of the pane."
+msgstr "Los módulos de biblioteca estándar también tienen un enlace a los correspondientes `Python docs`_, que pueden ser vistos justo dentro del panel."
+
+#: ../../panes/onlinehelp.rst:41
+msgid "If you're not sure of the name of the object you want help on, or are looking for a specific keyword, use the :guilabel:`Search` field to get a list of results."
+msgstr "Si no estás seguro del nombre del objeto en el que deseas obtener ayuda, o estás buscando una palabra clave específica, usa el campo :guilabel:`Search` para obtener una lista de resultados."
+
+#: ../../panes/onlinehelp.rst:46
+msgid "Links above the search field provide an index of topics with general help and a list of Python keywords linked to their corresponding docs."
+msgstr "Los enlaces que están por encima del campo de búsqueda proporcionan un índice de temas con ayuda general y una lista de palabras clave Python vinculadas a sus documentos correspondientes."
+
+#: ../../panes/onlinehelp.rst:55
+msgid "Toolbar items"
+msgstr "Elementos de la barra de herramientas"
+
+#: ../../panes/onlinehelp.rst:57
+msgid "Just like in a web browser, the forward and back buttons move through the pages you have visited, and the home button (house icon) returns you to the module index."
+msgstr "Al igual que en un navegador web, los botones de adelante y atrás se mueven a través de las páginas que has visitado, y el botón de inicio (icono de la casa) te devuelve al índice de módulos."
+
+#: ../../panes/onlinehelp.rst:62
+msgid "Perform a realtime search within a page's content with the :guilabel:`Find` button (magnifying glass icon top left) or :kbd:`Ctrl-F`, navigate through matches with the Up and Down buttons, and make matching case sensitive with the :guilabel:`Aa` button."
+msgstr "Realiza una búsqueda en tiempo real dentro del contenido de una página con el botón :guilabel:`Encontrar texto` (icono de lupa arriba a la derecha) o :kbd:`Ctrl-F`, y navega a través de coincidencias con los botones Arriba y Abajo; además puedes hacer que coincida mayúsculas y minúsculas con el botón :guilabel:`Aa`."
+
+#: ../../panes/onlinehelp.rst:67
+msgid "You can view and re-run previous searches from the drop-down menu in the :guilabel:`Package` field."
+msgstr "Puedes ver y volver a ejecutar búsquedas anteriores desde el menú desplegable en el campo :guilabel:`Paquete`."
+
+#: ../../panes/onlinehelp.rst:72
+msgid "You can also use the zoom in/out buttons (:guilabel:`-` and :guilabel:`+`, top right) to change the font size to suit your preferences."
+msgstr "También puedes usar los botones de acercar/alejar (:guilabel:`-` y :guilabel:`+`, arriba a la derecha) para cambiar el tamaño de la fuente según tus preferencias."
+
+#: ../../panes/onlinehelp.rst:77
+msgid "To cancel searching or page loading, click the stop button (red square), and to reload the page (such as when you change your own package's documentation), press the refresh button (circular arrow)."
+msgstr "Para cancelar la búsqueda o la carga de la página, haz clic en el botón de detener (cuadrado rojo), y para recargar la página, como cuando cambias la documentación de tu propio paquete, pulsa el botón de actualizar (flecha circular)."
+
+#: ../../panes/outline.rst:3
+msgid "Outline"
+msgstr "Explorador de código"
+
+#: ../../panes/outline.rst:5
+msgid "The **Outline** pane allows you to view and navigate the functions, classes, methods, cells and comments in open Python files. To show or hide the Outline pane, use :menuselection:`View --> Panes --> Outline` or :kbd:`Ctrl-Shift-O` / :kbd:`Cmd-Shift-O`. Click an entry in the outline to jump to its source file location, and use the :guilabel:`Go to cursor position` toolbar button to highlight the item corresponding to the current :doc:`editor` position."
+msgstr "El panel **Explorador de código** te permite ver y navegar las funciones, clases, métodos, celdas y comentarios en archivos Python abiertos. Para mostrar u ocultar el panel de Explorador de código, usa :menuselection:`Ver --> Paneles --> Explorador de código` o :kbd:`Ctrl-Shift-O` / :kbd:`Cmd-Shift-O`. Haz clic en una entrada del esquema para saltar a la ubicación de su archivo de origen y utiliza el botón de la barra de herramientas :guilabel:`Ir a la posición del cursor` para resaltar el elemento correspondiente a la posición actual del :doc:`editor`."
+
+#: ../../panes/outline.rst:18
+msgid "The options menu in the top-right of the pane allows customizing how the outline is displayed."
+msgstr "El menú de opciones en la parte superior derecha del panel te permite personalizar la forma en que se muestra el explorador de código."
+
+#: ../../panes/outline.rst:23
+msgid "These customization settings include:"
+msgstr "Estas opciones de personalización incluyen:"
+
+#: ../../panes/outline.rst:25
+msgid ":guilabel:`Show absolute path`: Display the full path to each file instead of just the name."
+msgstr ":guilabel:`Mostrar la ruta completa`: Muestra la ruta completa a cada archivo en lugar de solo el nombre."
+
+#: ../../panes/outline.rst:26
+msgid ":guilabel:`Show all files`: List every open file rather than just the current one. This allows using the Outline as a file switcher."
+msgstr ":guilabel:`Mostrar todos los archivos`: lista cada archivo abierto en lugar de solo el actual. Esto permite usar el explorador de código como un selector de archivos."
+
+#: ../../panes/outline.rst:28
+msgid ":guilabel:`Group code cells`: Group code cells in multiple nested levels in the outline rather than showing all cells in one level. You can create subsections by adding more ``%`` signs to the cell separator."
+msgstr ":guilabel:`Agrupar celdas`: agrupa celdas de código anidadas en múltiples niveles en el explorador de código en lugar de mostrar todas las celdas en un solo nivel. Puedes crear subsecciones añadiendo más signos de ``%`` al separador de celdas."
+
+#: ../../panes/outline.rst:30
+msgid ":guilabel:`Display variables and attributes`: Display top-level variable/constant definitions and class attributes in the outline."
+msgstr ":guilabel:`Mostrar variables y atributos`: muestra las definiciones de variable/constante de nivel superior y los atributos de clase en el explorador de código."
+
+#: ../../panes/outline.rst:31
+msgid ":guilabel:`Follow cursor position`: Automatically highlight and expand the entry corresponding to the current cursor position in the :doc:`editor`."
+msgstr ":guilabel:`Ir a la posición del cursor`: resalta y expande automáticamente la entrada correspondiente a la posición actual del cursor en el :doc:`editor`."
+
+#: ../../panes/outline.rst:32
+msgid ":guilabel:`Show special comments`: List special comments in the outline, which start with ``# ----``."
+msgstr ":guilabel:`Mostrar comentarios especiales`: lista los comentarios especiales en el explorador de código, los cuales comienzan con ``# ----``."
+
+#: ../../panes/outline.rst:33
+msgid ":guilabel:`Sort files alphabetically`: Sort the file list in alphabetical order. When disabled, all tabs will be sorted by the tab order of the currently selected Editor panel."
+msgstr ":guilabel:`Organizar archivos alfabéticamente`: ordena la lista de archivos en orden alfabético. Cuando se deshabilita, todas las pestañas se ordenarán según el orden de las pestañas del panel Editor seleccionado actualmente."
+
+#: ../../panes/outline.rst:40
+msgid "Icons"
+msgstr "Iconos"
+
+#: ../../panes/outline.rst:42
+msgid "The following icons are used for outline elements:"
+msgstr "Los siguientes iconos se utilizan para elementos del explorador de código:"
+
+#: ../../panes/outline.rst:44
+msgid ":guilabel:`m` for methods"
+msgstr ":guilabel:`m` para métodos"
+
+#: ../../panes/outline.rst:45
+msgid ":guilabel:`f` for functions"
+msgstr ":guilabel:`f` para funciones"
+
+#: ../../panes/outline.rst:46
+msgid ":guilabel:`c` for classes"
+msgstr ":guilabel:`c` para clases"
+
+#: ../../panes/outline.rst:47
+msgid ":guilabel:`%` for code cells"
+msgstr ":guilabel:`%` para celdas de código"
+
+#: ../../panes/outline.rst:48
+msgid ":guilabel:`#` for comments"
+msgstr ":guilabel:`#` para comentarios"
+
+#: ../../panes/plots.rst:3
+msgid "Plots"
+msgstr "Gráficos"
+
+#: ../../panes/plots.rst:5
+msgid "The **Plots** pane shows the static figures and images created during your session. It will show you plots from the :doc:`ipythonconsole`, produced by your code in the :doc:`editor` or generated by the :doc:`variableexplorer` allowing you to interact with them in several ways."
+msgstr "El panel **Gráficos** muestra las figuras e imágenes estáticas creadas durante tu sesión. Te mostrará gráficos de la :doc:`ipythonconsole` producidos por tu código en el :doc:`editor` o generados por el :doc:`variableexplorer` permitiéndote interactuar con ellos de varias maneras."
+
+#: ../../panes/plots.rst:11
+msgid "The figures shown in the Plots pane are those associated with the currently active :guilabel:`Console` tab; if you switch consoles, the list of plots displayed (or none at all, if a new console) will change accordingly."
+msgstr "Las figuras que se muestran en el panel de Gráficos son las asociadas con la pestaña activa :guilabel:`Terminal`. Si cambias de terminal, la lista de gráficos mostrados cambiará en consecuencia o no mostrará ninguno si abres una terminal nueva."
+
+#: ../../panes/plots.rst:22
+msgid "The options menu in the top right of the :guilabel:`Plots` pane offers several ways to customize how your plots are displayed."
+msgstr "El menú de opciones en la parte superior derecha del panel de :guilabel:`Gráficos` ofrece varias maneras de personalizar como se muestran tus gráficos."
+
+#: ../../panes/plots.rst:26
+msgid "Mute inline plotting"
+msgstr "Silenciar los gráficos en línea"
+
+#: ../../panes/plots.rst:28
+msgid "The :guilabel:`Mute inline plotting` option is enabled by default, preventing your plots from appearing in the Console. If you deactivate this option, figures will display in both the Plots pane and the Console."
+msgstr "La opción :guilabel:`Silenciar los gráficos en línea` está activada por defecto, evitando que tus gráficos aparezcan en la consola. Si desactivas esta opción, las figuras se mostrarán tanto en el panel Gráficos como en la Terminal."
+
+#: ../../panes/plots.rst:36
+msgid "Show plot outline"
+msgstr "Mostrar el borde del gráfico"
+
+#: ../../panes/plots.rst:38
+msgid "The :guilabel:`Show plot outline` option, off by default, shows a thin stroke surrounding the area of the figure area, which will also appear in the exported images."
+msgstr "La opción :guilabel:`Mostrar el borde del gráfico`, desactivada por defecto, muestra un trazo delgado alrededor del área de la figura, que también aparecerá en las imágenes exportadas."
+
+#: ../../panes/plots.rst:45
+msgid "Fit plots to window"
+msgstr "Ajustar gráficos a la ventana"
+
+#: ../../panes/plots.rst:47
+msgid "The :guilabel:`Fit plots to Window` option, also enabled by default, sizes the figures to match the pane. Disabling it will display plots at their native size, and allow you use the zoom buttons at the top of the pane to scale them manually."
+msgstr "La opción :guilabel:`Ajustar gráficos a la ventana`, también activada por defecto,ajusta el tamaño de las figuras para que coincidan con el panel. Al deshabilitarlo, se mostrarán los gráficos en su tamaño nativo y podrás usar los botones de zoom en la parte superior del panel para escalarlos manualmente."
+
+#: ../../panes/plots.rst:57
+msgid "Toolbar options"
+msgstr "Opciones de la barra de herramientas"
+
+#: ../../panes/plots.rst:59
+msgid "The toolbar at the top of the Plots pane provides several useful features that allow you to interact with your figures. For example, you can cycle sequentially through the plot list with the forward and back arrows."
+msgstr "La barra de herramientas en la parte superior del panel de Gráficos proporciona varias funciones útiles que te permiten interactuar con sus figuras. Por ejemplo, puede recorrer secuencialmente la lista de gráficos con las flechas hacia adelante y hacia atrás."
+
+#: ../../panes/plots.rst:65
+msgid "You can also save one or all the plots in the pane to file(s) by clicking the respective \"save\"/\"save all\" icons in the toolbar. Plots are rendered and saved as PNG by default, but SVG can be selected as an option under :menuselection:`Preferences --> IPython console --> Graphics --> Inline backend --> Format`."
+msgstr "También puedes guardar uno o todos los gráficos en el panel a archivo(s) haciendo clic en los iconos respectivos \"guardar gráfico como...\"/\"guardar todos los gráficos...\" en la barra de herramientas. Los gráficos son procesados y guardados como PNG por defecto, aunque también puedes seleccionar SVG como una opción bajo :menuselection:`Preferencias --> Terminal de IPython --> Gráficas --> Salida en línea --> Formato`."
+
+#: ../../panes/plots.rst:71
+msgid "Additionally, if you want to use a figure in another document, you can click the \"copy to clipboard\" button and paste your plot wherever you want, such as a word processor."
+msgstr "Además, si deseas utilizar una figura en otro documento, puedes hacer clic en el botón \"Copiar gráfico al portapapeles como imagen\" y pegar tu gráfico donde quieras, por ejemplo en un procesador de textos."
+
+#: ../../panes/plots.rst:76
+msgid "Finally, you can use the \"remove\" and \"remove all\" buttons in the toolbar to clear plots from the list."
+msgstr "Por último, puedes utilizar los botones \"Borrar gráfico\" y \"Borrar todos los gráficos\" de la barra de herramientas para borrar los gráficos de la lista."
+
+#: ../../panes/profiler.rst:3
+msgid "Profiler"
+msgstr "Perfilador (Profiler)"
+
+#: ../../panes/profiler.rst:5
+msgid "The **Profiler** pane recursively determines the run time and number of calls for every function and method called in a file, breaking down each procedure into its smallest individual units. This allows you to easily identify the bottlenecks in your code, points you toward the exact statements most critical for optimization, and measures the performance delta after followup changes."
+msgstr "El panel **Perfilador (Profiler)** determina recursivamente el tiempo de ejecución y el número de llamadas para cada función, y el método llamado en un archivo, dividiendo cada procedimiento en sus unidades individuales más pequeñas. Esto te permite identificar fácilmente los cuellos de botella en tu código, te indica las sentencias exactas más críticas para la optimización, y mide el delta del rendimiento después de los cambios de seguimiento."
+
+#: ../../panes/profiler.rst:15
+msgid "Running the Profiler"
+msgstr "Ejecutando el Perfilador (Profiler)"
+
+#: ../../panes/profiler.rst:17
+msgid "You can browse for a file using the open button to the right of the Profiler's path box (top left of the pane), which will run profiling over this file automatically."
+msgstr "Puedes buscar un archivo usando el botón \"Seleccionar archivo de Python\", ubicado a la derecha del cuadro de ruta del perfil (arriba a la izquierda del panel), que ejecutará automáticamente el perfilador sobre este archivo."
+
+#: ../../panes/profiler.rst:22
+msgid "You can manually enter the path in the pane's path box and then run the analysis on the file by pressing :guilabel:`Profile` in the Profiler pane."
+msgstr "Puedes introducir manualmente la ruta en el cuadro de ruta del panel y luego ejecutar el análisis en el archivo pulsando :guilabel:`Ejecutar el perfilador` en el panel del Perfilador (Profiler)."
+
+#: ../../panes/profiler.rst:24
+msgid "You can also run profiling for the file that is currently open in the :doc:`editor` by clicking :menuselection:`&Run --> Profile` in the menu bar, or by using a configurable shortcut (:kbd:`F10` by default)."
+msgstr "También puedes ejecutar perfiles para el archivo que está actualmente abierto en el :doc:`editor` haciendo clic en :menuselection:`&Ejecutar --> Ejecutar el perfilador` en la barra de menú, o usando un acceso directo configurable (:kbd:`F10` por defecto)."
+
+#: ../../panes/profiler.rst:30
+msgid "If you'd like to cancel an in-progress run, click the :guilabel:`Stop` button in the top right, and if profiling fails for any reason, the :guilabel:`Output` dialog will be displayed, indicating the error that occurred."
+msgstr "Si quieres cancelar una ejecución en curso, haz clic en el botón :guilabel:`Detener el perfilador` en la parte superior derecha, y si el perfil falla por cualquier razón, se mostrará el diálogo :guilabel:`Salida del perfilador` indicando el error que ha ocurrido."
+
+#: ../../panes/profiler.rst:32
+msgid "By double-clicking an item in the Profiler, you will be taken to the file and line in the :doc:`editor` where it was called."
+msgstr "Al hacer doble clic en un elemento del Perfilador, serás llevado al archivo y a la línea en el :doc:`editor` donde fue llamado."
+
+#: ../../panes/profiler.rst:37
+msgid "You can increase the number of levels displayed for a particular object by clicking the dropdown arrows to the left of the name, and expand/collapse all the items with the buttons in the top left."
+msgstr "Puedes aumentar el número de niveles mostrados para un objeto en particular haciendo clic en las flechas desplegables a la izquierda del nombre, y expandir/contraer todos los elementos con los botones de la parte superior izquierda."
+
+#: ../../panes/profiler.rst:42
+msgid "By clicking the dropdown or press the :kbd:`Down Arrow` key in the filename field, you can recall paths of previous profiled files."
+msgstr "Haciendo clic en el menú desplegable o pulsando la tecla :kbd:`Flecha abajo` en el campo de nombre de archivo, puedes recuperar las rutas de acceso de los archivos perfilados anteriormente."
+
+#: ../../panes/profiler.rst:47
+msgid "Finally, you can save the data for a given run to disk as a file with the ``.Result`` extension using the :guilabel:`Save data` button. This can be loaded to compare with a previous run of the same file using the :guilabel:`Load data` button. To remove the loaded data, click the :guilabel:`Clear comparison` button."
+msgstr "Finalmente, puedes guardar los datos para una ejecución dada en el disco como un archivo con el ``.Result`` usando el botón :guilabel:`Guardar información de perfilado`. Esto se puede cargar para comparar con una ejecución anterior del mismo archivo usando el botón 'Cargar datos' de :guilabel:. Para eliminar los datos cargados, haga clic en el botón :guilabel:'Limpiar comparación'."
+
+#: ../../panes/profiler.rst:58
+msgid "Interpreting the results"
+msgstr "Interpretar los resultados"
+
+#: ../../panes/profiler.rst:60
+msgid "Results are broken down by function/method/statement, with each sub-element listed hierarchically under the top-level item that called them. :guilabel:`Total Time` is that taken by the specified item and every function \"underneath\" (*i.e.* called by) it, while :guilabel:`Local Time` only counts the time spent in the particular callable object's own scope. The :guilabel:`Calls` column displays the total number of times the specified object was called at that level inside its parent calling function (or within the ``__main__`` scope, if a top-level object). Finally, the numbers in the :guilabel:`Diff` columns for each of the three appear if a comparison is loaded, and indicate the deltas between each measurement."
+msgstr "Los resultados son desglosados por función/método/sentencia, con cada subelemento listado jerárquicamente bajo el elemento de nivel superior que los llama. :guilabel:`Tiempo total` es el tiempo que tarda el objeto especificado y todas las funciones \"debajo\" del objeto(es decir, las llamadas por el objeto), mientras que :guilabel:`Tiempo Local` solo cuenta el tiempo empleado en el ámbito propio del objeto en particular. La columna :guilabel:`Llamados` muestra el número total de veces que el objeto especificado fue llamado en ese nivel dentro de su función de llamada primaria o dentro del ámbito ``__main__``, si se trata de un objeto de nivel superior. Finalmente, los números en la columna :guilabel:`Diff` para cada uno de los tres aparecen si se carga una comparación, e indican los deltas entre cada medición."
+
+#: ../../panes/profiler.rst:68
+msgid "For example, suppose you ran the :guilabel:`Profiler` on a file calling a function ``sleep_wrapper()`` that in turn called the ``sleep()`` function, and the ``sleep_wrapper()`` function took a total of 3.87 ms to run, with 3.86 ms of that spent executing the ``sleep()`` function inside it. Therefore, if ``sleep()`` called nothing else itself, its :guilabel:`Total Time` and :guilabel:`Local Time` would both be identical, at 3.87 ms. Meanwhile, :guilabel:`Total Time` for ``sleep_wrapper()`` would be 3.86 ms, but :guilabel:`Local Time` only 0.01 ms as the rest was spent inside the ``sleep()`` function it called."
+msgstr "Por ejemplo, supongamos que ejecutaste el :guilabel:`Perfilador (Profiler)` en un archivo que llama a una función ``sleep_wrapper()``, que a su vez llama a la función ``sleep()``; y la función ``sleep_wrapper()`` tardó un total de 3.87 ms en ejecutarse, de los cuales 3,86 ms se dedicaron a ejecutar la función ``sleep()`` dentro de ella. Por lo tanto, si ``sleep()`` no llama a ninguna otra función, su :guilabel:`Tiempo total` y su :guilabel:`Tiempo local` serían idénticos a 3.87 ms. Mientras tanto, el :guilabel:`Tiempo total` para ``sleep_wrapper()`` sería de 3.86 ms, pero el :guilabel:`Tiempo local` sería solo de 0.01 ms , ya que el resto se gastó en la función ``sleep()`` a la que llamó."
+
+#: ../../panes/profiler.rst:76
+msgid "Profiler plugins"
+msgstr "Plugins del perfilador"
+
+#: ../../panes/profiler.rst:78
+msgid "There are two additional plugins that you can install to enable other types of profiling in Spyder. First, Spyder Line Profiler allows you to benchmark each line of your code individually. To learn more, visit the `spyder-line-profiler git repository`_."
+msgstr "Hay dos plugins adicionales que puedes instalar para habilitar otros tipos de perfiles en Spyder. En primer lugar, Spyder Line Profiler te permite analizar cada línea de tu código individualmente. Para obtener más información, visita el `spyder-line-profiler git repository`_."
+
+#: ../../panes/profiler.rst:87
+msgid "Second, Spyder Memory Profiler measures the memory usage of your code. For more information, go to the `spyder-memory-profiler git repository`_."
+msgstr "Segundo, el Spyder Memory Profiler mide el uso de memoria de tu código. Para más información, ve a `spyder-memory-profiler git repository`_."
+
+#: ../../panes/projects.rst:3
+msgid "Projects"
+msgstr "Proyectos"
+
+#: ../../panes/projects.rst:5
+msgid "Spyder allows you to associate a given directory with a **Project**, which automatically saves and restores the files you have open in the :doc:`editor` from the last time you opened that project. With the :ref:`Project <project-explorer>` pane, you can browse all your project's files, regardless of your current working directory or :doc:`fileexplorer` location."
+msgstr "Spyder te permite asociar un directorio determinado con un **Proyecto**, el cual automáticamente guarda y restaura los archivos que has abierto en el :doc:`editor` desde la última vez que abriste ese proyecto. En el panel :ref:`Proyecto <project-explorer>` puedes navegar todos los archivos de tu proyecto, independientemente de tu directorio de trabajo actual o de la ubicación de :doc:`fileexplorer`."
+
+#: ../../panes/projects.rst:11
+msgid "In addition, your project's root folder is used to set your working directory, and automatically added to the ``PYTHONPATH``, so you can easily ``import`` and work with any modules and packages you create inside of it."
+msgstr "Además, la carpeta raíz del proyecto se utiliza para establecer tu directorio de trabajo, y se añade automáticamente al ``PYTHONPATH``, para que puedas ``importar`` fácilmente y trabajar con cualquier módulo y paquetes que crees dentro de él."
+
+#: ../../panes/projects.rst:15
+msgid "Projects are completely optional and not imposed on users. All of Spyder' functionality (code completion, session saving, File Explorer, working directory, etc) is available without creating a :guilabel:`Project`."
+msgstr "Los proyectos son completamente opcionales y no se imponen a los usuarios. Todas las funcionalidades de Spyder (finalización de código, guardado de sesión, Explorador de archivos, directorio de trabajo, etc) están disponibles sin crear un :guilabel:`Proyecto`."
+
+#: ../../panes/projects.rst:22
+msgid "Creating a Project"
+msgstr "Crear un proyecto"
+
+#: ../../panes/projects.rst:24
+msgid "To create a :guilabel:`Project`, click the :guilabel:`New Project` entry in the :guilabel:`Projects` menu, choose whether you'd like to associate a :guilabel:`Project` with an existing directory or make a new one, and enter the :guilabel:`Project`'s name and path."
+msgstr "Para crear un :guilabel:`Proyecto`, haz clic en la entrada :guilabel:`Nuevo Proyecto` en el menú :guilabel:`Proyectos`. Elige si quieres asociar un :guilabel:`Proyecto` con un directorio existente o crear uno nuevo, e introduce el nombre y la ruta del :guilabel:`Proyecto`."
+
+#: ../../panes/projects.rst:35
+msgid "Using the Projects Pane"
+msgstr "Usar el panel de Proyectos"
+
+#: ../../panes/projects.rst:37
+msgid "Once a :guilabel:`Project` is opened, the :guilabel:`Project` pane is shown, presenting a tree view of the current :guilabel:`Project`'s files and directories. It allows you to perform all the same :ref:`operations<file-operations>` as Spyder's :doc:`fileexplorer` pane."
+msgstr "Una vez que se abre un :guilabel:`Proyecto`, se muestra el panel :guilabel:`Project`, presentando una vista de árbol de los archivos y directorios del :guilabel:`Proyecto` actual. Esto te permite realizar las mismas :ref:`operaciones <file-operations>` que el panel :doc:`fileexplorer` de Spyder."
+
+#: ../../panes/projects.rst:49
+msgid "Working with version control"
+msgstr "Trabajar con control de versiones"
+
+#: ../../panes/projects.rst:51
+msgid "The :guilabel:`Project` pane has basic integration with the `Git`_ distributed version control system, just like :ref:`in the Files pane<files-vcs-support>`. You can commit or browse a file, directory or the entire repository via the commands in the context menu."
+msgstr "El panel :guilabel:`Proyectos` tiene integración básica con el sistema de control de versiones distribuidas `Git`_ al igual que :ref:`en el panel de Archivos<files-vcs-support>`. Puedes hacer un commit o navegar por un archivo, directorio o el repositorio completo mediante los comandos en el menú contextual."
+
+#: ../../panes/projects.rst:56
+msgid "To use this functionality, the :guilabel:`Project` must be located in a ``git`` repository and the ``git`` and ``gitk`` commands must be on the system path."
+msgstr "Para utilizar esta funcionalidad, el :guilabel:`Proyecto` debe estar ubicado en un repositorio ``git`` y los comandos ``git`` y ``gitk`` deben estar en la ruta del sistema."
+
+#: ../../panes/pylint.rst:3
+msgid "Code Analysis"
+msgstr "Análisis del código"
+
+#: ../../panes/pylint.rst:5
+msgid "The **Code Analysis** pane detects style issues, bad practices, potential bugs, and other quality problems in your code, all without having to actually execute it. Based on these results, it also gives your code an overall quality score. Spyder's code analyzer is powered by the best-in-class `Pylint`_ back-end, which can intelligently detect an enormous and customizable range of potential errors, bad practices, quality issues, style violations, and more."
+msgstr "El panel **Análisis del código** detecta problemas de estilo, malas prácticas, posibles errores y otros problemas de calidad en tu código, todo sin tener que ejecutarlo realmente. Basado en estos resultados, también le da a tu código una puntuación de calidad general. El analizador del código de Spyder funciona con el mejor back-end de `Pylint`_ de su clase, que pueden detectar de forma inteligente una gama enorme y personalizable de posibles errores, malas prácticas, problemas de calidad, violaciones de estilo y mucho más."
+
+#: ../../panes/pylint.rst:18
+msgid "Using the code analyzer"
+msgstr "Usar el analizador del código"
+
+#: ../../panes/pylint.rst:20
+msgid "You can select the desired file to analyze directly in the :doc:`editor` by clicking anywhere within it. To run the analysis, press the configurable shortcut (:kbd:`F8` by default), select :menuselection:`Source --> Run code analysis` from the menu bar or click the :guilabel:`Analyze` button in the Code Analysis pane. If the Code Analysis pane is not visible, you can open it under :menuselection:`View --> Panes --> Code Analysis`. All standard checks are run by default. To go directly to a line in the :doc:`editor` highlighted by a failed check, just click its name."
+msgstr "Puedes seleccionar el archivo deseado para analizarlo directamente en el :doc:`editor` haciendo clic en cualquier lugar dentro de él. Para ejecutar el análisis, presiona el acceso directo configurable (:kbd:`F8` por defecto), selecciona :menuselection:`Código fuente --> Ejecutar análisis del código` desde la barra de menú o haz clic en el botón :guilabel:`Ejecutar análisis del código` en el panel de Análisis de código. Si el panel de análisis de código no está visible, puedes abrirlo en :menuselection:`Ver --> Paneles --> Análisis del código`. Todas las comprobaciones estándar se ejecutan de forma predeterminada. Para ir directamente a una línea en el :doc:`editor` que ha sido resaltada por una comprobación fallida, simplemente haz clic en su nombre."
+
+#: ../../panes/pylint.rst:29
+msgid "You can also manually enter the path of a file you'd like it to check in the path entry box in the pane's toolbar. The analyzer works with both individual scripts and whole Python packages (directories containing an :file:`__init__.py` file)."
+msgstr "También puedes introducir manualmente la ruta de un archivo que te gustaría comprobar en la casilla de entrada de la ruta de la barra de herramientas del panel. El analizador funciona tanto con scripts individuales como con paquetes completos de Python (directorios que contienen un archivo :file:`__init__.py`)."
+
+#: ../../panes/pylint.rst:35
+msgid "Cancel analyzing a file with the :guilabel:`Stop` button, and if analysis fails, click the :guilabel:`Output` button to find out why. If Pylint does succeed, the :guilabel:`Output` will show the raw plain text analysis results on the selected file, allowing you to easily browse and copy/paste the full message names and descriptions."
+msgstr "Cancela el análisis de un archivo con el botón :guilabel:`Detener`, y si se produce un error en el análisis, haz clic en el botón :guilabel:`Salida` para averiguar por qué. Si Pylint tiene éxito, la :guilabel:`Salida` mostrará los resultados de análisis de texto sin formato en el archivo seleccionado, permitiéndote navegar y copiar/pegar fácilmente los nombres de los mensajes completos y las descripciones."
+
+#: ../../panes/pylint.rst:41
+msgid "Finally, you can click the dropdown or press the dropdown arrow in the filename field to view results of previous analyses."
+msgstr "Finalmente, puedes hacer clic en el menú desplegable o pulsar la flecha desplegable en el campo nombre del archivo para ver los resultados de análisis anteriores."
+
+#: ../../panes/pylint.rst:52
+msgid "The number of recent runs Spyder should remember can be customized in the :guilabel:`History` dialog, available from the Code Analysis options menu."
+msgstr "El número de ejecuciones recientes que Spyder debe recordar puede personalizarse en el cuadro de diálogo :guilabel:`Historial`, disponible en el menú de opciones de Análisis del código."
+
+#: ../../panes/pylint.rst:57
+msgid "You can also expand or collapse one or all the sections in the pane by using the corresponding options in the options menu."
+msgstr "También puedes expandir o contraer una o todas las secciones del panel usando las opciones correspondientes en el menú de opciones."
+
+#: ../../panes/pylint.rst:66
+msgid "Advanced options"
+msgstr "Opciones avanzadas"
+
+#: ../../panes/pylint.rst:68
+msgid "You can turn certain messages off at the line, block or file/module level by adding a ``# pylint: disable=MESSAGE-NAMES`` comment at the respective `scope`_, where ``MESSAGE_NAMES`` should be replaced with a comma-separated list (or single value) of `Pylint message names`_. For example, a directive might look like ``# pylint: disable=invalid-name``, or ``# pylint: disable=fixme, line-too-long``."
+msgstr "Puedes desactivar ciertos mensajes en el nivel de línea, bloque o archivo/módulo añadiendo un comentario ``# pylint: disable=MESSAGE-NAMES`` en el `scope`_ respectivo, donde ``MESSAGE_NAMES`` debe reemplazarse por una lista separada por comas (o valor único) de `Pylint message names`_. Por ejemplo, una directiva podría verse como ``# pylint: disable=invalid-name``, o ``# pylint: disable=fixme, line-too-long``."
+
+#: ../../panes/pylint.rst:78
+msgid "Or, you can globally suppress specific messages and adjust other Pylint settings by editing the :file:`.pylintrc` configuration file in your user folder. If it doesn't exist, you can generate it by running ``pylint --generate-rcfile > .pylintrc`` in your user directory, from Anaconda Prompt (on Windows) or your terminal (macOS/Linux). For more details on configuring Pylint, see the `Pylint documentation`_."
+msgstr "O bien, puedes eliminar globalmente mensajes específicos y ajustar otras configuraciones de Pylint editando el archivo de configuración :file:`.pylintrc` en tu carpeta de usuario. Si no existe, puedes generarlo ejecutando ``pylint --generate-rcfile > . ylintrc`` en tu directorio de usuario, desde Anaconda Prompt (en Windows) o tu terminal (macOS/Linux). Para más detalles sobre la configuración de Pylint, consulta la `Pylint documentation`_."
+
+#: ../../panes/pylint.rst:94
+msgid ":doc:`profiler`"
+msgstr ":doc:`profiler`"
+
+#: ../../panes/variableexplorer.rst:3
+msgid "Variable Explorer"
+msgstr "Explorador de variables"
+
+#: ../../panes/variableexplorer.rst:5
+msgid "The **Variable Explorer** allows you to interactively browse and manage the objects generated running your code."
+msgstr "El **Explorador de variables** te permite navegar y administrar de forma interactiva los objetos generados al ejecutar tu código."
+
+#: ../../panes/variableexplorer.rst:10
+msgid "It shows the namespace contents (including all global objects, variables, class instances and more) of the currently selected :doc:`ipythonconsole` session, and allows you to add, remove, and edit their values through a variety of GUI-based editors."
+msgstr "Muestra el contenido del espacio de nombres (incluyendo todos los objetos globales, variables, instancias de clase y más) de la sesión :doc:`ipythonconsole` seleccionada, y te permite agregar, eliminar y editar sus valores a través de una variedad de editores basados en GUI."
+
+#: ../../panes/variableexplorer.rst:15
+msgid "The Variable Explorer gives you information on the name, size, type and value of each object. To modify a scalar variable, like an number, string or boolean, simply double click it in the pane and type its new value."
+msgstr "El Explorador de variables te proporciona información sobre el nombre, tamaño, tipo y valor de cada objeto. Para modificar una variable escalar, como un número, cadena o booleano, simplemente haz doble clic en el panel y escribe su nuevo valor."
+
+#: ../../panes/variableexplorer.rst:25
+msgid "Object viewers"
+msgstr "Visor de objetos"
+
+#: ../../panes/variableexplorer.rst:27
+msgid "Spyder's :guilabel:`Variable Explorer` offers built in support for editing lists, strings, dictionaries, NumPy arrays, Pandas DataFrames, Series and more; as well as being able to plot and visualize them with one click."
+msgstr "El :guilabel:`Explorador de variables` de Spyder ofrece soporte integrado para editar listas, cadenas, diccionarios, matrices NumPy, Pandas DataFrames, Series y más; además de poder crear gráficos y visualizarlos con un solo clic."
+
+#: ../../panes/variableexplorer.rst:31
+msgid "Strings"
+msgstr "Cadenas de texto"
+
+#: ../../panes/variableexplorer.rst:33
+msgid "When a string variable is longer than forty characters, you can double click it to see its value in a text editor to more easily modify it."
+msgstr "Cuando una variable de cadena es más larga que cuarenta caracteres, puedes hacer doble clic en ella para ver su valor en un editor de texto para modificarla más fácilmente."
+
+#: ../../panes/variableexplorer.rst:41
+msgid "Dictionaries"
+msgstr "Diccionarios"
+
+#: ../../panes/variableexplorer.rst:43
+msgid "Double-clicking on dictionaries will show a viewer displaying each of its keys with its associated value. You can double click any of the values to modify them, which will open a new viewer if the value is itself an object."
+msgstr "Al hacer doble clic en los diccionarios se desplegará un visor que muestra cada una de sus llaves con su valor asociado. Puedes hacer doble clic en cualquiera de los valores para modificarlos, lo que abrirá un nuevo visor si el valor en sí mismo es un objeto."
+
+#: ../../panes/variableexplorer.rst:52
+msgid "Lists"
+msgstr "Listas"
+
+#: ../../panes/variableexplorer.rst:54
+msgid "For lists, the main Variable Explorer displays a preview of the first ten values. To see them all, double click the list to open a viewer that will display the index, type, size and value of each element of the list. Just like dictionaries, you can double-click values to edit them."
+msgstr "En el caso de las listas, el Explorador de variables principal muestra una vista previa de los diez primeros valores. Para verlos todos, haz doble clic en la lista para abrir un visor que te mostrará el índice, tipo, tamaño y valor de cada elemento de la lista. Al igual que los diccionarios, puedes hacer doble clic en los valores para editarlos."
+
+#: ../../panes/variableexplorer.rst:64
+msgid "Numpy arrays"
+msgstr "Arreglos de NumPy"
+
+#: ../../panes/variableexplorer.rst:66
+msgid "Like lists, for Numpy arrays the Variable Explorer shows a preview of their values. Double-clicking them will open a viewer displaying the array values in a \"heat map\", with each value in a grid cell colored based on its numeric quantity. You can deactivate the background color by unchecking the appropriate option in the viewer, which will happen automatically if the array is too large to improve performance."
+msgstr "Al igual que las listas, para las arreglos de Numpy el Explorador de variables muestra una vista previa de sus valores. Al hacer doble clic en ellos, se abrirá un visor que muestra los valores de la matriz en un \"mapa de calor\", con cada valor en una celda de cuadrícula coloreada en base a su cantidad numérica. Puedes desactivar el color de fondo desmarcando la opción apropiada en el visor, lo que sucederá automáticamente si la matriz es demasiado grande para mejorar el rendimiento."
+
+#: ../../panes/variableexplorer.rst:73
+msgid "If supported by the datatype, you can also change the format of the array's values, choosing the number of decimals that you want the array to display. For this, click the :guilabel:`Format` button and and set the desired formatting in the dialog that appears, using standard `Printf-style syntax`_."
+msgstr "Si es compatible con el tipo de datos, también puedes cambiar el formato de los valores del arreglo, eligiendo el número de decimales que desea que el arreglo muestre. Para esto, haz clic en el botón :guilabel:`Formato` y establece el formato deseado en el diálogo que aparece, usando la sintaxis estándar `Printf-style syntax`_."
+
+#: ../../panes/variableexplorer.rst:78
+msgid "Additionally, you can adjust the size of the rows and columns of the array by expanding or contracting their headers. Clicking the :guilabel:`Resize` button will set it automatically."
+msgstr "Además, puedes ajustar el tamaño de las filas y columnas del arreglo expandiendo o contrayendo sus encabezados. Al hacer clic en el botón :guilabel:`Cambiar tamaño` se establecerá automáticamente."
+
+#: ../../panes/variableexplorer.rst:86
+msgid "DataFrames"
+msgstr "DataFrames"
+
+#: ../../panes/variableexplorer.rst:88
+msgid "DataFrames, like Numpy arrays, display in a viewer where you can show or hide \"heatmap\" colors, change the format and resize the rows and columns either manually or automatically."
+msgstr "Los DataFrames, al igual que los arreglos de Numpy, se muestran en un visor donde puedes mostrar u ocultar los colores del \"mapa de calor\", cambiar el formato y cambiar el tamaño de las filas y columnas, ya sea de forma manual o automática."
+
+#: ../../panes/variableexplorer.rst:93
+msgid "Additionally, starting in Spyder 4, the Variable Explorer has MultiIndex support in its DataFrame inspector, including for multi-level and multi-dimensional indices."
+msgstr "Adicionalmente, a partir de Spyder 4, el Explorador de variables tiene soporte MultiIndex en su inspector de DataFrame, incluyendo índices multi-nivel y multidimensionales."
+
+#: ../../panes/variableexplorer.rst:105
+msgid "The options menu in the top right of the Variable Explorer pane allows you filter the objects shown by a number of different criteria."
+msgstr "El menú de opciones en la parte superior derecha del panel de Explorador de variables te permite filtrar los objetos mostrados por una serie de criterios diferentes."
+
+#: ../../panes/variableexplorer.rst:110
+msgid "It also allows you to display the min and max of Numpy arrays instead of a preview of their values."
+msgstr "También te permite mostrar el mínimo y máximo de los arreglos de NumPy en lugar de una vista previa de sus valores."
+
+#: ../../panes/variableexplorer.rst:120
+msgid "Toolbar buttons"
+msgstr "Botones de la barra de herramientas"
+
+#: ../../panes/variableexplorer.rst:122
+msgid "The Variable Explorer's toolbar includes several useful features that affect the entire namespace. For example, you can save the current session's data as a ``.spydata`` file, which can be loaded later to recover all the variables stored."
+msgstr "La barra de herramientas del Explorador de variables incluye varias características útiles que afectan a todo el espacio de nombres. Por ejemplo, puedes guardar los datos de la sesión actual como un archivo ``.spydata``, que se puede cargar más tarde para recuperar todas las variables almacenadas."
+
+#: ../../panes/variableexplorer.rst:130
+msgid "You should **not** load any ``.spydata`` file from any source you don't fully trust (ideally, only those files you've saved yourself). Like with any `Python pickle`_, it is inherently not secure against malicious code, as it can load any Python object and can execute arbitrary code on your machine. Additionally, it is not guaranteed to work reliably across all Python environments other than the one it was created in, so it should be only used as a local persistence format, not for interchange."
+msgstr "**No** debes cargar ningún archivo ``.spydata`` desde cualquier fuente en la que no confíes (idealmente, solo aquellos archivos que hayas guardado tu mismp). Al igual que con cualquier `Python pickle`_, no es inherentemente seguro contra código malicioso, ya que puede cargar cualquier objeto Python y puede ejecutar código arbitrario en tu máquina. Además, no se garantiza que funcione de forma fiable en todos los entornos de Python que no sean en aquel en el que se creó, por lo que sólo debería utilizarse como formato de persistencia local, y no para intercambio."
+
+#: ../../panes/variableexplorer.rst:136
+msgid "There is also a button to remove all displayed variables, and a search box to find objects by  name or type."
+msgstr "También hay un botón para eliminar todas las variables mostradas, y un cuadro de búsqueda para encontrar objetos por nombre o tipo."
+
+#: ../../panes/variableexplorer.rst:141
+msgid "Finally, there is a button to refresh the Variable Explorer's contents, which will update it to show the current state of the code running in the IPython console."
+msgstr "Por último, hay un botón para actualizar el contenido del Explorador de variables, que lo actualizará para mostrar el estado actual del código que se ejecuta en la consola IPython."
+
+#: ../../panes/variableexplorer.rst:147
+msgid "Advanced functionality"
+msgstr "Funcionalidad avanzada"
+
+#: ../../panes/variableexplorer.rst:149
+msgid "The context menu, available by right-clicking any variable, provides numerous additional options to interact with objects of various types. These include renaming, removing or editing existing variables, as well as the :guilabel:`duplicate` option to create a new copy of one of them under a new name you enter in the resulting dialog box."
+msgstr "El menú contextual, disponible haciendo clic derecho en cualquier variable, proporciona numerosas opciones adicionales para interactuar con objetos de varios tipos. Estas incluyen renombrar, eliminar o editar variables existentes, así como la opción :guilabel:`Duplicar` para crear una nueva copia de una de ellas bajo un nuevo nombre que puedes ingresar en el cuadro de diálogo resultante."
+
+#: ../../panes/variableexplorer.rst:155
+msgid "Furthermore, you can copy and paste the value of a variable, saving it in the Variable Explorer with any name that you choose. This allows you to change the type of the variable that you are pasting which can be very useful, allowing you to, for example, easily copy the elements of a list into an array."
+msgstr "Además, puedes copiar y pegar el valor de una variable, guardándola en el Explorador de variables con el nombre que elijas. Esto te permite cambiar el tipo de variable que estás pegando, lo que puede ser muy útil. Por ejemplo, te permite copiar fácilmente los elementos de una lista en una matriz."
+
+#: ../../panes/variableexplorer.rst:161
+msgid "Additionally, you can create an object from scratch directly in the Variable Explorer with the :guilabel:`Insert` option, which allows you to type the key (which should be in quotation marks) and the value for the item that you want to insert. In addition to adding a new top-level variable, this feature also allows you to create a new key in a dictionary, a new element in a list, and much more."
+msgstr "Adicionalmente, puedes crear un objeto desde cero directamente en el Explorador de variables con la opción :guilabel:`Insertar`, que te permite escribir la clave (que debería estar entre comillas) y el valor del elemento que deseas insertar. Además de añadir una nueva variable de nivel superior, esta característica también te permite crear una nueva llave en un diccionario, un nuevo elemento en una lista, y mucho más."
+
+#: ../../panes/variableexplorer.rst:167
+msgid "For lists and Numpy arrays, more advanced options are available, including generating plots and histograms of their values appropriate to their type and dimensions."
+msgstr "Para listas y arreglos de NumPy, hay opciones avanzadas disponibles, incluyendo la generación de gráficos e histogramas de sus valores apropiados a su tipo y dimensiones."
+
+#: ../../panes/variableexplorer.rst:172
+msgid "You can even save an array to a ``.npy`` file by simply clicking the appropriate option, which can later be loaded by Spyder or in your code via ``numpy.load()``."
+msgstr "Incluso puedes guardar un arreglo en un archivo ``.npy`` simplemente haciendo clic en la opción apropiada, que luego puede ser cargada por Spyder o en tu código a través de ``numpy.load()``."
+
+#: ../../panes/variableexplorer.rst:178
+msgid "For two-dimensional arrays, you can also display them as images, treating their values as RGB colors. For this, Spyder uses Matplotlib's colormaps, which can be `easily changed to match your preferences`_."
+msgstr "En el caso de arreglos bidimensionales, también puedes mostrarlos como imágenes, tratando sus valores como colores RGB. Para esto, Spyder utiliza los mapas de colores de Matplotlib, que pueden ser `fácilmente cambiados para que coincidan con tus preferencias`_."
+
+#: ../../panes/variableexplorer.rst:185
+msgid "Finally, we added a context-menu action to open any object using the new Object Explorer even if they already have a builtin viewer (DataFrames, arrays, etc), allowing for deeper inspection of the inner workings of these datatypes."
+msgstr "Finalmente, hemos añadido una acción de menú contextual para abrir cualquier objeto usando el nuevo Explorador de objetos incluso si ya tienen un visor incorporado (DataFrames, arreglos, etc) permitiendo una inspección más profunda del funcionamiento interno de estos tipos de datos."
+

--- a/doc/locales/es/LC_MESSAGES/plugins.po
+++ b/doc/locales/es/LC_MESSAGES/plugins.po
@@ -1,0 +1,233 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: spyder-documentation\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: 2024-09-10 00:48\n"
+"Last-Translator: \n"
+"Language: es\n"
+"Language-Team: Spanish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+"X-Crowdin-Project: spyder-documentation\n"
+"X-Crowdin-Project-ID: 641502\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /doc/locales/en/LC_MESSAGES/plugins.po\n"
+"X-Crowdin-File-ID: 20\n"
+
+#: ../../plugins/index.rst:3
+msgid "Spyder Plugins"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:3
+msgid "Spyder Line Profiler"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:5
+msgid "**Spyder-Line-Profiler** is a plugin to run the Python `line profiler`_. This package profiles the time that individual lines of code take to execute."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:17
+msgid "Installing the Line Profiler"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:19
+msgid "If you installed Spyder using conda, the best way to obtain Spyder-Line-Profiler is to run the following command in your terminal (or Anaconda prompt on Windows):"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:27
+msgid "At the moment it is not possible to use this plugin with the Spyder :ref:`install-standalone` for Windows and macOS. We're working to add support for them in the future."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:30 ../../plugins/notebook.rst:26
+#: ../../plugins/terminal.rst:27
+msgid "Restart Spyder in order to be able to use the plugin."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:36
+msgid "Using the Line Profiler"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:38
+msgid "When the Line Profiler is installed, it will be available under the menu item :menuselection:`View --> Panes --> Line Profiler`."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:43
+msgid "You will see it then as a tab next to the :guilabel:`Files` tab. For the Line Profiler to work, you must place the ``@profile`` decorator on the line above any functions that you wish to profile."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:49
+msgid "Now that the decorators have been added, you can then either select a script with the button present in the pane or run the profiler from :menuselection:`Run --> Profile line by line`. Your file will then be profiled line by line."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:55
+msgid "After running the profiler, either from the button in the pane or the :menuselection:`Run` menu, the results are shown in the :guilabel:`Line Profiler` pane. The path displayed there is that of the file being profiled."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:61
+msgid "The Line Profiler pane shows six columns:"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:63
+msgid "``Line #:`` the number of the line being profiled."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:64
+msgid "``Hits:`` how many times that line is hit in the scope."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:65
+msgid "``Time (ms):`` time spent running the line in total for all hits, in milliseconds."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:66
+msgid "``Per hit (ms):`` average time spent per hit, in milliseconds."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:67
+msgid "``% Time:`` percentage of time taken by that line of total scope time."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:68
+msgid "``Line contents:`` the source code in the line."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:70
+msgid "Lines with a stronger color take more time to run."
+msgstr ""
+
+#: ../../plugins/notebook.rst:3
+msgid "Spyder Notebook"
+msgstr ""
+
+#: ../../plugins/notebook.rst:5
+msgid "**Spyder-notebook** is a plugin that allows you to open, edit and interact with Jupyter Notebooks right inside Spyder."
+msgstr ""
+
+#: ../../plugins/notebook.rst:10
+msgid "Using notebooks inside Spyder allows you to take advantage of their web interface alongside Spyder’s powerful features such as the Variable explorer, console and debugger."
+msgstr ""
+
+#: ../../plugins/notebook.rst:14
+msgid "Installing the Notebook"
+msgstr ""
+
+#: ../../plugins/notebook.rst:16
+msgid "If you installed Spyder using conda, the best way to install Spyder-notebook is to run the following command in your terminal or Anaconda prompt on Windows:"
+msgstr ""
+
+#: ../../plugins/notebook.rst:24 ../../plugins/terminal.rst:25
+msgid "At the moment it is not possible to use this plugin with the Spyder :ref:`install-standalone` for Windows and macOS. We're working to make that possible in the future."
+msgstr ""
+
+#: ../../plugins/notebook.rst:30
+msgid "Using the Notebook"
+msgstr ""
+
+#: ../../plugins/notebook.rst:32
+msgid "When the Notebook is installed, it will be available under the menu item :menuselection:`View --> Panes --> Notebook`."
+msgstr ""
+
+#: ../../plugins/notebook.rst:37
+msgid "You will see it then as a tab in the bottom of the editor area. When switching to it, a welcome screen will be displayed, from where you can create a new notebook by right-clicking it and selecting :guilabel:`New notebook`."
+msgstr ""
+
+#: ../../plugins/notebook.rst:42
+msgid "You can also click the :guilabel:`Plus` button at the top right of the pane. A new Jupyter Notebook will be opened as a tab, ready for user input in a temporary file. This can serve as a scratch pad where you can do quick calculations and plots."
+msgstr ""
+
+#: ../../plugins/notebook.rst:47
+msgid "To save this notebook go to the options menu at the top right of the pane and click the :guilabel:`Save as...` option. This will store your notebook locally with the ``ipynb`` extension, which will allow you to open it then as a Jupyter Notebook outside of Spyder."
+msgstr ""
+
+#: ../../plugins/notebook.rst:52
+msgid "You can also open any Jupyter Notebook inside Spyder. For this go to the options menu at the top right of the pane and click :guilabel:`Open`, which will allow you to look for ``ipynb`` files in your computer. Click any notebook that you want to open inside Spyder and you will be able to see it as a new tab in the Notebook pane."
+msgstr ""
+
+#: ../../plugins/notebook.rst:57
+msgid "The :guilabel:`Open recent` option displays a list of the recent notebooks you opened in Spyder, from which you can select them and open them again in Spyder."
+msgstr ""
+
+#: ../../plugins/notebook.rst:61
+msgid "Connecting an IPython Console"
+msgstr ""
+
+#: ../../plugins/notebook.rst:63
+msgid "You can connect an :doc:`/panes/ipythonconsole` to your notebook, which will allow you to view your variables in the :doc:`/panes/variableexplorer`. To do so, go to the options menu and click the :guilabel:`Open console` option. This will open a new console with the same name of your notebook and display the variables of the cells that you have executed previously in your Notebook. If you don't see them, press :kbd:`Enter` in the console."
+msgstr ""
+
+#: ../../plugins/notebook.rst:68
+msgid "You can view, modify and create new ones in the console too."
+msgstr ""
+
+#: ../../plugins/notebook.rst:70
+msgid "Since the Variable Explorer is associated to each console, closing the notebook's console will immediately hide the variables from the Variable Explorer."
+msgstr ""
+
+#: ../../plugins/notebook.rst:74
+msgid "Additional Options"
+msgstr ""
+
+#: ../../plugins/notebook.rst:76
+msgid "The context menu, available by right-clicking the pane area outside the notebook, allows you to zoom your notebook in or out."
+msgstr ""
+
+#: ../../plugins/notebook.rst:81
+msgid "You can also select the code from your Notebook and copy it on your clipboard to paste this code anywhere you want."
+msgstr ""
+
+#: ../../plugins/notebook.rst:86
+msgid "Finally, you can see all the server information of your notebook by clicking the :guilabel:`Server info` option in the context menu."
+msgstr ""
+
+#: ../../plugins/terminal.rst:3
+msgid "Spyder Terminal"
+msgstr ""
+
+#: ../../plugins/terminal.rst:5
+msgid "**Spyder-terminal** is a plugin that allows you to have integrated system terminals inside Spyder."
+msgstr ""
+
+#: ../../plugins/terminal.rst:10
+msgid "Spyder-terminal allows you to use any system shell installed in your system (e.g. Bash, Zsh or Powershell) rather than just the IPython console. You can use it to issue commands, interact with version control or to run programs."
+msgstr ""
+
+#: ../../plugins/terminal.rst:15
+msgid "Installing the Terminal"
+msgstr ""
+
+#: ../../plugins/terminal.rst:17
+msgid "If you installed Spyder using conda, the best way to install Spyder-terminal is to run the following command in your Terminal or Anaconda prompt on Windows:"
+msgstr ""
+
+#: ../../plugins/terminal.rst:31
+msgid "Using the Terminal"
+msgstr ""
+
+#: ../../plugins/terminal.rst:33
+msgid "When the Terminal is installed, it will be available under the menu item :menuselection:`View --> Panes --> Terminal`."
+msgstr ""
+
+#: ../../plugins/terminal.rst:38
+msgid "You will see it then as a tab at the bottom of the console area. When switching to it, a new terminal tab will be created. You can also create more terminals by clicking in the :guilabel:`+` button at the upper right corner of the terminal area."
+msgstr ""
+
+#: ../../plugins/terminal.rst:43
+msgid "Clicking the :guilabel:`Options` button next to the :guilabel:`+` button will allow you to rename terminals, undock the terminal, and open a terminal in the directory of the current Editor file."
+msgstr ""
+
+#: ../../plugins/terminal.rst:48
+msgid "If you right click the terminal area, it's possible to issue commands such as :guilabel:`Clear Terminal`, :guilabel:`Zoom In/Out` and :guilabel:`Copy/Paste Text`."
+msgstr ""
+
+#: ../../plugins/terminal.rst:55
+msgid "Terminal Preferences"
+msgstr ""
+
+#: ../../plugins/terminal.rst:57
+msgid "It's also possible to customize the Terminal by going to :menuselection:`python --> Preferences...` and then clicking on the Terminal tab on the menu to the left. You can select the shell interpreter, set the buffer limit and the type of cursor."
+msgstr ""
+

--- a/doc/locales/es/LC_MESSAGES/quickstart.po
+++ b/doc/locales/es/LC_MESSAGES/quickstart.po
@@ -1,0 +1,28 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: spyder-documentation\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: 2024-09-10 00:48\n"
+"Last-Translator: \n"
+"Language: es\n"
+"Language-Team: Spanish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+"X-Crowdin-Project: spyder-documentation\n"
+"X-Crowdin-Project-ID: 641502\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /doc/locales/en/LC_MESSAGES/quickstart.po\n"
+"X-Crowdin-File-ID: 14\n"
+
+#: ../../quickstart.rst:3
+msgid "Quickstart"
+msgstr ""
+
+#: ../../quickstart.rst:5
+msgid "Welcome to our Quickstart! Here you will find an interactive tour that will guide you through Spyder's interface. You'll get familiar with the most important parts of the IDE, especially those we'll be mentioning throughout our docs. Finally, you'll get to walk through some of Spyder's key panes and functionality."
+msgstr ""
+

--- a/doc/locales/es/LC_MESSAGES/troubleshooting.po
+++ b/doc/locales/es/LC_MESSAGES/troubleshooting.po
@@ -1,0 +1,804 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: spyder-documentation\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: 2024-09-11 23:01\n"
+"Last-Translator: \n"
+"Language: es\n"
+"Language-Team: Spanish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+"X-Crowdin-Project: spyder-documentation\n"
+"X-Crowdin-Project-ID: 641502\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /doc/locales/en/LC_MESSAGES/troubleshooting.po\n"
+"X-Crowdin-File-ID: 28\n"
+
+#: ../../troubleshooting/basic-first-aid.rst:3
+msgid "Basic First Aid"
+msgstr "Primera ayuda básica"
+
+#: ../../troubleshooting/basic-first-aid.rst:5
+msgid "These suggestions, while more of a shotgun approach, tend to fix the majority of reported issues just on their own."
+msgstr "Estas sugerencias, si bien son más un enfoque de shotgun, tienden a arreglar la mayoría de los problemas informados por sí solos."
+
+#: ../../troubleshooting/basic-first-aid.rst:11
+msgid "Recommended troubleshooting steps"
+msgstr "Pasos recomendados para la solución de problemas"
+
+#: ../../troubleshooting/basic-first-aid.rst:13
+msgid "**Restart Spyder**, and try what you were doing before again."
+msgstr "**Reinicia Spyder**, y prueba lo que estabas haciendo antes de nuevo."
+
+#: ../../troubleshooting/basic-first-aid.rst:15
+msgid "**Upgrade Spyder** to the latest release, and you might find your issue is resolved (along with new features, enhancements, and other bug fixes). Minor releases come out every couple months, so unless you've updated recently, there is a good chance your version isn't the latest. You can find out with the :guilabel:`Check for updates` command under the :guilabel:`Help` menu."
+msgstr "**Actualiza Spyder** a la última versión, y puede que encuentres que tu problema está resuelto (junto con nuevas características, mejoras y otras correcciones de errores). Los lanzamientos menores salen cada par de meses, así que a menos que se haya actualizado recientemente, hay una buena posibilidad de que tu versión no sea la última. Puedes encontrar con el comando :guilabel:`Buscar actualizaciones` en el menú de :guilabel:`Ayuda`."
+
+#: ../../troubleshooting/basic-first-aid.rst:22
+msgid "To perform the update with Conda (strongly recommended), from your terminal (or Anaconda Prompt on Windows) run:"
+msgstr "Para realizar la actualización con Conda (altamente recomendado), desde tu terminal (o en el Anaconda Prompt en Windows):"
+
+#: ../../troubleshooting/basic-first-aid.rst:29
+msgid "**Update Spyder's dependencies and environment**, either by installing the latest version of your distribution (e.g. the recommended Anaconda), or with the relevant \"update all\" command in your terminal (or Anaconda Prompt on Windows). To get the latest stable version of everything using Conda, you can run:"
+msgstr "**Actualiza las dependencias y el entorno de Spyder**, instalando la última versión de tu distribución (p. ej. el recomendado Anaconda), o con el comando correspondiente \"update all\" en tu terminal (o en el Anaconda Prompt en Windows). Para obtener la última versión estable de todo usando Conda puedes ejecutar:"
+
+#: ../../troubleshooting/basic-first-aid.rst:36
+msgid "**Restart your machine**, in case the problem lies with a lingering process or another such issue."
+msgstr "**Reinicie tu máquina**, en caso de que el problema resida en un proceso de permanencia o de cualquier otro tipo."
+
+#: ../../troubleshooting/basic-first-aid.rst:38
+msgid "**Restore Spyder's config files** to their defaults, which solves a huge variety of Spyder issues. From your terminal (or Anaconda Prompt on Windows), run:"
+msgstr "**Restaura los archivos de configuración de Spyder** a sus valores predeterminados, lo que resuelve una gran variedad de problemas de Spyder. Desde tu terminal (o en el Anaconda Prompt en Windows), ejecuta:"
+
+#: ../../troubleshooting/basic-first-aid.rst:47
+msgid "This will reset your preferences, as well as any custom keyboard shortcuts or syntax highlighting schemes. If you particularly care about any of those, you should make a copy of the :file:`.spyder-py3` folder in your user home directory (:file:`C:/Users/YOUR_USERNAME` on Windows, :file:`/Users/YOUR_USERNAME` on macOS, or :file:`/home/YOUR_USERNAME` on Linux), and restore it afterwards if this doesn't solve the problem."
+msgstr "Esto restablecerá tus preferencias, así como cualquier atajo de teclado personalizado o esquemas de resaltado de sintaxis. Si te preocupa especialmente alguno de ellos, deberías hacer una copia de la carpeta :file:`.spyder-py3` en tu directorio de inicio de usuario (:file:`C:/Users/YOUR_USERNAME` en Windows, :file:`/Users/YOUR_USERNAME` en macOS, o :file:`/home/YOUR_USERNAME` en Linux), y restaurarlo después si esto no resuelve el problema."
+
+#: ../../troubleshooting/basic-first-aid.rst:50
+msgid "**Try installing Spyder into a new Conda environment** (recommended) or ``virtualenv``/``venv``, and see if the issue reoccurs."
+msgstr "**Intenta instalar Spyder en un nuevo entorno Conda** (recomendado) o ``virtualenv``/``venv``, y mira si el problema vuelve a producirse."
+
+#: ../../troubleshooting/basic-first-aid.rst:52
+msgid "In your system terminal (or Anaconda Prompt on Windows), run the following commands to create an a fresh, clean environment and start Spyder in it:"
+msgstr "En tu terminal de sistema (o en el Anaconda Prompt en Windows), ejecuta los siguientes comandos para crear un entorno fresco y limpio e iniciar Spyder en él:"
+
+#: ../../troubleshooting/basic-first-aid.rst:60
+msgid "If this fixes the issue, the problem was likely due to another package installed on your system, particularly if done with pip, which can cause many problems and should be avoided if at all possible."
+msgstr "Si esto soluciona el problema es porque probable el problema se deba a otro paquete instalado en tu sistema, especialmente si se hace con pip que puede causar muchos problemas y debe evitarse si es posible."
+
+#: ../../troubleshooting/basic-first-aid.rst:62
+msgid "**Watch our video** on solving and avoiding problems with pip, Conda and Conda-Forge, and follow its instructions."
+msgstr "**Mira nuestro vídeo** para resolver y evitar problemas con pip, Conda y Conda-Forge, y sigue sus instrucciones."
+
+#: ../../troubleshooting/basic-first-aid.rst:75
+msgid "Reinstalling Spyder"
+msgstr "Reinstalar Spyder"
+
+#: ../../troubleshooting/basic-first-aid.rst:77
+msgid "If none of the previous steps solve your issue, you should do a full uninstall of Spyder by whatever means you originally installed it."
+msgstr "Si ninguno de los pasos anteriores resuelve tu problema, deberías hacer una desinstalación completa de Spyder por el mismo medio que lo hayas instalado originalmente."
+
+#: ../../troubleshooting/basic-first-aid.rst:79
+msgid "For Anaconda, follow all the steps under Option B in the `Anaconda uninstall guide`_, delete the Anaconda directory wherever it was originally installed, and (on Windows) remove the :file:`%appdata%/python` directory if it exists."
+msgstr "Para Anaconda, sigue todos los pasos bajo la opción B en la `Anaconda uninstall guide`_, borra el directorio de Anaconda dondequiera que fue instalado originalmente, y (en Windows) elimina el directorio :file:`%appdata%/python` si existe."
+
+#: ../../troubleshooting/basic-first-aid.rst:84
+msgid "Then, do a clean install of the latest version of the `Anaconda distribution`_ which is how we recommend you install Spyder and keep it up to date."
+msgstr "Luego, haz una instalación limpia de la última versión de la `Anaconda distribution`_ que es la forma en que te recomendamos instalar Spyder y mantenerlo actualizado."
+
+#: ../../troubleshooting/basic-first-aid.rst:88
+msgid "While you are welcome to get Spyder working on your own by one of the many other means we offer, we are only able to provide individual support for install-related issues for users of the Anaconda distribution. In particular, pip installation, while doable, is only really for experts, as there are many pitfalls involved and different issues specific to your setup, which is why we recommend using Conda whenever possible. For further information, please visit our :doc:`/installation`."
+msgstr "Aunque eres bienvenido a hacer que Spyder trabaje por tu cuenta por uno de los muchos otros medios que ofrecemos, solo podemos proporcionar soporte individual para problemas relacionados con la instalación para los usuarios de la distribución Anaconda. En particular, la instalación de pip, aunque factible, es realmente para expertos ya que hay muchas dificultades involucradas y diferentes problemas específicos para su configuración, por eso recomendamos usar Conda siempre que sea posible. Para más información, por favor visite nuestro :doc:`/installation`."
+
+#: ../../troubleshooting/basic-first-aid.rst:99
+msgid "Isolating problems"
+msgstr "Aislar problemas"
+
+#: ../../troubleshooting/basic-first-aid.rst:101
+msgid "If you get an error while running a specific line, block, or script/program, it may not be an issue with Spyder, but rather something lower down in the packages it depends on. Try running it in the following in order if and until it starts working as you expect. If you manage to isolate the bug, report it to the last one it *doesn't* work in."
+msgstr "Si obtienes un error al ejecutar una línea, bloque o programa específico, puede que no sea un problema con Spyder, sino más bien algo más bajo en los paquetes de los que depende. Intenta ejecutarlo de la siguiente manera en orden hasta que comience a funcionar como esperas. Si logras aislar el error, repórtarlo al último en el que *no* funciona."
+
+#: ../../troubleshooting/basic-first-aid.rst:105
+msgid "**Spyder** itself, of course! Make sure you can reproduce the error after closing and reopening it, if possible."
+msgstr "¡**Spyder** mismo, por supuesto! Asegúrate de que puedas reproducir el error después de cerrarlo y reabrirlo, si es posible."
+
+#: ../../troubleshooting/basic-first-aid.rst:108
+msgid "**A bare QtConsole instance**, e.g. launched from Anaconda navigator or from the Anaconda Prompt/Terminal/command line (Windows/Mac/Linux) with ``jupyter qtconsole``."
+msgstr "**Una instancia de QtConsole**, por ejemplo, lanzada desde el navegador Anaconda o desde Anaconda Prompt/Consola/línea de comando (Windows/Mac/Linux) con ``jupyter qtconsole``."
+
+#: ../../troubleshooting/basic-first-aid.rst:113
+msgid "QtConsole is the GUI console backend Spyder depends on to run its code, so most issues involving Spyder's :doc:`/panes/ipythonconsole` are actually something with QtConsole instead, and can be reported to their `issue tracker`_."
+msgstr "QtConsole es el backend de la consola GUI Spyder del que depende para ejecutar su código, así que la mayoría de los problemas involucrando :doc:`/panes/ipythonconsole` son en realidad algo relacionado con QtConsole y pueden ser reportados a su `issue tracker`_."
+
+#: ../../troubleshooting/basic-first-aid.rst:115
+msgid "**An IPython command line shell**, launched with e.g. ``ipython`` from the Anaconda Prompt/Terminal/command line (Windows/Mac/Linux). Reproducible bugs can be reported to their `Github page`_, though make sure to read their guidelines and docs first."
+msgstr "**Un intérprete de línea de comandos IPython** lanzado con, por ejemplo, ``ipython`` desde Anaconda Prompt/Consola/línea de comandos (Windows/Mac/Linux). Los errores reproducibles pueden ser reportados a su `Github page`_, aunque primero asegúrate de leer sus directrices y documentos."
+
+#: ../../troubleshooting/basic-first-aid.rst:118
+msgid "**A standard Python interpreter**, either run as a script file with ``python path/to/your/file.py`` or launched interactively with ``python`` from your Anaconda Prompt/Terminal/command line (Windows/Mac/Linux). While it is not impossible that you've found Python bug, it is much more likely to be an issue with the code itself or a package you are using, so your best sources are the `Python docs`_ and the other resources listed above."
+msgstr "**Un intérprete estándar de Python** que puedes ejecutar como un archivo de script con ``python path/to/your/file.py`` o interactivamente con ``python`` desde Anaconda Prompt/Consola/línea de comandos (Windows/Mac/Linux). Aunque no es imposible que hayas encontrado un error en Python, es mucho más probable que sea un problema con el código en sí mismo o con un paquete que estés usando, así que tus mejores fuentes son la `Python docs`_ y los demás recursos listados anteriormente."
+
+#: ../../troubleshooting/basic-first-aid.rst:127
+msgid "If the problem reoccurs in a similar or identical way with any of these methods (other than only Spyder itself), then it is almost certainly not an issue with Spyder, and would be best handled elsewhere. As we usually aren't able to do much about issues not related to Spyder, a forum like `Stack Overflow`_ or the relevant package's docs is a much better place to get help or report the issue."
+msgstr "Si el problema se reproduce de forma similar o idéntica con cualquiera de estos métodos (aparte de Spyder en sí), entonces casi con toda seguridad no es un problema con Spyder, y sería mejor manejarlo en otros lugares. Como normalmente no somos capaces de hacer mucho sobre problemas no relacionados con Spyder, un foro como `Stack Overflow`_ o la documentación de paquetes relevantes son lugares mucho más apropiados para obtener ayuda o reportar el problema."
+
+#: ../../troubleshooting/basic-first-aid.rst:132
+msgid "See the :doc:`call-for-help` section for other places to look for information and assistance."
+msgstr "Vea la sección :doc:`call-for-help` para conocer otros lugares para buscar información y asistencia."
+
+#: ../../troubleshooting/basic-first-aid.rst:138
+msgid "Debugging and patching"
+msgstr "Depuración y ajuste del código de Spyder"
+
+#: ../../troubleshooting/basic-first-aid.rst:140
+msgid "If you know your way around Python, you can often diagnose and even fix Spyder issues yourself, since the IDE is written in the same language you use in it. You can explore the error messages you're receiving and Spyder's inner workings with the :guilabel:`Internal Console`, available under the menu item :menuselection:`View --> Panes --> Internal Console`."
+msgstr "Si conoces Python, a menudo puedes diagnosticar e incluso solucionar los problemas de Spyder tú mismo, ya que la IDE está escrita en el mismo idioma que utilizas en él. Puedes explorar los mensajes de error que estás recibiendo y el funcionamiento interno de Spyder con la :guilabel:`Terminal interna`, disponible bajo el menú :menuselection:`Ver --> Paneles --> Terminal interna`."
+
+#: ../../troubleshooting/basic-first-aid.rst:146
+msgid "For more detailed debug output, start Spyder from the command line (Anaconda Prompt on Windows) with ``spyder --debug-info verbose``."
+msgstr "Para obtener una salida de depuración más detallada, inicia Spyder desde la línea de comandos (Anaconda Prompt en Windows) con ``spyder --debug-info verbose``."
+
+#: ../../troubleshooting/basic-first-aid.rst:148
+msgid "Even if you don't manage to fix the problem yourself, this output can be very helpful in aiding us to quickly narrow down and solve your issue for you."
+msgstr "Incluso si no logras solucionar el problema por ti mismo, esta salida puede ser muy útil para ayudarnos a reducir rápidamente y resolver tu problema por ti."
+
+#: ../../troubleshooting/call-for-help.rst:3
+msgid "Calling for Help"
+msgstr "Pedir ayuda"
+
+#: ../../troubleshooting/call-for-help.rst:5
+msgid "Aside from this troubleshooting guide, there are a number of other sources of documentation and troubleshooting information you can check before submitting an issue, as they might already offer an answer, or at least help you better understand the problem. Even if we aren't able to help you, these places might."
+msgstr "Además de esta guía de solución de problemas, hay una serie de otras fuentes de documentación e información de solución de problemas que puedes consultar antes de enviar un problema, ya que es posible que ya ofrezcan una respuesta o al menos te ayuden a comprender mejor el problema. Incluso si no somos capaces de ayudarte, estos lugares podrían hacerlo."
+
+#: ../../troubleshooting/call-for-help.rst:14
+msgid "Spyder-related platforms"
+msgstr "Plataformas relacionadas con Spyder"
+
+#: ../../troubleshooting/call-for-help.rst:19
+msgid "Spyder's FAQ section"
+msgstr "Sección de preguntas frecuentes (FAQ) de Spyder"
+
+#: ../../troubleshooting/call-for-help.rst:21
+msgid "Spyder's documentation has a FAQ section, where you might find the answers that you are looking for."
+msgstr "La documentación de Spyder tiene una sección de preguntas frecuentes, donde puedes encontrar las respuestas que estás buscando."
+
+#: ../../troubleshooting/call-for-help.rst:27
+msgid "Spyder's YouTube channel"
+msgstr "Canal de YouTube de Spyder"
+
+#: ../../troubleshooting/call-for-help.rst:29
+msgid "Our `YouTube channel`_ contains helpful videos that will guide you through many of Spyder's features, and provide a starting point for newer users."
+msgstr "Nuestro `YouTube channel`_ contiene videos útiles que te guiarán a través de muchas de las características de Spyder y proporcionan un punto de partida para los nuevos usuarios."
+
+#: ../../troubleshooting/call-for-help.rst:37
+msgid "Spyder Gitter"
+msgstr "Gitter de Spyder"
+
+#: ../../troubleshooting/call-for-help.rst:39
+msgid "We have a public `Gitter room`_ where you can chat directly with the Spyder developers. If you've got a quick question to ask the team and are looking for a quick answer, this is a great place to go."
+msgstr "Tenemos una sala pública `Gitter`_ donde puedes chatear directamente con los desarrolladores de Spyder. Si tienes una pregunta rápida para hacer al equipo y estás buscando una respuesta rápida, este es un buen lugar para ir."
+
+#: ../../troubleshooting/call-for-help.rst:48
+msgid "Spyder Google Group"
+msgstr "Grupo de Google de Spyder"
+
+#: ../../troubleshooting/call-for-help.rst:50
+msgid "Our `Google Group`_ is great for help-related questions, particularly those you aren't sure are a full-on Spyder issue."
+msgstr "Nuestro `Google Group`_ es ideal para preguntas relacionadas con la ayuda, en particular aquellas que no estás seguro de que sean un problema de Spyder."
+
+#: ../../troubleshooting/call-for-help.rst:58
+msgid "Spyder website"
+msgstr "Sitio web de Spyder"
+
+#: ../../troubleshooting/call-for-help.rst:60
+msgid "The `Spyder site`_ contains basic information about the IDE and links to many other helpful resources."
+msgstr "El `Spyder site`_ contiene información básica sobre el IDE y enlaces a muchos otros recursos útiles."
+
+#: ../../troubleshooting/call-for-help.rst:68
+msgid "Stack Overflow tag"
+msgstr "Etiqueta Stack Overflow"
+
+#: ../../troubleshooting/call-for-help.rst:70
+msgid "`Stack Overflow`_ is a great place to start searching and posting, particularly if your question is more programming-related, or has to do with something specific to your own code. It has an vibrant Spyder community as well, with new questions posted every day, and the developers (especially Carlos Cordoba, the lead maintainer) are active in answering them."
+msgstr "`Stack Overflow`_ es un buen lugar para empezar a buscar y publicar, particularmente si tu pregunta está más relacionada con la programación o tiene que ver con algo específico de tu propio código. También tiene una vibrante comunidad Spyder, con nuevas preguntas publicadas todos los días y los desarrolladores (especialmente Carlos Cordoba, el mantenedor principal) están activos para responderlas."
+
+#: ../../troubleshooting/call-for-help.rst:79
+msgid "OpenTeams support"
+msgstr "Soporte de OpenTeams"
+
+#: ../../troubleshooting/call-for-help.rst:81
+msgid "On `OpenTeams`_, you can get help from expert Spyder consultants. OpenTeams offers services from Spyder experts ranging from a brief consultation to an experienced team to help you with a large scale implementation project."
+msgstr "En `OpenTeams`_, puedes obtener ayuda de consultores expertos Spyder. OpenTeams ofrece servicios desde expertos de Spyder que van desde una breve consulta a un equipo experimentado para ayudarte con un proyecto de implementación a gran escala."
+
+#: ../../troubleshooting/call-for-help.rst:91
+msgid "Python resources"
+msgstr "Recursos de Python"
+
+#: ../../troubleshooting/call-for-help.rst:96
+msgid "Official Python help page"
+msgstr "Página oficial de ayuda de Python"
+
+#: ../../troubleshooting/call-for-help.rst:98
+msgid "The `Python help page`_ is a great resource that lists a number of places you can get assistance, support and learning resources for the language and its packages."
+msgstr "La Página de ayuda de Python (`Python help page`_) es un gran recurso que lista una serie de lugares en los que puedes obtener asistencia, soporte y recursos de aprendizaje para del lenguaje y sus paquetes."
+
+#: ../../troubleshooting/call-for-help.rst:106
+msgid "Python documentation"
+msgstr "Documentación de Python"
+
+#: ../../troubleshooting/call-for-help.rst:108
+msgid "The `Python docs`_ can help you understand a number of issues that can be caused by quirks in the language itself, or misunderstandings as to how it behaves."
+msgstr "La `Python docs`_ puede ayudarte a entender una serie de problemas que pueden ser causados por peculiaridades del lenguaje en sí o malentendidos sobre cómo se comporta."
+
+#: ../../troubleshooting/call-for-help.rst:116
+msgid "Python subreddits"
+msgstr "Los subreddits de Python"
+
+#: ../../troubleshooting/call-for-help.rst:118
+msgid "`r/python`_ and `r/learnpython`_ are resources you can use to ask about and discuss issues with Python and its packages. The former is aimed more at general Python usage, and the latter more specifically at beginners."
+msgstr "`r/python`_ y `r/learnpython`_ son recursos que puedes usar para preguntar y discutir problemas con Python y sus paquetes. La primera se dirige más al uso general de Python, y la segunda es más específica para principiantes."
+
+#: ../../troubleshooting/call-for-help.rst:130
+msgid "Data science/SciPy resources:"
+msgstr "Recursos de ciencia de datos/SciPy:"
+
+#: ../../troubleshooting/call-for-help.rst:136
+msgid "Anaconda help"
+msgstr "Ayuda de Anaconda"
+
+#: ../../troubleshooting/call-for-help.rst:138
+msgid "The `Anaconda docs`_ site offers free community help and documentation for the Anaconda applications, installing the Anaconda distribution, and using the Conda package and environment manager; along with paid support options."
+msgstr "El sitio `Anaconda docs`_ ofrece ayuda y documentación gratuita de la comunidad para las aplicaciones de Anaconda, la instalación de la distribución de Anaconda y el uso del administrador de paquetes y entornos Conda; junto con opciones de soporte pagas."
+
+#: ../../troubleshooting/call-for-help.rst:145
+msgid "SciPy.org website"
+msgstr "Sitio web de SciPy.org"
+
+#: ../../troubleshooting/call-for-help.rst:147
+msgid "The `Scipy website`_ is the the central home of the SciPy stack, with information, documentation, help, and bug tracking for many of the core packages used with Spyder, including NumPy, SciPy, Matplotlib, Pandas, Sympy and IPython."
+msgstr "El `Scipy website`_ es el hogar central de SciPy, con información, documentación, ayuda, y seguimiento de errores para muchos de los paquetes principales utilizados con Spyder, incluyendo NumPy, SciPy, Matplotlib, Pandas, Sympy y IPython."
+
+#: ../../troubleshooting/call-for-help.rst:155
+msgid "Project Jupyter"
+msgstr "Proyecto Jupyter"
+
+#: ../../troubleshooting/call-for-help.rst:157
+msgid "`Jupyter`_ is the development hub for IPython, Spyder's QtConsole, Jupyter notebooks used with the `Spyder-Notebook`_ plugin, and more."
+msgstr "`Jupyter`_ es el centro de desarrollo de IPython, el QtConsole de Spyder, los Jupyter notebooks usados con el plugin `Spyder-Notebook`_ y más."
+
+#: ../../troubleshooting/call-for-help.rst:166
+msgid "Data Science Stack Exchange"
+msgstr "Stack Exchange de Data Science"
+
+#: ../../troubleshooting/call-for-help.rst:168
+msgid "The `Data Science`_ site in Stack Exchange can be very useful for questions that relate more to data science than programming specifically."
+msgstr "El sitio `Data Science`_ en Stack Exchange puede ser muy útil para preguntas que se relacionan más con la ciencia de datos que con la programación específica."
+
+#: ../../troubleshooting/common-illnesses.rst:3
+msgid "Common Illnesses"
+msgstr "Problemas comunes"
+
+#: ../../troubleshooting/common-illnesses.rst:5
+msgid "Beyond the general troubleshooting steps, some frequently-reported problems require more specialized solutions."
+msgstr "Más allá de los pasos generales de la solución de problemas, algunos problemas reportados con frecuencia requieren soluciones más especializadas."
+
+#: ../../troubleshooting/common-illnesses.rst:13
+msgid "Errors starting the kernel"
+msgstr "Errores al iniciar el núcleo"
+
+#: ../../troubleshooting/common-illnesses.rst:15
+msgid "If you receive the message ``An error occurred while starting the kernel`` in the :doc:`/panes/ipythonconsole`, Spyder was unable to launch a new Python interpreter in the current working environment to run your code. There are a number of problems that can cause this, but most can be fixed fairly quickly with a few easy steps."
+msgstr "Si recibes el mensaje ``Ocurrió un error mientras iniciaba el núcleo`` en el :doc:`/panes/ipythonconsole`, Spyder no pudo lanzar un nuevo intérprete de Python en el entorno de trabajo actual para ejecutar su código. Hay una serie de problemas que pueden causarlo, pero la mayoría se puede solucionar con bastante rapidez con unos pocos pasos fáciles."
+
+#: ../../troubleshooting/common-illnesses.rst:22
+msgid "Spyder-Kernels not installed/incompatible"
+msgstr "Spyder-Kernels no está instalado o es incompatible"
+
+#: ../../troubleshooting/common-illnesses.rst:24
+msgid "Spyder requires a supported version of the ``spyder-kernels`` package to be present in the working environment you want to run your console in."
+msgstr "Spyder requiere que una versión compatible del paquete``spyder-kernels`` esté presente en el entorno de trabajo en el que deseas ejecutar tu consola."
+
+#: ../../troubleshooting/common-illnesses.rst:29
+msgid "It is included by default with Anaconda, but if you want to run your code in another Python environment or installation, you'll need to make sure it's installed and updated to the latest version."
+msgstr "Se incluye por defecto con Anaconda, pero si quieres ejecutar tu código en otro entorno Python o instalación, necesitarás asegurarte de que esté instalado y actualizado a la última versión."
+
+#: ../../troubleshooting/common-illnesses.rst:31
+msgid "Check the required version of spyder-kernels for your version of Spyder in the following table:"
+msgstr "Revisa la versión requerida de los spyder-kernels para tu versión de Spyder en la siguiente tabla:"
+
+#: ../../troubleshooting/common-illnesses.rst:33
+msgid "Spyder and Spyder-Kernels version compatibility"
+msgstr "Compatibilidad de versiones de Spyder y Spyder-Kernels"
+
+#: ../../troubleshooting/common-illnesses.rst:36
+msgid "Spyder"
+msgstr "Spyder"
+
+#: ../../troubleshooting/common-illnesses.rst:36
+msgid "Spyder-Kernels"
+msgstr "Spyder-Kernels"
+
+#: ../../troubleshooting/common-illnesses.rst:38
+msgid "4.0.0-4.0.1"
+msgstr "4.0.0-4.0.1"
+
+#: ../../troubleshooting/common-illnesses.rst:38
+msgid "1.8.1"
+msgstr "1.8.1"
+
+#: ../../troubleshooting/common-illnesses.rst:39
+msgid "4.1.0-4.1.2"
+msgstr "4.1.0-4.1.2"
+
+#: ../../troubleshooting/common-illnesses.rst:39
+msgid "1.9.0"
+msgstr "1.9.0"
+
+#: ../../troubleshooting/common-illnesses.rst:40
+msgid "4.1.3"
+msgstr "4.1.3"
+
+#: ../../troubleshooting/common-illnesses.rst:40
+msgid "1.9.1"
+msgstr "1.9.1"
+
+#: ../../troubleshooting/common-illnesses.rst:41
+msgid "4.1.4"
+msgstr "4.1.4"
+
+#: ../../troubleshooting/common-illnesses.rst:41
+msgid "1.9.3"
+msgstr "1.9.3"
+
+#: ../../troubleshooting/common-illnesses.rst:42
+msgid "4.1.5-4.1.6"
+msgstr "4.1.5-4.1.6"
+
+#: ../../troubleshooting/common-illnesses.rst:42
+msgid "1.9.4"
+msgstr "1.9.4"
+
+#: ../../troubleshooting/common-illnesses.rst:43
+msgid "4.2.0"
+msgstr "4.2.0"
+
+#: ../../troubleshooting/common-illnesses.rst:43
+msgid "1.10.0"
+msgstr "1.10.0"
+
+#: ../../troubleshooting/common-illnesses.rst:44
+msgid "5.0.0-5.0.5"
+msgstr "5.0.0-5.0.5"
+
+#: ../../troubleshooting/common-illnesses.rst:44
+msgid "2.0.5"
+msgstr "2.0.5"
+
+#: ../../troubleshooting/common-illnesses.rst:45
+msgid "5.1.0-5.1.5"
+msgstr "5.1.0-5.1.5"
+
+#: ../../troubleshooting/common-illnesses.rst:45
+msgid "2.1.3"
+msgstr "2.1.3"
+
+#: ../../troubleshooting/common-illnesses.rst:46
+msgid "5.2.0-5.2.1"
+msgstr "5.2.0-5.2.1"
+
+#: ../../troubleshooting/common-illnesses.rst:46
+msgid "2.2.0"
+msgstr "2.2.0"
+
+#: ../../troubleshooting/common-illnesses.rst:47
+msgid "5.2.2"
+msgstr "5.2.2"
+
+#: ../../troubleshooting/common-illnesses.rst:47
+msgid "2.2.1"
+msgstr "2.2.1"
+
+#: ../../troubleshooting/common-illnesses.rst:48
+msgid "5.3.0-5.3.3"
+msgstr "5.3.0-5.3.3"
+
+#: ../../troubleshooting/common-illnesses.rst:48
+msgid "2.3.3"
+msgstr "2.3.3"
+
+#: ../../troubleshooting/common-illnesses.rst:49
+msgid "5.4.0-5.4.3"
+msgstr "5.4.0-5.4.3"
+
+#: ../../troubleshooting/common-illnesses.rst:49
+msgid "2.4.3"
+msgstr "2.4.3"
+
+#: ../../troubleshooting/common-illnesses.rst:52
+msgid "To do so, activate the environment, then install ``spyder-kernels``. If using Anaconda, open a terminal (Anaconda Prompt on Windows) and run:"
+msgstr "Para ello, activa el entorno, a continuación, instala ``spyder-kernels``. Si utilizas Anaconda, abre una consola (Anaconda Prompt en Windows) y ejecuta:"
+
+#: ../../troubleshooting/common-illnesses.rst:60
+msgid "Otherwise, activate your environment by whatever means you created it, and execute:"
+msgstr "De lo contrario, activa tu entorno por el medio que lo hayas creado, y ejecuta:"
+
+#: ../../troubleshooting/common-illnesses.rst:66
+msgid "For both of the previous commands, replace ``<VERSION>`` with the corresponding version in the table."
+msgstr "Para los dos comandos anteriores, reemplaza ``<VERSION>`` con la versión correspondiente en la tabla."
+
+#: ../../troubleshooting/common-illnesses.rst:70
+msgid "Issue with another dependency"
+msgstr "Problemas con otra dependencia"
+
+#: ../../troubleshooting/common-illnesses.rst:72
+msgid "If the kernel displays a long error traceback that mentions other packages like ``ipython``, ``ipykernel``, ``jupyter_client``, ``traitlets`` or ``pyzmq``, the problem may be an out of date or incompatible version of a dependency package. To fix this, activate the environment and update the key dependencies."
+msgstr "Si el núcleo muestra un seguimiento de errores largo que menciona otros paquetes como ``ipython``, ``ipykernel``, ``jupyter_client``, ``traitlets`` o ``pyzmq``, el problema puede ser una versión desactualizada o incompatible de un paquete de dependencias. Para arreglar esto, activa el entorno y actualiza las dependencias clave."
+
+#: ../../troubleshooting/common-illnesses.rst:75
+msgid "In an Anaconda environment:"
+msgstr "En un ambiente de Anaconda:"
+
+#: ../../troubleshooting/common-illnesses.rst:82
+msgid "Otherwise, activate your environment by whatever means you created it, and run:"
+msgstr "De lo contrario, activa tu entorno por el medio que lo hayas creado, y ejecuta:"
+
+#: ../../troubleshooting/common-illnesses.rst:90
+msgid "AttributeError/ImportError"
+msgstr "AttributeError/ImportError"
+
+#: ../../troubleshooting/common-illnesses.rst:92
+msgid "Check the last few lines of the error message, and see if its an ``AttributeError`` or ``ImportError``, or refers to a file you created in your current working directory or your home folder (:file:`C:/Users/YOUR_USERNAME` on Windows, :file:`/Users/YOUR_USERNAME` on macOS, or :file:`/home/YOUR_USERNAME` on Linux)."
+msgstr "Comprueba las últimas líneas del mensaje de error y revisa si es un ``AttributeError`` o ``ImportError``, o si se refiere a un archivo que creaste en tu directorio de trabajo actual o en tu carpeta de inicio (:file:`C:/Users/YOUR_USERNAME` en Windows, :file:`/Users/YOUR_USERNAME` on macOS, or :file:`/home/YOUR_USERNAME` en Linux)."
+
+#: ../../troubleshooting/common-illnesses.rst:97
+msgid "If so, the the error is likely due to your file being named the same as a Python standard library module, such as ``string.py`` or ``time.py``, which overrides the built-in module that Spyder-Kernels is trying to load. To fix this, simply rename your file to something other than one of these names, and try restarting the kernel. To check the names of these modules, see the list in the `Python standard library documentation`_."
+msgstr "Si es así, el error probablemente se deba a que tu archivo recibe el mismo nombre que un módulo de librería estándar de Python, como ``string.py`` o ``time.py``, que anula el módulo integrado que Spyder-Kernels está intentando cargar. Para arreglar esto, simplemente renombra tu archivo con un nombre distinto e intenta reiniciar el núcleo. Para comprobar los nombres de estos módulos, revisa la lista en la `Python standard library documentation`_."
+
+#: ../../troubleshooting/common-illnesses.rst:109
+msgid "Completion/help not working"
+msgstr "El autocompletado o la ayuda no funcionan"
+
+#: ../../troubleshooting/common-illnesses.rst:111
+msgid "To provide code completions, help and real-time analysis in the Editor, Spyder uses the Python Language Server (PyLS), an implementation of the Language Server Protocol specification used by VSCode, Atom and other popular editors/IDEs. Most help and completion issues lie outside of Spyder's control, and are either limitations with PyLS or the code that is being introspected, but some can be worked around."
+msgstr "Para proporcionar completado, ayuda y análisis de código en tiempo real en el Editor, Spyder utiliza el Python Language Server (PyLS), una implementación de la especificación del Language Server Protocol utilizado por VSCode, Atom y otros editores e IDEs populares. La mayoría de los errores de ayuda y completado están fuera del control de Spyder y son limitaciones de PyLS o del código que se está programando, pero algunos pueden ser solucionados por los usuarios."
+
+#: ../../troubleshooting/common-illnesses.rst:116
+msgid "Object missing docstring"
+msgstr "Docstring faltante de un objeto"
+
+#: ../../troubleshooting/common-illnesses.rst:118
+msgid "If nothing is displayed in the calltip, hover hint or help pane, the object you're trying to introspect may not have a docstring."
+msgstr "Si no se muestra nada en el calltip, las sugerencias al pasar el cursor o en el panel de ayuda, es posible que el objeto al que estás intentando realizar una introspección no tenga un docstring."
+
+#: ../../troubleshooting/common-illnesses.rst:124
+msgid "In this case, the only solution is to add one in the source code of the original function, method or class."
+msgstr "En este caso, la única solución es añadir uno en el código fuente de la función original, método o clase."
+
+#: ../../troubleshooting/common-illnesses.rst:128
+msgid "Object cannot be found"
+msgstr "El objeto no puede ser encontrado"
+
+#: ../../troubleshooting/common-illnesses.rst:130
+msgid "Some objects, whether due to being written in C, Cython or another language; generated dynamically at runtime; or being a method of an object you create, cannot be easily found without executing the code."
+msgstr "Algunos objetos, ya sea por estar escritos en C, Cython u otro idioma; por ser generados dinámicamente en tiempo de ejecución; o por ser un método de un objeto que creaste, no se pueden encontrar fácilmente sin ejecutar el código."
+
+#: ../../troubleshooting/common-illnesses.rst:136
+msgid "However, once you run your code in the :doc:`/panes/ipythonconsole`, you might be able to get help and completions on the object there."
+msgstr "Sin embargo, una vez que ejecutes tu código en la :doc:`/panes/ipythonconsole`, es posible que puedas obtener la ayuda y el completado del objeto allí."
+
+#: ../../troubleshooting/common-illnesses.rst:140
+msgid "LSP has stopped working"
+msgstr "El LSP ha dejado de funcionar"
+
+#: ../../troubleshooting/common-illnesses.rst:142
+msgid "Occasionally, especially after using Spyder for a while, code completion, help and analysis may stop working. If this is the case, you can check LSP status with the :guilabel:`LSP Python` item in Spyder's status bar at the bottom of the screen, and restart it by right-clicking it and selecting the :guilabel:`Restart Python Language Server` item."
+msgstr "Ocasionalmente, especialmente después de usar Spyder por un tiempo, el completado, la ayuda y el análisis de código pueden dejar de funcionar. Si este es el caso, puedes comprobar el estado LSP con el elemento :guilabel:`LSP Python` en la barra de estado de Spyder en la parte inferior de la pantalla, y reiniciarlo haciendo clic con el botón derecho y seleccionando el elemento :guilabel:`Reiniciar el servidor de lenguaje de Python`."
+
+#: ../../troubleshooting/common-illnesses.rst:150
+msgid "Spyder bug/dependency issue"
+msgstr "Error de Spyder debido a problemas con sus dependencias"
+
+#: ../../troubleshooting/common-illnesses.rst:152
+msgid "Given the variety of dependencies involved in making LSP work, an incompatible or out of date version in your environment can result in error messages, incomplete results, or help/analysis not working at all."
+msgstr "Dada la variedad de dependencias involucradas en hacer que el LSP funcione, una versión incompatible o desactualizada de tu entorno puede resultar en mensajes de error, resultados incompletos o ayuda/análisis que no funcionen en absoluto."
+
+#: ../../troubleshooting/common-illnesses.rst:154
+msgid "To address this, first try updating Anaconda and Spyder as described in :doc:`basic-first-aid`. If the issue still isn't resolved, update the various relevant dependencies with:"
+msgstr "Para solucionar esto, primero intenta actualizar Anaconda y Spyder como se describe en :doc:`basic-first-aid`. Si el problema todavía no está resuelto, actualiza las distintas dependencias relevantes con:"
+
+#: ../../troubleshooting/common-illnesses.rst:165
+msgid "Plugin Problems"
+msgstr "Problemas de plugin"
+
+#: ../../troubleshooting/common-illnesses.rst:168
+msgid "Plugin does not work at all"
+msgstr "El plugin no funciona en absoluto"
+
+#: ../../troubleshooting/common-illnesses.rst:170
+msgid "If you have installed a Spyder plugin, but you can't see it, go to the :guilabel:`Panes` submenu of the :guilabel:`View` menu and select the plugin's name, which should make its pane visible. If you don't see the plugin there, select the :guilabel:`Dependencies` item under the :guilabel:`Help` menu and see if the plugin appears at the bottom."
+msgstr "Si tienes instalado un plugin de Spyder, pero no puedes verlo, ve al submenú :guilabel:`Paneles` del menú :guilabel:`Ver` y selecciona el nombre del plugin, que debería hacer que su panel sea visible. Si no ves el plugin allí, selecciona el elemento :guilabel:`Dependencias` en el menú :guilabel:`Ayuda` y mira si el plugin aparece en la parte inferior."
+
+#: ../../troubleshooting/common-illnesses.rst:176
+msgid "If the plugin with the problem is not listed in the dependencies dialog, check that you installed it in the same environment as Spyder. If you have, then the problem may well be caused by a dependency issue. Test whether you can import the plug-in manually by opening a Python console in the same environment as Spyder and typing, for instance, ``import spyder_unittest`` to test the Spyder-Unittest` plug-in; this command should run without errors."
+msgstr "Si el plugin con el problema no aparece en el diálogo de dependencias, comprueba que lo instalaste en el mismo entorno que Spyder. Si lo tienes, el problema puede deberse a un problema de dependencia. Comprueba si puedes importar el plugin manualmente abriendo una consola Python en el mismo entorno que Spyder y escribiendo, por ejemplo, ``importar spyder_unittest`` para probar el plugin de Spyder-Unittest; este comando debe ejecutarse sin errores."
+
+#: ../../troubleshooting/common-illnesses.rst:180
+msgid "If none of this helps you to resolve the problem, then continue to the next section."
+msgstr "Si nada de esto te ayuda a resolver el problema, entonces continúa a la siguiente sección."
+
+#: ../../troubleshooting/common-illnesses.rst:184
+msgid "Other issues"
+msgstr "Otros problemas"
+
+#: ../../troubleshooting/common-illnesses.rst:186
+msgid "If you get an error which mentions or involves a Spyder plugin, such as ``spyder-unittest``, ``spyder-terminal`` or ``spyder-notebook``, or if you encounter any other problem with a Spyder plugin, then the first approach should be to update Spyder and the plugin to their latest versions."
+msgstr "Si obtienes un error que mencione o involucra un plugin de Spyder, como ``spyder-unittest``, ``spyder-terminal`` o ``spyder-notebook``, o si encuentras cualquier otro problema con un plugin de Spyder, entonces el primer enfoque debe ser actualizar Spyder y el plugin a sus últimas versiones."
+
+#: ../../troubleshooting/common-illnesses.rst:188
+msgid "If this doesn't fix the problem, you should check the plugin's website or repository to see if it is compatible with your version of Spyder."
+msgstr "Si esto no soluciona el problema, deberías comprobar el sitio web o repositorio del plugin para ver si es compatible con tu versión de Spyder."
+
+#: ../../troubleshooting/common-illnesses.rst:190
+msgid "Finally, if compatibility doesn't seem to be the problem, please check those repositories to see if an issue was already opened, and report it there if not."
+msgstr "Finalmente, si la compatibilidad no parece ser el problema, por favor, comprueba esos repositorios para ver si ya se ha abierto un problema e infórmalo allí si no es así."
+
+#: ../../troubleshooting/emergency-cpr.rst:3
+msgid "Emergency CPR"
+msgstr "Kit de emergencia"
+
+#: ../../troubleshooting/emergency-cpr.rst:5
+msgid "Is Spyder not launching at all? The steps on this section should hopefully get it back up and running in no time."
+msgstr "¿Spyder no se está lanzando en lo absoluto? Esperemos que los pasos en esta sección lo vuelvan a poner en marcha en poco tiempo."
+
+#: ../../troubleshooting/emergency-cpr.rst:12
+msgid "Common solutions"
+msgstr "Soluciones comunes"
+
+#: ../../troubleshooting/emergency-cpr.rst:14
+msgid "Try :doc:`basic-first-aid` first, which usually resolves most Spyder install-related issues."
+msgstr "Prueba primero :doc:`basic-first-aid`, que normalmente resuelve la mayoría de los problemas relacionados con la instalación de Spyder."
+
+#: ../../troubleshooting/emergency-cpr.rst:16
+msgid "**Make sure Spyder isn't already running** and no Spyder related windows (*e.g.* :doc:`/panes/variableexplorer` dialogs) are left open, and check that the preference setting :menuselection:`Application --> Advanced Settings --> Use a single instance` isn't checked."
+msgstr "**Asegúrate de que Spyder no se esté ejecutando** y de que no haya ventanas relacionadas con Spyder abiertas (por ejemplo los diálogos :doc:`/panes/variableexplorer`) y comprueba que la configuración de preferencias :menuselection:`Aplicación --> Opciones avanzadas --> Utilizar una única instancia` no está seleccionada."
+
+#: ../../troubleshooting/emergency-cpr.rst:21
+msgid "Try **starting Spyder via a different means**, such as from a shortcut, Anaconda navigator, or your command line (or Anaconda Prompt on Windows) by simply typing ``spyder`` then :kbd:`Enter`/:kbd:`Return`, and see if any of those work. If so, then something's wrong with your install, not Spyder itself, and so we recommend following :ref:`troubleshooting-reinstalling-spyder-ref` to uninstall and reinstall Anaconda."
+msgstr "Intenta **iniciar Spyder por medios diferentes**, como por ejemplo desde un acceso directo, Anaconda navigator o tu línea de comandos (o Anaconda Prompt en Windows) simplemente escribiendo ``spyder`` luego :kbd:`Enter`/:kbd:`Return`, y observa si alguno de esos medios funciona. De ser así, entonces algo está mal con tu instalación, no con Spyder en sí, por lo que recomendamos seguir :ref:`troubleshooting-reinstalling-spyder-ref` para desinstalar y reinstalar Anaconda."
+
+#: ../../troubleshooting/emergency-cpr.rst:24
+msgid "**Disable any security software** you may be using, such as a firewall or antivirus, as these products can occasionally interfere with Spyder or its related packages. Make sure to re-enable it if it doesn't fix the problem, and if it does, add a rule or exception for Spyder or Python."
+msgstr "**Desactiva cualquier software de seguridad** que estés usando, como un firewall o antivirus, ya que estos productos pueden interferir ocasionalmente con Spyder o sus paquetes relacionados. Asegúrate de volver a activarlo si esto no soluciona el problema, y si lo hace, agrega una regla o excepción para Spyder o Python."
+
+#: ../../troubleshooting/emergency-cpr.rst:27
+msgid "If it is currently installed \"for just you\", **try uninstalling and reinstalling Anaconda \"for all users\" instead**, and vice versa, as some systems can have issues with one or the other installation method."
+msgstr "Si actualmente está instalado \"solo para ti\", **intenta desinstalar y reinstalar Anaconda \"para todos los usuarios\"**, y viceversa, ya que algunos sistemas pueden tener problemas con uno u otro método de instalación."
+
+#: ../../troubleshooting/emergency-cpr.rst:29
+msgid "**Check and repair/reset permissions**, your disk, and OS if all else fails."
+msgstr "**Comprueba y repara o reestablece tus permisos**, tu disco y tu sistema operativo si todo lo demás falla."
+
+#: ../../troubleshooting/emergency-cpr.rst:35
+msgid "Advanced tricks"
+msgstr "Trucos avanzados"
+
+#: ../../troubleshooting/emergency-cpr.rst:37
+msgid "If none of the above solves the problem, you can try starting Spyder directly from its Python source files which may either get it running, or at least provide useful information to help debug the issue further."
+msgstr "Si nada de lo anterior resuelve el problema, puedes intentar iniciar Spyder directamente desde sus archivos fuente de Python, lo que puede hacer que se ejecute, o al menos proporcionar información útil para ayudar a depurar aún más el problema."
+
+#: ../../troubleshooting/emergency-cpr.rst:39
+msgid "This technique consists of starting Spyder from your terminal (or Anaconda Prompt on Windows) by manually running the Spyder startup routine ( :guilabel:`start.py` ) with a known good Python interpreter, and observing the results."
+msgstr "Esta técnica consiste en iniciar Spyder desde tu terminal (o Anaconda Prompt en Windows) ejecutando manualmente la rutina de inicio de Spyder ( :guilabel:`start. y` ) con un buen intérprete de Python conocido, y observando los resultados."
+
+#: ../../troubleshooting/emergency-cpr.rst:41
+msgid "To do so, you'll need to:"
+msgstr "Para hacerlo, necesitarás:"
+
+#: ../../troubleshooting/emergency-cpr.rst:43
+msgid "Find the path to the Spyder :file:`app` directory from the command line. For this, run:"
+msgstr "Encuentra la ruta al directorio `:file:`app` de Spyder desde la línea de comandos. Para esto, ejecuta:"
+
+#: ../../troubleshooting/emergency-cpr.rst:50
+msgid "Go to the output path of the above command on your command line:"
+msgstr "Vaya a la ruta de salida del comando anterior en tu línea de comandos:"
+
+#: ../../troubleshooting/emergency-cpr.rst:56
+msgid "Once inside the :file:`app` directory, run ``python start.py`` to launch Spyder."
+msgstr "Una vez dentro del directorio :file:`app`, ejecuta ``python start.py`` para iniciar Spyder."
+
+#: ../../troubleshooting/emergency-cpr.rst:62
+msgid "#. If it doesn't start successfully, then you should see an error traceback printed; carefully copy that for future reference. Also run ``python mainwindow.py``, and record your results as well."
+msgstr "Si no se inicia con éxito, deberías ver un seguimiento de errores impreso; cópialo cuidadosamente para futuras referencias. También ejecuta ``python mainwindow.py``, y registra sus resultados también."
+
+#: ../../troubleshooting/emergency-cpr.rst:65
+msgid "(*Windows only*) In case the command window disappears immediately after the error, create a ``.bat`` file in the :file:`app` directory with the following content:"
+msgstr "(*Solo Windows*) En caso de que la ventana de comandos desaparezca inmediatamente después del error, crea un archivo ``.bat`` en el directorio :file:`app` con el siguiente contenido:"
+
+#: ../../troubleshooting/emergency-cpr.rst:73
+msgid "Replace ``<PYTHON-PATH>`` with the output of:"
+msgstr "Reemplaza ``<PYTHON-PATH>`` con la salida de:"
+
+#: ../../troubleshooting/emergency-cpr.rst:79
+msgid "Then, double click the batch file to run it, and you should see the error information you need."
+msgstr "Luego, haz doble clic en el archivo por lotes para ejecutarlo, y deberías ver la información de error que necesitas."
+
+#: ../../troubleshooting/emergency-cpr.rst:81
+msgid "If reading the output (particularly the last line) doesn't help you solve the problem, then record all of it carefully, and post it as part of your bug report as described under the :doc:`submit-a-report` section."
+msgstr "Si leer el resultado (particularmente la última línea) no te ayuda a resolver el problema, regístralo todo cuidadosamente y publícalo como parte de tu informe de error como se describe en la sección :doc:`submit-a-report` ."
+
+#: ../../troubleshooting/first-steps.rst:3
+msgid "First Steps"
+msgstr "Primeros Pasos"
+
+#: ../../troubleshooting/first-steps.rst:5
+msgid "If Spyder crashes or you receive an error message, please read the following troubleshooting steps before opening a new issue. There's a good chance that someone else has already experienced the same problem, so checking for an existing solution will likely get Spyder working again for you as quickly as possible."
+msgstr "Si Spyder se bloquea o recibes un mensaje de error, por favor lee los siguientes pasos de solución de problemas antes de abrir uno nuevo. Hay una buena posibilidad de que alguien más ya haya experimentado el mismo problema, así que comprobar si ya hay una solución existente probablemente hará que Spyder vuelva a trabajar para ti lo más rápido posible."
+
+#: ../../troubleshooting/first-steps.rst:9
+msgid "To make sure you're getting the most relevant help for your problem, please make sure the issue is actually related to Spyder:"
+msgstr "Para asegurarte de que estás recibiendo la ayuda más relevante para tu problema, por favor asegúrate de que el problema está realmente relacionado con Spyder:"
+
+#: ../../troubleshooting/first-steps.rst:11
+msgid "If the problem appears to be a result of *your own code*, `Stack Overflow`_ is a better place to start."
+msgstr "Si el problema parece ser el resultado de *tu propio código*, `Stack Overflow`_ es un mejor lugar para empezar."
+
+#: ../../troubleshooting/first-steps.rst:12
+msgid "If the bug also occurs in the *standard Python, IPython, or QtConsole* environments, or only with *a specific package*, it is unlikely to be something in Spyder, and you should report it to those sources instead."
+msgstr "Si el error también ocurre en los entornos *estándar de Python, IPython, o QtConsole*, o solo con *un paquete específico*, es poco probable que sea algo en Spyder, y deberías reportarlo a esas fuentes en su lugar."
+
+#: ../../troubleshooting/first-steps.rst:13
+msgid "If the problem lies with *your specific install*, uninstalling and clean-reinstalling the `Anaconda`_ distribution is strongly recommended. As the other methods of installing Spyder can result in tricky user-specific problems, we generally aren't able to give individual support for install issues."
+msgstr "Si el problema radica en *tu instalación específica*, se recomienda encarecidamente desinstalar y reinstalar la distribución `Anaconda`_. Como los otros métodos de instalación de Spyder pueden resultar en complicados problemas específicos del usuario, generalmente no somos capaces de dar soporte individual para problemas de instalación."
+
+#: ../../troubleshooting/first-steps.rst:19
+msgid "Just like the programs you code in it, Spyder is written in Python, so you can often figure out many problems just by reading the last line of the traceback or error message. To view it, simply click :guilabel:`Show details` in the Spyder error dialog."
+msgstr "Al igual que los programas que codificas en él, Spyder está escrito en Python, por lo que a menudo puedes resolver muchos problemas con solo leer la última línea del traceback o mensaje de error. Para verlo, simplemente haz clic en :guilabel:`Mostrar detalles` en la ventana de error de Spyder."
+
+#: ../../troubleshooting/first-steps.rst:25
+msgid "Often, that alone will tell you how to fix the problem on your own, but if not, we're here to help."
+msgstr "A menudo, eso por sí solo te dirá cómo solucionar el problema por tu cuenta, pero si no, estamos aquí para ayudarte."
+
+#: ../../troubleshooting/first-steps.rst:31
+msgid "Where to go from here"
+msgstr "Donde buscar ayuda a partir de aquí"
+
+#: ../../troubleshooting/first-steps.rst:33
+msgid "If you check out our list of issue categories and problem descriptions and see a question, error message or traceback that looks familiar, the relevant sub-section will likely be of the most specific help solving your issue as quickly as possible."
+msgstr "Si revisas nuestra lista de categorías de incidencias y descripciones de problemas y ves una pregunta, mensaje de error o seguimiento te resulte familiar, es probable que la subsección correspondiente te brinde la ayuda más específica para resolver tu problema rápidamente."
+
+#: ../../troubleshooting/first-steps.rst:37
+msgid "As a first step to solving your issue, you can try some :doc:`basic-first-aid`."
+msgstr "Como primer paso para resolver tu problema, puedes probar algo de :doc:`basic-first-aid`."
+
+#: ../../troubleshooting/first-steps.rst:41
+msgid "If Spyder won't launch, check the :doc:`emergency-cpr` section and see if that clears it up."
+msgstr "Si Spyder no se inicia, comprueba la sección de :doc:`emergency-cpr` y verifica si eso soluciona el problema."
+
+#: ../../troubleshooting/first-steps.rst:45
+msgid "If your problem is related to the kernel not starting, autocompletion or a plugin go to :doc:`common-illnesses` section."
+msgstr "Si tu problema está relacionado con el núcleo que no se inicia, el autocompletado o un plugin, ve a la sección :doc:`common-illnesses`."
+
+#: ../../troubleshooting/first-steps.rst:49
+msgid "If you still can't get it to work, and the problem is indeed Spyder-related, you should consult the the :doc:`call-for-help` section for other resources to explore."
+msgstr "Si todavía no puedes hacer que funcione, y el problema está realmente relacionado con Spyder, deberías consultar la sección :doc:`call-for-help` para ver otros recursos para explorar."
+
+#: ../../troubleshooting/first-steps.rst:53
+msgid "Finally, if you couldn't solve your problem and want to submit an issue to our Github issue tracker, so the bug can hopefully be fixed for everyone, :doc:`submit-a-report`."
+msgstr "Por último, si no pudiste resolver tu problema y deseas enviar un issue a nuestro gestor de issues de Github, para que el error puede corregirse para todos, usa :doc:`submit-a-report`."
+
+#: ../../troubleshooting/index.rst:3
+msgid "Troubleshooting"
+msgstr "Solución de problemas"
+
+#: ../../troubleshooting/submit-a-report.rst:3
+msgid "Submit a Report"
+msgstr "Enviar un reporte"
+
+#: ../../troubleshooting/submit-a-report.rst:5
+msgid "If you can't fix your issue with any of the troubleshooting steps, then you'll want to submit it to our issue tracker so our team can take a look at it for you. You'll need a `Github account`_ to do this, so make sure you have one before you begin (a good idea anyway)."
+msgstr "Si no puedes solucionar tu problema con ninguno de los pasos de solución de problemas, entonces querrás enviarlo a nuestro gestor de issues de GitHub para que nuestro equipo pueda echarle un vistazo por usted. Para hacer esto necesitarás una `Github account`_, así que asegúrate de tener una antes de comenzar (una buena idea de todos modos)."
+
+#: ../../troubleshooting/submit-a-report.rst:13
+msgid "Before you submit an issue, make sure you've searched a description of the problem and a relevant portion of the error traceback, on both Google and Spyder's `issue tracker`_ to make sure it hasn't been submitted before. If that's the case, your issue will be closed as a duplicate."
+msgstr "Antes de enviar un issue, asegúrate de haber buscado una descripción del problema y una parte relevante del seguimiento de errores, tanto en Google como en el `issue tracker`_ de Spyder para asegurarte de que no ha sido enviado antes. Si ese es el caso, tu problema se cerrará como un duplicado."
+
+#: ../../troubleshooting/submit-a-report.rst:23
+msgid "Ways to submit an issue"
+msgstr "Formas de enviar un issue"
+
+#: ../../troubleshooting/submit-a-report.rst:25
+msgid "There are several ways to submit an issue, either from Spyder or GitHub directly. In order of preference and difficulty:"
+msgstr "Hay varias maneras de enviar un issue, ya sea desde Spyder o GitHub directamente. Por orden de preferencia y dificultad:"
+
+#: ../../troubleshooting/submit-a-report.rst:28
+msgid "**If Spyder presents an error dialog** you can submit an issue directly from it. You will have to fill out a title for your issue, specify the steps that lead to this problem and click :guilabel:`submit to Github`. This will prefill an error report with your environment details, key versions and dependencies and automatically insert the error/traceback for you."
+msgstr "**Si Spyder presenta un reporte de problemas** puedes enviar un issue directamente desde él. Tendrás que llenar un título para tu petición, especificar los pasos que llevan a este problema y hacer clic en :guilabel:`Enviar a Github`. Esto prellenará un reporte de error con los detalles de tu entorno, las versiones claves y las dependencias, e insertará automáticamente el error o traceback por ti."
+
+#: ../../troubleshooting/submit-a-report.rst:36
+msgid "**If Spyder opens and your issue does not involve an error dialog**, the best way to do so is to simply select :guilabel:`Report issue` from the :guilabel:`Help` menu, which manually brings up the issue report form and fills in the key information about your Spyder installation. Describe the issue you're experiencing (including any error/traceback information) along with a descriptive title, and click :guilabel:`Submit to Github`."
+msgstr "**Si Spyder se abre y tu problema no implica un diálogo de error**, la mejor manera de hacerlo es simplemente seleccionar :guilabel:`Reporte de error` en el menú :guilabel:`Ayuda`, que muestra manualmente el formulario de informe del problema y rellena la información clave sobre tu instalación de Spyder. Describe el problema que estás experimentando (incluyendo cualquier información de error/seguimiento) junto con un título descriptivo, y haz clic en :guilabel:`Enviar a Github`."
+
+#: ../../troubleshooting/submit-a-report.rst:42
+msgid "**If Spyder won't launch**, you can submit a report manually at our issues page on `Github`_. Unlike the above, you'll need to manually provide the versions of everything (Spyder, Python, OS, Qt/PyQt, Anaconda, and Spyder's dependencies) as listed in the error report template; see below for more on that."
+msgstr "**Si Spyder no se lanza**, puedes enviar un informe manualmente en nuestra página de issues en `Github`_. A diferencia de lo anterior, necesitarás proporcionar manualmente las versiones de todo (Spyder, Python, OS, Qt/PyQt, Anaconda y las dependencias de Spyder) como se muestra en la plantilla de informe de errores; ver abajo para más información sobre eso."
+
+#: ../../troubleshooting/submit-a-report.rst:50
+msgid "Once you submit your report, our team will try to get back to you as soon as possible, often within 24 hours or less, to try to help you fix it."
+msgstr "Una vez que envíes tu informe, nuestro equipo intentará responderte lo antes posible, a menudo dentro de 24 horas o menos, para tratar de ayudarte a arreglarlo."
+
+#: ../../troubleshooting/submit-a-report.rst:55
+msgid "What to include in your report"
+msgstr "Qué incluir en tu informe"
+
+#: ../../troubleshooting/submit-a-report.rst:57
+msgid "**Please include as much as possible of the following in your report** to maximize your chances of getting relevant help and our ability to diagnose, reproduce and solve your issue."
+msgstr "**Por favor, incluye la mayor cantidad posible de la siguiente información en tu informe** para aumentar las posibilidades de obtener ayuda relevante y facilitar nuestra capacidad de diagnosticar, reproducir y resolver tu problema."
+
+#: ../../troubleshooting/submit-a-report.rst:59
+msgid "The key items, in order of priority:"
+msgstr "Los elementos clave, en orden de prioridad son:"
+
+#: ../../troubleshooting/submit-a-report.rst:61
+msgid "The full, **complete error message or traceback** copy/pasted or automatically entered exactly as displayed by Spyder:"
+msgstr "El **mensaje de error completo o el traceback** copiado y pegado, o ingresado automáticamente, tal como aparece en Spyder:"
+
+#: ../../troubleshooting/submit-a-report.rst:63
+msgid "Auto-generated reports directly from the error dialog should include this automatically, but double check to make sure."
+msgstr "Los informes autogenerados directamente desde el cuadro de diálogo de error deben incluir esto automáticamente, pero compruébalo dos veces para asegurarte."
+
+#: ../../troubleshooting/submit-a-report.rst:64
+msgid "You can copy and paste this from the the :guilabel:`Show Details` section of the error dialog."
+msgstr "Puedes copiar y pegar esto de la sección :guilabel:`Mostrar detalles` en el diálogo de error."
+
+#: ../../troubleshooting/submit-a-report.rst:65
+msgid "If not present, or a dialog is not displayed, you can also find it printed to Spyder's :guilabel:`Internal Console`, located under the :guilabel:`View` menu at :menuselection:`Panes --> Internal Console`."
+msgstr "Si no está presente o no se muestra un diálogo, también puedes encontrarlo impreso en la :guilabel:`Terminal interna` de Spyder, ubicada en el menú :guilabel:`Ver` en :menuselection:`Paneles --> Terminal interna`."
+
+#: ../../troubleshooting/submit-a-report.rst:66
+msgid "If you prefer, or if Spyder won't start, you can start Spyder from your command line (or Anaconda prompt on windows) with ``spyder`` and copy the output printed there."
+msgstr "Si lo prefieres, o si Spyder no se inicia, puede iniciar Spyder desde tu línea de comandos (o Anaconda Prompt en Windows) con ``spyder`` y copiar la salida impresa allí."
+
+#: ../../troubleshooting/submit-a-report.rst:70
+msgid "If you are reporting a specific behavior rather than an error, or the message does not fully explain what occurs, please describe in detail what actually happened, and what you expected Spyder to do."
+msgstr "Si estás reportando un comportamiento específico en lugar de un error, o el mensaje no explica completamente lo que ocurre, por favor describe en detalle lo que realmente ocurrió, y lo que esperabas que Spyder hiciera."
+
+#: ../../troubleshooting/submit-a-report.rst:72
+msgid "A **detailed, step by step description of exactly what you did** leading up to the error occurring, complete with sample code that triggers it, if applicable."
+msgstr "Una **descripción detallada y paso a paso de exactamente lo que hiciste** antes de que ocurriera el error, incluyendo código de ejemplo que lo provoque, si es aplicable."
+
+#: ../../troubleshooting/submit-a-report.rst:74
+msgid "**Information about Spyder and its environment** as listed in the error report template, which you can find under :guilabel:`About Spyder` in the :guilabel:`Help` menu; along with its key dependencies, shown in the dialog under :menuselection:`Help --> Dependencies` (there's a button to copy-paste them)."
+msgstr "**Información sobre Spyder y su entorno** tal y como se indica en la plantilla de reporte de errores, que puedes encontrar bajo :guilabel:`Acerca de Spyder` en el menú :guilabel:`Ayuda`; junto con sus dependencias clave, mostradas en el diálogo :menuselection:`Ayuda --> Dependencias` (hay un botón para copiarlas)."
+
+#: ../../troubleshooting/submit-a-report.rst:79
+msgid "If Spyder won't launch, paste the output of ``conda list`` from your command line (or Anaconda prompt on Windows) in the :guilabel:`Dependencies` section of the issue template."
+msgstr "Si Spyder no se lanza, pega la salida de ``lista conda`` desde tu línea de comandos (o Anaconda Prompt en Windows) en la sección :guilabel:`Dependencias` de la plantilla de incidencias."
+
+#: ../../troubleshooting/submit-a-report.rst:85
+msgid "**How you installed Spyder** and any other relevant packages, *e.g.* Anaconda, MacPorts or pip and **whether Spyder has worked before** since you installed it."
+msgstr "**Cómo instalaste Spyder** y cualquier otro paquete relevante, *por ejemplo* Anaconda, MacPorts o pip y **si Spyder ha funcionado antes** desde que lo instalaste."
+
+#: ../../troubleshooting/submit-a-report.rst:87
+msgid "**What else you've tried to fix it**, *e.g.* from this guide or elsewhere on the web, and if you've **tried to reproduce it in standalone QtConsole, IPython, and/or the plain Python** interpreter."
+msgstr "**Qué más intentaste para solucionarlo**, *por ejemplo*, siguiendo esta guía o buscando en otros sitios web, y si **has intentado reproducir el problema en una QtConsole independiente, IPython, y/o el intérprete de Python simple**."
+
+#: ../../troubleshooting/submit-a-report.rst:89
+msgid "**Whether the problem occurred consistently before** in similar situations or if this is the first time you've observed it."
+msgstr "**Si el problema ha ocurrido de manera consistente** en situaciones similares o si es la primera vez que lo observas."
+
+#: ../../troubleshooting/submit-a-report.rst:91
+msgid "**Anything else special or unusual** about your system, environment, packages, or specific usage that might have anything to do with the problem"
+msgstr "**Cualquier otra cosa especial o inusual** sobre tu sistema, entorno, paquetes o uso específico que pueda tener algo que ver con el problema"
+
+#: ../../troubleshooting/submit-a-report.rst:95
+msgid "If including block(s) of code in your report, be sure to precede and follow it with a line of three backticks \\`\\`\\` to get a code block like this:"
+msgstr "Si incluyes bloque(s) de código en tu informe, asegúrate de precederlos y seguirlos con una línea de tres comillas invertidas \\`\\`\\` para obtener un bloque de código como este:"
+
+#: ../../troubleshooting/submit-a-report.rst:101
+msgid "Otherwise, your code will likely contain random formatting or missing indentation, making it difficult to examine and run it to reproduce and fix your issue."
+msgstr "De lo contrario, es probable que tu código contenga un formato aleatorio o falta de indentación, lo que dificultará examinarlo y ejecutarlo para reproducir y solucionar tu problema."
+

--- a/doc/locales/es/LC_MESSAGES/videos.po
+++ b/doc/locales/es/LC_MESSAGES/videos.po
@@ -1,0 +1,453 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: spyder-documentation\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: 2024-09-10 00:48\n"
+"Last-Translator: \n"
+"Language: es\n"
+"Language-Team: Spanish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+"X-Crowdin-Project: spyder-documentation\n"
+"X-Crowdin-Project-ID: 641502\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /doc/locales/en/LC_MESSAGES/videos.po\n"
+"X-Crowdin-File-ID: 12\n"
+
+#: ../../videos/first-steps-with-spyder.rst:3
+msgid "First Steps with Spyder"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:5
+msgid "The videos in this section provide a starting point for new users who have never opened Spyder before. You'll get familiar with opening Spyder in different ways, working with the four main panes and customizing the Spyder to your heart's content."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:12
+msgid "Getting started"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:14
+msgid "Discover the basics of using the Spyder interface and get an introduction to its four main panes, along with a quick look at the others."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:16
+msgid "Find out different ways to open Spyder"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:17
+msgid "Understand the key elements of Spyder’s interface"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:18
+msgid "Learn more about Spyder’s four core panes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:19
+msgid "Explore the other default panes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:33
+msgid "Hello everyone! I'm Juanita, and in this video I'm going to show you how to open Spyder and go over the basics of Spyder's interface. We will learn about Spyder's four panes that you'll likely be using most often, as well as briefly explore the others that are open by default. If you don't have Spyder installed and would like to follow along, you can `download it here`_."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:37
+msgid "The easiest way to open Spyder is by opening Anaconda Navigator and clicking on the Spyder application. In case you have an older version of Spyder in Anaconda, open the command line (or the Anaconda Prompt in the case of Windows) and type the commands:"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:44
+msgid "To launch Spyder without opening Navigator, open your command line and type ``spyder``. If you followed the :doc:`/installation`, you should have everything necessary to open Spyder 4."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:46
+msgid "This is what Spyder 4 looks like in its default configuration, though you can thoroughly customize it, which we'll get to in a later tutorial. You can see that it is divided into three sections showing three different panes: the Editor, the IPython Console and the Help viewer. These three, along with the Variable Explorer, are the four core panes you'll work with the most in Spyder."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:48
+msgid "On the left we have the Editor, where you can open, edit and run files. Bottom right is the IPython Console, which you can use both interactively and to run your code in the Editor. It shows you which version of Python you are using. Above it, you'll find the Help pane, where you can get more information and documentation for any object in the Editor or Console by pressing :kbd:`Ctrl-I` (or :kbd:`Cmd-I` on macOS). We'll see how to do this in our next video."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:50
+msgid "For the two sections on the right, you can switch tabs to see the other panes that are open by default when launching Spyder. In the top section, you can switch to the Variable Explorer, which shows you the name, type, size and value of the variables that you have previously defined in the Editor or the Console. You can also modify the value of these variables directly from this pane by double clicking them under the Value column. The Plots pane will show you the figures you generate with Matplotlib and other libraries, and the Files pane allows you to browse the files on your computer and open them in the Editor with just a click."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:52
+msgid "Finally, in the bottom section you can also access the History pane, which shows you the commands you have entered in the Console, including those from previous sessions."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:54
+msgid "I hope you're now familiar with the basics of using the Spyder interface. In the next video, we will start working with Spyder's core panes."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:56
+msgid "Happy Spydering!"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:62
+msgid "Learning the basics"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:64
+msgid "Learn the basics of using Spyder’s four main panes."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:66
+msgid "Open and edit a file in Spyder’s Editor"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:67
+msgid "Run a script in the Editor and see the output in Spyder’s IPython Console"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:68
+msgid "Execute basic Python commands in the IPython Console"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:69
+msgid "Define variables in the Editor and modify their values in the IPython Console"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:70
+msgid "View and interact with the variables in Spyder’s Variable Explorer"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:71
+msgid "Get documentation in the Help pane in two different ways"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:84
+msgid "Hello everyone! I'm Juanita, and in this video I will show you how to start working with Spyder's four main panes. First, let's take a look at the Editor, which you can use to open, edit and run files from your computer. I will open a short \"Hello World\" program for this demo, which you can `download here`_. Once you have it open in your Editor, you can execute it by pressing the green run button. We can see the output in the Python Console [Show IPython console] as well as the path of the file that we are running and the working directory where this code was run."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:88
+msgid "We can also run any Python code that is entered directly in the IPython Console. For example, we can type ``print(\"Hello\")`` and see the output. Or, we can try some math operations and see the results here too. Note that for implicitly printed output, there is a red indication that differs from the output of the ``print()`` function."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:90
+msgid "Now, let's start defining some variables. We can do this both from the editor or from the Console. If I define a variable ``a = 10`` and then run this code, I can see its value in the console just by typing its name ``a``. However, you can also assign any variable in the IPython console (``b = 20``) and its value will be stored too. In both cases, they can also be seen in the Variable Explorer pane, which shows the name, type, size and value of each of the objects previously defined. In this case, we see variables ``a`` and ``b``, both of type int and with size 1. We can also define a list ``l`` with ``l = [1, 2, 3]`` and see that the type of the variable is list and the size is 3."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:92
+msgid "We can change the values of the variables in the Variable Explorer too by double-clicking them and typing their new value. Now, we can check their new value in the console. In the case of a more complex type like a list, double-clicking it will open a viewer in which you can modify each of its values separately, along with other more complex operations which we'll demonstrate in a future video. We can remove a variable by right-clicking it and selecting the option Remove. After doing this, we can check in the IPython Console that the variable was actually deleted."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:94
+msgid "Finally, we are going to learn how to get help for objects in two different ways. First, we can press :kbd:`Ctrl-I` (or :kbd:`Cmd-I` on macOS) right after the name of an object written in the Editor or the Console, for example ``numpy.array``. You can see that we obtain its documentation in the Help pane if it is available. Second, if we change the Source dropdown option to Console, we can type its name in the object box in the Help pane. Now we can get help for Numpy arrays."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:96
+msgid "You should now be ready to start using Spyder's four main panes. Check out our next video to continue learning and as always, Happy Spydering!"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:102
+msgid "Customization"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:104
+msgid "Learn how to customize Spyder’s interface to match your workflow and development style."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:106
+msgid "Choose your preferred fonts"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:107
+msgid "Switch between different interface, icon and syntax themes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:108
+msgid "Show, hide, undock and rearrange Spyder panes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:109
+msgid "Split, close and pop out Editor panels"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:123
+msgid "Hello everyone, I'm Juanita! In this video, I will show you how to customize Spyder to match your workflow and development style."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:125
+msgid "First, we are going to learn how to change the font in the Editor, IPython Console and Help panes. To do this, go to Preferences, select the Appearance entry and scroll down to Fonts. You can change both the style and the size of the font for both plain and rich text. You can see how this affects the font in the Editor, Console and Help panes."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:127
+msgid "In this same dialog, you can easily change the syntax highlighting theme, for which you can see the preview at the right of the window. Note that Spyder's interface theme changes to match the highlighting theme because the Interface theme option is set to Automatic by default. However, you can change the theme for the entire Spyder interface, choosing between Light and Dark. After selecting this change, click Apply to restart Spyder to apply the new theme."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:129
+msgid "Beyond just Spyder's preferences, you can freely rearrange the panes in Spyder's main window. To show or hide panes, go to Panes under the View menu, and select which ones you want to see. For example, let's hide the Files pane and show the Profiler pane. You can also close a pane from its options menu, which will hide it from the main window."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:131
+msgid "By default, the panes and toolbars are locked so they can't be moved accidentally. However, unchecking the option Lock panes and toolbars in the View menu will allow you to move them freely anywhere on the window, by dragging them from the top and dropping them at any position you like. You can also undock a pane, which will open a new window with it. You can have as many separate windows as you have panes, if you choose. This feature is very useful if you work with several monitors because you can undock the Editor and move it to a different monitor, while working with the rest of the panes in your main monitor."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:133
+msgid "Additionally, you can split the Editor pane vertically or horizontally in as many copies as you want, and open one or more panels in separate Spyder windows, complete with their own toolbar, outline and status bar."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:135
+msgid "Finally, each pane can be customized further under its respective options menu and Preferences panel."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:137
+msgid "With all these options, you can customize Spyder to your heart's content. However, if you ever want to return to its default configuration, you can always reset the window layout under Window Layouts in the View menu, or your entire Spyder configuration with the Reset to Default button in the Preferences."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:139
+msgid "Enjoy your customized version of Spyder, and Happy Spydering!"
+msgstr ""
+
+#: ../../videos/index.rst:3
+msgid "Intro Videos"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:3
+msgid "Working with Spyder"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:5
+msgid "In this section, you will learn about Spyder's more advanced functionality, and explore most of the panes."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:11
+msgid "Beyond the main panes"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:13
+msgid "Explore how to take advantage of Spyder’s functionality beyond just the four core panes."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:15
+msgid "View, manage and save figures with the Plots pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:16
+msgid "Browse, interact with and open external programs in the in the Files pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:17
+msgid "Quickly navigate within and between files with the Outline pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:18
+msgid "Search for text or regular expressions across your entire project with the Find pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:19
+msgid "Discover and explore structured documentation in the Online Help pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:33
+msgid "Hello everyone! I'm Juanita, and I am going to show you how to use some of the remaining panes available in Spyder beyond just the four primary ones."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:35
+msgid "Let's start with the Plots pane, which is open by default when launching Spyder. To see how it works, let's open a file that will generate a couple plots from Matplotlib's documentation. You can view the generated plots in the Plots pane and browse between them using the arrows, or simply clicking them in the sidebar."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:37
+msgid "If you open the pane's options menu, you will see that Fit Plots to Window is enabled by default. Disabling it will allow you to zoom the plots in or out. You can also see that Mute inline plotting is enabled, which prevents the same figures from also appearing in the IPython Console. Note that every time that the code is run, new copies of the plots are generated in the pane, but you can remove any you don't want to keep around with the X button in the pane toolbar. Additionally, the pane automatically updates to show the plots generated by each console as you switch between them."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:39
+msgid "To use a plot in another document, click the Copy to Clipboard button and paste it wherever you want, such as a word processor. Additionally, you can save a plot as a PNG by clicking the save icon."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:41
+msgid "The Files pane, also open by default, lets you browse the contents of the directories on your computer, open them in the Editor, and perform a variety of other file operations. You can show or hide the size, kind and date of the files in the pane's options menu. As you change the top-level folder you're viewing in the pane, Spyder's working directory shown in the top right of the main toolbar will update, which will also be synchronized with the currently active console. Double-clicking a text file will open it in the Editor, and copying one or more files will allow you to paste them as automatically-formatted absolute or relative paths. Right-clicking any item will offer an array of additional options for interacting with it."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:43
+msgid "You can also open a file in the system default external application, or set up a custom file association in the File Associations tab of the Files preferences pane. For example, we can add the ``.csv`` extension and associate it with LibreOffice Calc under associated applications. Now every time you click a file with this extension, it opens externally with this program."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:45
+msgid "Now, let's see how to use the Outline pane to navigate within a file. First, we have to open the pane under Panes in the View menu, since it isn't visible by default. As you can see, it shows you all the classes, methods and functions that are currently defined, and allows you to move between them with just a click. For a very large file like this one, it is very useful to switch between classes easily instead of scrolling through the four-thousand-plus lines of code. You can also browse the methods of a class by expanding it using the arrows, or the buttons in the Outline pane's toolbar. The Outline continuously updates to highlight the function, method or class corresponding to the cursor position in your code, so you can easily keep track of what object you are working on. Finally, by going to the pane options menu and activating Show all files, you can easily switch between the scripts and modules you have open, which is particularly important for navigating larger projects."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:47
+msgid "The Files pane is another useful tool for particularly larger projects. Like the Outline pane, it can be opened under Panes in the View menu. This allows you to view and navigate through all occurrences of text or regular expressions in any file in the working directory, project or another custom directory. We see, for example, in the ``mainwindow.py`` file we import the ``is_dark_font_color`` function. If we want to quickly find the file where it was defined, we can write this string in the search bar. With this search, we get 7 matches from 3 different files. When we click on any of these matches, the file is opened automatically in the Editor, right where this string appears."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:49
+msgid "Finally, we'll learn how to browse documentation using the Online Help pane. Once you open it, again under Panes in the View menu, you will see an index of modules from which documentation is available, including both those in the Python standard library and any third-party packages that may be installed in Spyder's environment. For example, we can find help for Numpy, Pandas and Matplotlib, which are all installed if you've downloaded Spyder with Anaconda. You can browse the contents in the built-in web browser provided by the pane, and click the hyperlinks within to navigate to different pages. You can also enter the name of the item you'd like documentation on in the Get field or in the space over the pane's toolbar, to load its information directly. If you're not sure of the object's name, use the Search field to view a list of results applicable to any keyword."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:51
+msgid "Now that you're familiar with a wider array of Spyder's panes and features, you can accomplish a variety of common programming tasks with ease. Stay tuned for our our next videos to further add to your scientific toolbox, and as always, Happy Spydering!"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:57
+msgid "Improving your code quality"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:59
+msgid "Learn how to improve the quality of your programs using code analysis."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:61
+msgid "Open and use Code Analysis to evaluate the quality and style of Python files"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:62
+msgid "Run analysis on a file in the Editor or anywhere on your computer"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:63
+msgid "Determine what an error, warning or message means and how to fix it"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:64
+msgid "Turn off messages on a line, in a file or globally"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:78
+msgid "Hello everyone! I'm Juanita, and in this video we will learn how to improve your code quality using the Code Analysis pane. To display it, we can click its name under Panes in the View menu."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:80
+msgid "This pane detects style issues, bad practices, potential bugs and other quality problems in your code, without having to execute it. There are three ways of running code analysis:"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:82
+msgid "To analyze a file that is open in the Editor, we can press the configurable shortcut, :kbd:`F8` by default, or select Source --> Run code analysis from the menu bar."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:84
+msgid "We can also select a file to analyze by browsing for it using the file button next to the path box. This will start the analysis automatically."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:86
+msgid "The third way is to manually enter the path of a file we'd like to check in the path entry box in the pane's toolbar, and click the Analyze button in the pane."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:88
+msgid "Based on these results, the code analysis shows an overall score of 4.34/10, which allows us to track improvements in our code quality. We can also expand or collapse one or all the sections in the pane to be able to see the Pylint errors, warnings and messages identifying the issues with our code."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:90
+msgid "For example, the results tell us that there is a warning on line 20. To go directly to this line in the Editor, just click the message. Here, the code analysis says there is a ``bad-whitespace`` issue. To understand what this means, open the Pylint documentation. On the `Pylint docs page`_ , click on Pylint features and search for the code of the message."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:94
+msgid "We can see that the docs say that we used the wrong number of spaces around an operator."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:102
+msgid "We can fix the error by adding one space before and after the operator in this variable assignment. If we run the analysis again, we can see the error isn't shown any more on this line."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:104
+msgid "We can click the dropdown arrow in the filename field to view the list of previous analyses. Clicking one of them will show us the results."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:106
+msgid "Sometimes, it is useful to turn certain messages off. We can do that in three different ways."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:108
+msgid "We might want to silence warnings on only one line; for example, this \"unused\" import that is still necessary for the code execution. For this, type ``# pylint: disable=unused-import`` as a comment at the end of the line. Running the analysis again will show us that the error is no longer visible."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:110
+msgid "If we want to silence a message in the whole file, we can do it by writing the disable command at the beginning of the file. For example, we can disable the ``invalid-name`` warning that appears several times in this file. If we run the analysis again, all of these warnings are gone."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:112
+msgid "Finally, we can suppress specific messages for all files by editing the ``.pylintrc`` configuration file in your user folder. If it doesn't exist, we can generate it by opening our terminal, or the Anaconda Prompt if you're using Windows, and running ``pylint --generate-rc > .pylintrc`` in our user directory."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:114
+msgid "Now, we can go to the ``MESSAGE CONTROL`` section in this file and add the corresponding Pylint message name, for example ``no-name-in-module``. If we run the analysis one more time, we see that the ``no-name-in-module`` warnings don't appear anymore."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:116
+msgid "We can see that the score of our file increased to 7.63/10, a big improvement over the previous 4.34."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:118
+msgid "Now that we've learned how to improve the quality of our code, you are ready to write cleaner and more correct programs using Spyder. Stay tuned for our next videos and as always, Happy Spydering!"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:124
+msgid "Optimizing your code"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:126
+msgid "Learn how to optimize your code using the Profiler."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:128
+msgid "Use the Profiler to find bottlenecks in your programs"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:129
+msgid "Run profiling on a file in the Editor or elsewhere on your machine"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:130
+msgid "Interpret the results to evaluate function and method performance"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:131
+msgid "Use the information to speed up the run time of your code"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:145
+msgid "Hello everyone! I'm Juanita, and in this video we will learn how to optimize your code using the profiler. To display it, click its name under Panes in the View menu."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:147
+msgid "The Profiler will determine the run time and number of calls for every function and method used in a file. There are three ways of profiling a file:"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:149
+msgid "We can browse for a file using the open button to the right of the Profiler's path box, which will run profiling over it automatically."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:151
+msgid "We can also manually enter the path in the pane's path box, and then run the analysis on the file by pressing the Profile button."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:153
+msgid "If we want to run the profiler for the file that is currently open in the Editor, we can click Run --> Profile... in the menu bar, or use the configurable shortcut :kbd:`F10`."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:155
+msgid "We see that the results in the pane show us the different functions and methods in our file, with each sub-function listed hierarchically under the item that called them. The columns show the total time taken by each function and everything it called, while the local time includes only the time spent in that particular function."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:157
+msgid "For example, the function ``values`` in this file calls a function ``internal_values`` values took a total of 482 us to run, with 338 us of that spent executing internal_values inside of it. Therefore, the total time for values is 482 us, but its local time is only 144 us as the rest was spent inside ``internal_values``."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:159
+msgid "The Calls column displays the total number of times that function was called at that level. Finally, the numbers in the Diff columns for each of the three appear if a comparison is loaded, and indicate the change in runtime between the two measurements."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:161
+msgid "By double-clicking an item in the Profiler, we will be taken to the file and line in the Editor where it was called. If this function was not called in one of your open scripts, clicking it will open the file that contains it. We can click the down arrow button in the filename field to recall paths of previously profiled files."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:163
+msgid "Now that we know how to interpret the results of our profiling, let's optimize our code by finding the functions that take the longest time and making them faster. In this case, ``to_datetime`` takes 39 seconds to run. The reason for this is Pandas has to parse the non-standard timestamp format and is not told to try to use a faster parser than the default."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:165
+#, python-format
+msgid "We can reduce the time this function takes and compare it with the one before. For this, first we have to save the data as a ``.Result`` file with the save button in the pane. Now we have to figure out how to optimize the function, so let's search for it. We see that we can speed up this function by `manually specifying a datetime format`_. So, we add the appropriate argument, ``format=\"%Y-%m-%d %H:%M:%S.%f %z\"``, to our function call."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:169
+msgid "Now, we run the profiling again to see how our script's performance has improved. If we want to see how much we lowered the time, we can load our previous result and take a look at the diff columns. Notice the difference is green because the time was reduced by three times, taking only 13 seconds instead of 39. Our code is now 26 seconds faster!"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:171
+msgid "Now that you've learned how to analyze the execution time of your code, you are ready to write more efficient programs with Spyder's help. Stay tuned for our next videos and as always, Happy Spydering!"
+msgstr ""
+

--- a/doc/locales/es/LC_MESSAGES/workshops.po
+++ b/doc/locales/es/LC_MESSAGES/workshops.po
@@ -1,0 +1,2928 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: spyder-documentation\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: 2024-09-10 00:48\n"
+"Last-Translator: \n"
+"Language: es\n"
+"Language-Team: Spanish\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+"X-Crowdin-Project: spyder-documentation\n"
+"X-Crowdin-Project-ID: 641502\n"
+"X-Crowdin-Language: es-ES\n"
+"X-Crowdin-File: /doc/locales/en/LC_MESSAGES/workshops.po\n"
+"X-Crowdin-File-ID: 24\n"
+
+#: ../../workshops/financial.rst:3
+msgid "Financial Data Analysis with Spyder"
+msgstr ""
+
+#: ../../workshops/financial.rst:5
+msgid "By the end of this workshop participants will be able to use Spyder effectively for  applying some normative financial theories and models to assemble a portfolio of assets in a way that maximizes the expected return for a given level of risk. In this way, statistically-based tools are used to construct investment portfolios."
+msgstr ""
+
+#: ../../workshops/financial.rst:11 ../../workshops/plugin-development.rst:15
+#: ../../workshops/scientific-computing.rst:11
+msgid "Prerequisites"
+msgstr ""
+
+#: ../../workshops/financial.rst:13
+msgid "To follow this workshop we recommend that you have a intermediate knowledge of Python. You can visit `The Python Tutorial`_ to learn the basics of this programming language or to refresh your knowledge of Python."
+msgstr ""
+
+#: ../../workshops/financial.rst:17
+msgid "You will also need to have `Anaconda <https://www.anaconda.com/products/individual>`_ (or `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_) and Spyder installed. More information about Spyder installation in :doc:`installation guide<../installation>`."
+msgstr ""
+
+#: ../../workshops/financial.rst:21 ../../workshops/scientific-computing.rst:17
+msgid "Spyder now offers :ref:`install-standalone` for Windows and macOS, making it easier to get up and running with the application without having to download Anaconda or manually install it in your existing environment. While we still support Anaconda, we recommend this install method on those platforms to avoid most problems with package conflicts and other issues."
+msgstr ""
+
+#: ../../workshops/financial.rst:25 ../../workshops/plugin-development.rst:24
+#: ../../workshops/scientific-computing.rst:20
+msgid "It is also desirable to have the following prior knowledge:"
+msgstr ""
+
+#: ../../workshops/financial.rst:27
+msgid "Intermediate level of Python"
+msgstr ""
+
+#: ../../workshops/financial.rst:28
+msgid "Basic knowledge of Statistics"
+msgstr ""
+
+#: ../../workshops/financial.rst:29
+msgid "Some knowledge of Financial Econometrics is desirable"
+msgstr ""
+
+#: ../../workshops/financial.rst:34 ../../workshops/scientific-computing.rst:34
+msgid "Learning goals"
+msgstr ""
+
+#: ../../workshops/financial.rst:36 ../../workshops/scientific-computing.rst:36
+msgid "After completing this workshop, you should be able to:"
+msgstr ""
+
+#: ../../workshops/financial.rst:38
+msgid "Apply elementary statistical analysis to stock and cryptocurrency portfolios to measure their performance"
+msgstr ""
+
+#: ../../workshops/financial.rst:39
+msgid "Understand the advantages of programming with an IDE, such as inspecting variables using the Variable Explorer and interacting with plots leveraging the Plots Pane."
+msgstr ""
+
+#: ../../workshops/financial.rst:44 ../../workshops/scientific-computing.rst:45
+msgid "Learner profile"
+msgstr ""
+
+#: ../../workshops/financial.rst:46
+msgid "This workshop is intended for people interested in finance who want to take their first steps in Financial Analysis using Python and Spyder."
+msgstr ""
+
+#: ../../workshops/financial.rst:52 ../../workshops/scientific-computing.rst:53
+msgid "Intro"
+msgstr ""
+
+#: ../../workshops/financial.rst:54
+msgid "In this workshop we will obtain financial data in real-time from `Yahoo! Finance`_ API and explore financial portfolios using Econometrics and computational tools."
+msgstr ""
+
+#: ../../workshops/financial.rst:58
+msgid "Why use Python for financial analysis?"
+msgstr ""
+
+#: ../../workshops/financial.rst:60
+msgid "Real-time analysis of historical and current financial data is essential for those investing in financial instruments. Python has a number of features that make it ideal for financial tasks:"
+msgstr ""
+
+#: ../../workshops/financial.rst:62
+msgid "It is easy to learn for anyone, whether they have previous programming experience or not"
+msgstr ""
+
+#: ../../workshops/financial.rst:63
+msgid "It has a variety of specialized mathematical and statistical libraries (`SciPy <https://scipy.org>`_, `NumPy <https://numpy.org>`_, `Pandas <https://pandas.pydata.org>`_) that are commonly used for financial analysis"
+msgstr ""
+
+#: ../../workshops/financial.rst:64
+msgid "It can be connected to APIs for loading financial data in real time"
+msgstr ""
+
+#: ../../workshops/financial.rst:65
+msgid "It is the programming language with the most resources for machine learning (supervised learning, unsupervised learning, reinforcement learning), which is one of the most useful tools for Econometrics nowadays"
+msgstr ""
+
+#: ../../workshops/financial.rst:66 ../../workshops/scientific-computing.rst:68
+msgid "It has excellent libraries for plotting"
+msgstr ""
+
+#: ../../workshops/financial.rst:67
+msgid "You can use resources such as `Google Colab <https://colab.research.google.com>`_ or `Binder <https://mybinder.org>`_ to do your analysis in the cloud."
+msgstr ""
+
+#: ../../workshops/financial.rst:71
+msgid "Why should I use an IDE?"
+msgstr ""
+
+#: ../../workshops/financial.rst:73
+msgid "Although you can use Python without an IDE (Integrated Development Environment), you will work much better with one. Spyder is a Scientific Integrated Development Environment written in Python, and designed by and for scientists, engineers, and data analysts. Spyder's capabilities and its integration with Python make it perfect for financial analysis."
+msgstr ""
+
+#: ../../workshops/financial.rst:77
+msgid "Introduction to financial analysis with Spyder"
+msgstr ""
+
+#: ../../workshops/financial.rst:79 ../../workshops/scientific-computing.rst:96
+msgid "If you're not familiar with Spyder, we recommend you start with our :doc:`Quickstart<../quickstart>`. But if you want a  summary, here's a quick overview."
+msgstr ""
+
+#: ../../workshops/financial.rst:83
+msgid "If you already have experience with Spyder, you can skip this section."
+msgstr ""
+
+#: ../../workshops/financial.rst:87
+#: ../../workshops/scientific-computing.rst:104
+msgid "Editor"
+msgstr ""
+
+#: ../../workshops/financial.rst:89
+#: ../../workshops/scientific-computing.rst:106
+msgid "The :doc:`Editor<../panes/editor>` is the place where you write your code and save it as a file (script). It allows you to easily persist your work. This is where you write the code you want to keep from the data analysis you do in IPython Console. **Here you will also be able to read, edit and run the code from this workshop**."
+msgstr ""
+
+#: ../../workshops/financial.rst:93
+#: ../../workshops/scientific-computing.rst:110
+msgid "IPython Console"
+msgstr ""
+
+#: ../../workshops/financial.rst:95
+#: ../../workshops/scientific-computing.rst:112
+msgid "The :doc:`IPython Console<../panes/ipythonconsole>` is the Spyder's component where you write chunks of code that you want to experiment with. **In this workshop, we are going to give you pieces of code that you can copy and run in this console**."
+msgstr ""
+
+#: ../../workshops/financial.rst:97
+#: ../../workshops/scientific-computing.rst:114
+msgid "In essence, the IPython Console allows you to execute commands and interact with data using Python."
+msgstr ""
+
+#: ../../workshops/financial.rst:101
+#: ../../workshops/scientific-computing.rst:118
+msgid "Variable Explorer"
+msgstr ""
+
+#: ../../workshops/financial.rst:103
+#: ../../workshops/scientific-computing.rst:120
+msgid "The :doc:`Variable Explorer<../panes/variableexplorer>` is one of Spyder's best features. It allows you to interactively browse and manage the objects generated in the code of the currently selected :doc:`../panes/ipythonconsole` session."
+msgstr ""
+
+#: ../../workshops/financial.rst:105
+msgid "The Variable Explorer is one of the most frequently used components in this workshop. **This is the pane where we will observe the data and most of the results of the analysis, except for the plots**."
+msgstr ""
+
+#: ../../workshops/financial.rst:109
+#: ../../workshops/scientific-computing.rst:126
+msgid "Plots pane"
+msgstr ""
+
+#: ../../workshops/financial.rst:111
+msgid "The :doc:`Plots pane <../panes/plots>` shows all the static graphs and images created in your IPython Console session. **All plots generated by the code will appear in this component**.  This pane also allows you to save each graphic in a local file or copy it to the clipboard to share it with other people."
+msgstr ""
+
+#: ../../workshops/financial.rst:117
+#: ../../workshops/scientific-computing.rst:140
+msgid "Preparation work"
+msgstr ""
+
+#: ../../workshops/financial.rst:119
+#: ../../workshops/scientific-computing.rst:142
+msgid "Before starting, you must have installed some packages and libraries needed to run the code. We recommend you to install these requirements in a virtual environment. Here we explain step by step how to do it."
+msgstr ""
+
+#: ../../workshops/financial.rst:123
+msgid "Set up Conda environment"
+msgstr ""
+
+#: ../../workshops/financial.rst:125
+#: ../../workshops/scientific-computing.rst:148
+msgid "If you would like to have Spyder in a dedicated environment to update it separately from your other packages and avoid any conflicts, you can."
+msgstr ""
+
+#: ../../workshops/financial.rst:127
+#: ../../workshops/scientific-computing.rst:150
+msgid "You can set up your environment in two different ways."
+msgstr ""
+
+#: ../../workshops/financial.rst:131
+msgid "We recommend creating the virtual environment with Anaconda (or Miniconda) as it integrates seamlessly with Spyder. You can find installation instructions in `Anaconda documentation`_."
+msgstr ""
+
+#: ../../workshops/financial.rst:137
+msgid "With commands"
+msgstr ""
+
+#: ../../workshops/financial.rst:139
+msgid "Just run the following command in your Anaconda Prompt (Windows) or terminal (other platforms), to create a new environment called ``financial-analysis``:"
+msgstr ""
+
+#: ../../workshops/financial.rst:145
+msgid "To install Spyder's optional dependencies as well for full functionality, use the following command:"
+msgstr ""
+
+#: ../../workshops/financial.rst:156
+msgid "Spyder now offers :ref:`install-standalone` for Windows and macOS, making it easier to get up and running with the application without having to download Anaconda or manually install it in your existing environment."
+msgstr ""
+
+#: ../../workshops/financial.rst:160
+msgid "Download the datasets"
+msgstr ""
+
+#: ../../workshops/financial.rst:162
+msgid "Although during the workshop we will explain how to use some APIs to download up-to-date data, you can also download the datasets in csv format from `this link <https://figshare.com/articles/dataset/Historical_financial_datasets_for_Financial_Analysis_with_Spyder_workshop/14995215>`_."
+msgstr ""
+
+#: ../../workshops/financial.rst:164
+msgid "To follow this workshop you do not need to create a new directory. However, if you have downloaded the data and want to use it instead of the APIs, you must set the directory that has the downloaded data as the working directory. In order to do this, check that the working directory is correct. You should see in the upper right corner the path to the directory where you have the downloaded data. Something like this:"
+msgstr ""
+
+#: ../../workshops/financial.rst:171
+msgid "Setting up the virtual environment in Spyder"
+msgstr ""
+
+#: ../../workshops/financial.rst:173
+msgid "Let's check that the virtual environment we created is enabled in Spyder. Go to :guilabel:`Preferences > Python interpreter`, and use the dropdown below :guilabel:`Use the following Python interpreter` to choose your virtual environment. You should see something like this:"
+msgstr ""
+
+#: ../../workshops/financial.rst:178
+#: ../../workshops/scientific-computing.rst:239
+msgid "Now, you have everything ready to proceed with the workshop."
+msgstr ""
+
+#: ../../workshops/financial.rst:182
+#: ../../workshops/scientific-computing.rst:243
+msgid "Download the code"
+msgstr ""
+
+#: ../../workshops/financial.rst:184
+msgid "Although the workshop is designed for you to write the code in the IPython Console, we have created a file that you can download :download:`here <financial-analysis.py>`. This script provides all the code you will write in this workshop, and you can use it as a guide if you get lost."
+msgstr ""
+
+#: ../../workshops/financial.rst:190
+msgid "Obtain financial data"
+msgstr ""
+
+#: ../../workshops/financial.rst:192
+msgid "When it comes to finance, being up to date is very important. So we are going to use a Python library that allows us to get updated historical Stock Market records from `Yahoo! Finance`_ API. In this way, we will be able to download data in the period of time we are interested in analyzing."
+msgstr ""
+
+#: ../../workshops/financial.rst:197
+#: ../../workshops/scientific-computing.rst:261
+msgid "Remember to type and run all code for this workshop in the \"IPython Console\" at the bottom right of Spyder."
+msgstr ""
+
+#: ../../workshops/financial.rst:202
+msgid "You can also write your code in the Editor (the pane that occupies the entire left side of Spyder). If you use the Editor, you can run the code by selecting it and pressing the :guilabel:`Run selection or current line` button in the :guilabel:`Run toolbar` or by pressing the :kbd:`F9` key."
+msgstr ""
+
+#: ../../workshops/financial.rst:207
+#: ../../workshops/scientific-computing.rst:271
+msgid "To get started, import the libraries."
+msgstr ""
+
+#: ../../workshops/financial.rst:222
+msgid "The first group of imports is for basic operations. The second (``Historic_Crypto`` and ``yfinance``) imports the libraries that we will use to download financial data."
+msgstr ""
+
+#: ../../workshops/financial.rst:224
+msgid "Let's start exploring libraries with an example. We are going to get financial information about Netflix with one line of code:"
+msgstr ""
+
+#: ../../workshops/financial.rst:230
+msgid "We have used the ``Ticker`` class of the ``yfinance`` library to create a ``netflix`` object. This object contains attributes and methods that we can query to obtain various types of information."
+msgstr ""
+
+#: ../../workshops/financial.rst:234
+msgid "General stock information"
+msgstr ""
+
+#: ../../workshops/financial.rst:236
+msgid "If you want to know which methods and attributes you can query, you can do so with the built-in ``help()`` function."
+msgstr ""
+
+#: ../../workshops/financial.rst:238
+msgid "You can also type the name of the object (``netflix``) in the console, then type a period and hit the Tab key once. IPython suggestions will then appear to help you navigate the object:"
+msgstr ""
+
+#: ../../workshops/financial.rst:243
+msgid "For example, we can obtain general information with the ``info`` property of the object."
+msgstr ""
+
+#: ../../workshops/financial.rst:249
+msgid "We can observe the result in the Variable Explorer, in the ``netflix_info`` variable."
+msgstr ""
+
+#: ../../workshops/financial.rst:254
+msgid "If we double-click on it, a new window with detailed information will be displayed."
+msgstr ""
+
+#: ../../workshops/financial.rst:259
+msgid "In that window we can see a Python dictionary in which each key has a value assigned to it. Each type of value is represented by a distinctive color. For example, we see that Netflix is an Entertainment industry, the summary of the business type, among other indicators. The Variable Explorer is a very convenient way to view these types of results. We can compare it to viewing them in the IPython Console with the ``pprint`` function:"
+msgstr ""
+
+#: ../../workshops/financial.rst:268
+msgid "Although ``pprint`` displays all the information, it is easier to view it in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:272
+msgid "Historical stock data"
+msgstr ""
+
+#: ../../workshops/financial.rst:274
+msgid "We can download in a dataset the history of a stock with the following line of code:"
+msgstr ""
+
+#: ../../workshops/financial.rst:280
+msgid "We can see a summary and more details of this dataset in the Variable Explorer. It appears as a DataFrame object, with 7 columns and thousands of rows. If we double-click on it we will see the historical records of Netflix stock organized by ascending dates."
+msgstr ""
+
+#: ../../workshops/financial.rst:285
+msgid "Throughout this workshop we will use this historical information to compare, with various normative financial theories, different types of financial portfolios."
+msgstr ""
+
+#: ../../workshops/financial.rst:291
+msgid "First portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:293
+msgid "Let's build our first stock investment portfolio! Say we are interested in investing in technology, and we want to know what performance can be obtained by putting money into some of the \"heavyweights\" in this industry."
+msgstr ""
+
+#: ../../workshops/financial.rst:295
+msgid "To measure the performance of our first portfolio we are going to use a classic theory in the world of finance: `mean-variance portfolio (MVP) theory`_. This model assumes that investors only care about expected returns and the variance of such returns. The analysis is based entirely on statistical measures based on a time series of share prices, such as periodic mean returns and the variances of those returns with the same periodicity."
+msgstr ""
+
+#: ../../workshops/financial.rst:301
+msgid "Prepare portfolio data"
+msgstr ""
+
+#: ../../workshops/financial.rst:303
+msgid "Before we start, let's run some lines of code to style the plots.  These lines are optional, but we recommend that you run them so that the graphics look like the screenshots we present in this workshop."
+msgstr ""
+
+#: ../../workshops/financial.rst:312
+msgid "Suppose we want to measure the performance of a portfolio consisting of Google, Apple, Microsoft, Netflix and Amazon stocks. Let's call this set ``SYMBOLS_1``."
+msgstr ""
+
+#: ../../workshops/financial.rst:320
+msgid "If you search for ``SYMBOLS_1`` in Variable Explorer you will not find it: Python interprets this element not as a variable, but as a **constant**. This is because the name is written with uppercase letters (no letter is lowercase). By default, the Variable Explorer doesn't show this, but actually you can change the settings in the :guilabel:`Preferences` to be able to see these constants."
+msgstr ""
+
+#: ../../workshops/financial.rst:322
+msgid "We are going to download the historical data for this portfolio. To do this, we are going to use the ``yfinance`` ``download()`` function, which takes as its first argument a string with the symbols (``SYMBOLS_1``) defined above. The rest of the arguments are the start date (``start=\"2012-01-01\"``), the end date (``end=\"2021-01-01\"``) and how the data will be grouped (``group_by=\"Ticker\"``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:328
+msgid "The last argument (``group_by=\"Ticker\"``) groups the information mainly by stock. Otherwise, the primary grouping is done by the type of information (e.g., opening price, closing price, volume traded) of the transactions. In the following image you can see the differences (above is the default organization and below is the grouping by \"Ticker\")."
+msgstr ""
+
+#: ../../workshops/financial.rst:334
+msgid "The historical data has been downloaded as a Pandas DataFrame. We can explore this data in the variable ``data_1`` in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:339
+msgid "Let's change the formatting of the data a bit so that the symbols appear as the column names, and the Ticker moves from columns to rows. We will do this with the ``stack()`` operation of the DataFrame."
+msgstr ""
+
+#: ../../workshops/financial.rst:348
+msgid "From the Ticker we are only interested in the daily closing price. So we will leave only the values for ``\"Close\"`` and eliminate the Ticker column afterwards."
+msgstr ""
+
+#: ../../workshops/financial.rst:354
+msgid "You will notice that there is a new DataFrame in the Variable Explorer called ``close_data_1`` with 2,265 rows and 5 columns."
+msgstr ""
+
+#: ../../workshops/financial.rst:358
+msgid "A first glance at the portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:360
+msgid "We want to see how our portfolio would have performed if we had invested in it from 2012 to early 2021. How could we obtain this measurement? Let's look at the monthly closing prices of each stock. To do this we will do an automatic resample of the data. And then we will calculate the change in relative frequencies (percentages)."
+msgstr ""
+
+#: ../../workshops/financial.rst:362
+msgid "The resampling will be performed with the ``resample(\"M\")`` method and the calculation of percentages with the ``pct_change()`` method. The result will be stored in the ``monthly_data_1`` variable."
+msgstr ""
+
+#: ../../workshops/financial.rst:368
+msgid "Since each stock is a column, we can use the ``mean()`` method on the DataFrame to see the results."
+msgstr ""
+
+#: ../../workshops/financial.rst:383
+msgid "Remember that this closing information represents the relative growth of each stock, not its closing price in any currency."
+msgstr ""
+
+#: ../../workshops/financial.rst:385
+msgid "As we can see, all the results are positive, so this portfolio has been profitable over the years. In relative terms, the biggest gains would come from Netflix (0.4 percent). These percentages show an average of the monthly variation of the stock price. But how stable have that prices been? To find this out, we can calculate the standard deviation of stock price growth:"
+msgstr ""
+
+#: ../../workshops/financial.rst:398
+msgid "The highest volatility is found in Netflix (0.1454), which indicates that its price, despite being the fastest growing, has also had a lot of variation during these years. The most stable price, on the other hand, has been Microsoft's (0.0583)."
+msgstr ""
+
+#: ../../workshops/financial.rst:400
+msgid "A good way to observe both growth and variability is to draw a time-series plot. To scale the values, we are going to divide the relative frequency of the closing price of the actions by the initial value it has in the dataframe ``close_data_1`` (these initial values can be found with ``close_data_1.iloc[0])``). The plot is drawn with the ``plot()`` method of the Pandas DataFrame (to which we pass as arguments the size of the plot and the plot title)."
+msgstr ""
+
+#: ../../workshops/financial.rst:411
+msgid "You will be able to see the graph in the Plots pane. On the left, you will see the plot in detail. On the right, a stack will be created with all the plots that are generated both in the Console and by running the code directly in the Editor. You can copy, delete or save the plot to disk by clicking on it with the right mouse button or trackpad."
+msgstr ""
+
+#: ../../workshops/financial.rst:413
+msgid "The above time-series plot clearly shows the growth of all stocks, particularly Netflix. The high volatility discussed above can also be seen. For example, it can be seen from the plots that, due to high volatility, investing in Netflix in the years 2014 and 2019 left virtually no profit (if shares were bought at the beginning of the year and sold right at the end)."
+msgstr ""
+
+#: ../../workshops/financial.rst:415
+msgid "We can also plot with the ``plot()`` method the DataFrame we already have with the monthly data. To do this, we will add 1 to all the values and calculate the accumulated product with the ``cumprod()`` method:"
+msgstr ""
+
+#: ../../workshops/financial.rst:424
+msgid "This plot of the monthly data is \"smoother\" than the plot of the daily data."
+msgstr ""
+
+#: ../../workshops/financial.rst:428
+msgid "Returns and volatility"
+msgstr ""
+
+#: ../../workshops/financial.rst:430
+msgid "Remember that in the *mean-variance portfolio theory* what matters are the expected returns and variances. To calculate these returns, we will divide the price of the stock on one day by the price of the same stock on the previous day. We will do this by dividing the ``close_data_1`` DataFrame by a version of itself in which we shift each record one date backwards (``shift(1)``). For example, if on the date 2012-01-03 a stock was valued at 1, and on the next day (2012-01-02), it was valued at 2, then in our shifted dataset, on the day 2012-01-03 the stock would be worth 1. In this way, we would divide 1 by 2. And so on with all the values of all the shares. We will also normalize the results by passing them to a logarithmic scale with ``np.log()``."
+msgstr ""
+
+#: ../../workshops/financial.rst:434
+msgid "Trend lines are more easily drawn in logarithmic scale because they tend to fit better to the minimums. In addition, the logarithmic scale gives a more realistic view of price movements."
+msgstr ""
+
+#: ../../workshops/financial.rst:440
+msgid "In the variable ``rets_1`` you can see the resulting DataFrame. If you double-click on the variable name in the Variable Explorer, you will see that there are positive values (the share price increased) and negative values (the price decreased at the time of closing)."
+msgstr ""
+
+#: ../../workshops/financial.rst:445
+msgid "In addition to the returns of each stock, we will need the specific weight of each stock in the portfolio, i.e., how many shares of each company are in the portfolio. In this workshop we will assume that there is one share of each company and, therefore, the weights will be distributed equally."
+msgstr ""
+
+#: ../../workshops/financial.rst:449
+msgid "A stock is a financial security that represents that you own a part of a company (whatever the size of this part). A share, on the other hand, is the smallest unit of denomination of a stock. A stock is composed of one or several shares."
+msgstr ""
+
+#: ../../workshops/financial.rst:451
+msgid "This weight will be a vector (Python list) composed of the relative weight (between 0 and 1) of each stock in the portfolio. The sum of these weights has to be 1. Since we will assume that each stock is a single share, the distribution will be equal: ``[0.2, 0.2, 0.2, 0.2, 0.2]``."
+msgstr ""
+
+#: ../../workshops/financial.rst:457
+msgid "With this information we can calculate the expected return of this portfolio. The math is simple: this is given by the dot product of the portfolio weights vector and the vector of expected returns. This result must be multiplied by the number of days for which the return is to be calculated (a year has approximately 252 stock price closings)."
+msgstr ""
+
+#: ../../workshops/financial.rst:459
+msgid "Let's put all this into a function:"
+msgstr ""
+
+#: ../../workshops/financial.rst:466
+msgid "Let's look at the expected return of this portfolio if we hold it for one year:"
+msgstr ""
+
+#: ../../workshops/financial.rst:474
+#, python-format
+msgid "An expected gain of almost 30% in one year. Not bad, right? But don't forget the other side of this coin: volatility. This calculation is a bit more complex. First, the dot product of the annualized covariance of the returns (this is multiplied by the number of trading days in a year) and the weights is calculated. Then the dot product of the weights and the previous result is obtained. Finally, the square root of this result is extracted. Let's implement this into a function as well."
+msgstr ""
+
+#: ../../workshops/financial.rst:481
+msgid "Let's see how our portfolio performs with respect to its volatility:"
+msgstr ""
+
+#: ../../workshops/financial.rst:489
+msgid "If high return is desirable, high volatility is undesirable. The risk of this portfolio is relatively large."
+msgstr ""
+
+#: ../../workshops/financial.rst:493
+msgid "Sharpe ratio"
+msgstr ""
+
+#: ../../workshops/financial.rst:495
+msgid "The `Sharpe`_ ratio or index is a measure of portfolio performance. It relates the portfolio's return to its volatility, comparing the expected/realized return with the expected/realized risk. It is calculated as the difference between the actual investment returns and the expected return in a zero-risk situation, divided by the volatility of the investment. **It provides a model of the additional amount of returns received for each additional unit of risk**."
+msgstr ""
+
+#: ../../workshops/financial.rst:499
+msgid "Let's formalize this in a function:"
+msgstr ""
+
+#: ../../workshops/financial.rst:506
+msgid "And let's apply this to our portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:516
+msgid "The Sharpe ratio measure is best understood in context: when comparing two or more portfolios, the one with the higher Sharpe ratio provides more profit for the same amount of risk."
+msgstr ""
+
+#: ../../workshops/financial.rst:518
+msgid "We can also use a `Monte Carlo <https://en.wikipedia.org/wiki/Monte_Carlo_method>`_ simulation to randomize the weights of each stock in the portfolio so that we can see the range over which the Sharpe ratio can vary. In this way we can plot some scenarios that together will give us a good insight of the relationship between expected returns and expected volatility."
+msgstr ""
+
+#: ../../workshops/financial.rst:520
+msgid "We are going to do this with a function that we will explain step by step in the `monte_carlo_sharpe function explained`_ section."
+msgstr ""
+
+#: ../../workshops/financial.rst:538
+msgid "You do not need to type the following code in the IPython Console. If you write the function above it will be enough. It is just a code presentation to explain what is inside the function."
+msgstr ""
+
+#: ../../workshops/financial.rst:542
+msgid "``monte_carlo_sharpe`` function explained"
+msgstr ""
+
+#: ../../workshops/financial.rst:544
+msgid "Let's now break the function down to understand what is happening. First, we create a numpy array of length 1,000 and width of the number of shares in the portfolio. Each row of the array has random weights that always add up to 1:"
+msgstr ""
+
+#: ../../workshops/financial.rst:552
+msgid "The next section calculates the volatility and returns for the new random weights using a list comprehension. The resulting list is transformed back into a numpy array:"
+msgstr ""
+
+#: ../../workshops/financial.rst:559
+msgid "Finally, we obtain the Sharpe ratio by dividing the index 1 (volatilities) by the index 0 (returns) of the numpy array:"
+msgstr ""
+
+#: ../../workshops/financial.rst:567
+msgid "Using the ``monte_carlo_sharpe`` function"
+msgstr ""
+
+#: ../../workshops/financial.rst:569
+msgid "We use the function to get the simulated returns and volatility of portfolio 1 (``port_1_vr``) and the related Sharpe ratios (``port_1_sr``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:571
+msgid "Enter the following code in the console."
+msgstr ""
+
+#: ../../workshops/financial.rst:579
+msgid "Remember that the weights are initialized randomly, so each time you run this code you will get different results."
+msgstr ""
+
+#: ../../workshops/financial.rst:581
+msgid "With this we obtain two arrays with 1,000 simulated cases for our portfolio. But the best way to explore this is with a plot."
+msgstr ""
+
+#: ../../workshops/financial.rst:593
+msgid "You should see in the Plots pane something like this:"
+msgstr ""
+
+#: ../../workshops/financial.rst:598
+msgid "A roughly linear relationship can be observed between returns and volatility: the higher the volatility, the higher the gains. And the Sharpe ratio shows an important amount of variability (it is noticeable in the \"width\" of the line drawn)."
+msgstr ""
+
+#: ../../workshops/financial.rst:600
+msgid "This seems to be a good portfolio because it has a good performance with a not very large variance."
+msgstr ""
+
+#: ../../workshops/financial.rst:604
+msgid "Optimal portfolio weights"
+msgstr ""
+
+#: ../../workshops/financial.rst:606
+msgid "Can we use the data obtained to calculate the optimal weights for the portfolio by year? Of course we can. Let's start by delimiting the previous years as variables."
+msgstr ""
+
+#: ../../workshops/financial.rst:612
+msgid "We will now write a function to calculate these optimal weights."
+msgstr ""
+
+#: ../../workshops/financial.rst:629
+msgid "Let's describe this function in broad strokes. ``bounds`` indicates the maximum and minimum weights for each stock in the portfolio. The lowest weight will be 0 and the highest weight will be 1 for each stock in the portfolio. ``constraints`` is a function that ensures that the sum of the weights of all actions always adds up to 1. Then a loop is initialized that will segment the data for each year. In the variable ``_rets`` the returns for the specified year are obtained. In ``_opt_w`` the ``portfolio_shape()`` function is used to calculate the weights that maximize the Sharpe ratio. This is done with the ``minimize()`` function of SciPy (which takes as arguments the ``portfolio_shape`` function, the actual weights of our stocks in the portfolio, and the ``bounds`` and the ``constraints`` variables). Notice the ``-`` sign before ``portfolio_sharpe``? It's because ``minimize()`` aims to find the minimum value of a function relative to a parameter, but we are interested in the maximum, so we make the result of ``portfolio_sharpe`` a negative one."
+msgstr ""
+
+#: ../../workshops/financial.rst:631
+msgid "We will use the function we just defined to calculate the optimal weights for each year, and we are going to save the result in a Pandas DataFrame to take advantage of the Variable Explorer display options."
+msgstr ""
+
+#: ../../workshops/financial.rst:639
+msgid "Double click on the ``port_1_ow`` variable in the Variable Explorer. In the table, you can specify the number of decimal places to display, by clicking the format button at the bottom left of the pane, as you can see in the following image:"
+msgstr ""
+
+#: ../../workshops/financial.rst:644
+msgid "We set the number of decimal places to 4 and uncheck the **Column min/max** checkbox to better appreciate the contrasts in the row values (years)."
+msgstr ""
+
+#: ../../workshops/financial.rst:646
+msgid "You can see, for example, how 2015 was a particularly good year for investing in Amazon and Netflix, while 2014 was the year of Apple. Despite Netflix's rapid growth over the years, its high volatility means that its Sharpe Ratio is not very remarkable in any year, especially (as we said above) in 2014 and 2019. In the same respect, Apple and Microsoft seem to be safer bets in the return/volatility ratio."
+msgstr ""
+
+#: ../../workshops/financial.rst:650
+msgid "Comparison of expected and realized returns"
+msgstr ""
+
+#: ../../workshops/financial.rst:652
+msgid "Finally, we will use the optimal weights to calculate the expected returns and compare them with the actual returns."
+msgstr ""
+
+#: ../../workshops/financial.rst:668
+msgid "In this function we compare year to year realized returns with theoretically expected returns. This is done by estimating:"
+msgstr ""
+
+#: ../../workshops/financial.rst:670
+msgid "The returns from applying the optimal weights of the previous year's stocks to the data for that same year (``expected_pr``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:671
+msgid "The returns from applying the optimal weights of the previous year's stocks to the following year's data (``realized_pr``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:673
+msgid "We are going to apply this function to the data in portfolio 1 and store the results in a DataFrame that we can review in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:680
+msgid "The expected column shows the predicted values if the optimal portfolio composition had been used. The realized column, on the other hand, shows the actual profits that would have been obtained with those weights. It can be seen that there are notable differences in some years. Let's look at this in a plot."
+msgstr ""
+
+#: ../../workshops/financial.rst:689
+msgid "The most notable differences are seen in 2014 and 2016. In those years, the previous year's optimal portfolio weights (in blue in the above plot) are a lousy indicator of the following year's stock performance (in red). In 2013, our model estimated that Google and Netflix were excellent investments. But by 2014 their share price did not grow if we compare the price at the beginning and at the end of that year. And something similar happened in 2016, in which Amazon's growing trend of the previous year diminished, and the value of Microsoft and Apple shares grew."
+msgstr ""
+
+#: ../../workshops/financial.rst:691
+msgid "Let's summarize these numbers."
+msgstr ""
+
+#: ../../workshops/financial.rst:701
+msgid "Our optimal weight model offered us a profit of around 40%, but the profit we would have obtained, due to real market fluctuations, would have been almost 20%. Not bad, but the mean-variance portfolio model we have applied for annual calculations is not very accurate, is it?"
+msgstr ""
+
+#: ../../workshops/financial.rst:703
+msgid "And this result is less encouraging if we calculate the correlations between expected and realized profits."
+msgstr ""
+
+#: ../../workshops/financial.rst:713
+msgid "As we can see, the correlations are negative, which warns us that we should be cautious when using this type of modeling."
+msgstr ""
+
+#: ../../workshops/financial.rst:719
+msgid "Second portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:721
+msgid "We are now going to apply all the previous code with a portfolio of a different nature. Let's assume that instead of technology companies, we are now interested in pharmaceuticals. We will build a portfolio with stocks of Pfizer, Astra Zeneca, Johnson & Johnson."
+msgstr ""
+
+#: ../../workshops/financial.rst:725
+msgid "Download the data"
+msgstr ""
+
+#: ../../workshops/financial.rst:727
+msgid "Let's download the data and format it."
+msgstr ""
+
+#: ../../workshops/financial.rst:740
+msgid "If you do not want to use the yfinance API, you can download the ``close_data_2.csv`` file containing the closing information for this portfolio. Copy this file to your working directory. Load the data with the following instruction:  ``>>> close_data_2 = pd.read_csv(\"close_data_2.csv\")``."
+msgstr ""
+
+#: ../../workshops/financial.rst:744
+msgid "Mean and standard deviation"
+msgstr ""
+
+#: ../../workshops/financial.rst:746
+msgid "We are going to put the data in a monthly format and observe the mean and standard deviation."
+msgstr ""
+
+#: ../../workshops/financial.rst:768
+msgid "As in portfolio 1, all means are positive. But its largest value (that of JNJ) barely reaches 1% per month, which is slower growth than that of portfolio 1. The variation is also smaller compared to that of the previous portfolio (here the largest deviation is 0.06) which makes it a lower risk investment."
+msgstr ""
+
+#: ../../workshops/financial.rst:772
+msgid "Daily and monthly timelines"
+msgstr ""
+
+#: ../../workshops/financial.rst:774
+msgid "Let's better visualize the above with a couple of charts."
+msgstr ""
+
+#: ../../workshops/financial.rst:791
+msgid "These two plots show a steady growth over the years, but also a high variability in each year. This seems to be a good portfolio only if taken as a long-term investment."
+msgstr ""
+
+#: ../../workshops/financial.rst:795
+msgid "Returns, volatility and Sharpe ratio"
+msgstr ""
+
+#: ../../workshops/financial.rst:797
+msgid "To confirm what was said in the previous section, let's calculate returns, volatility and Sharpe ratio."
+msgstr ""
+
+#: ../../workshops/financial.rst:811
+msgid "The return of this portfolio is significantly lower than that of the previous portfolio (0.0809 < 0.2859). Its volatility (0.1637 < 0.2370) is also lower, but to a lesser extent. This is reflected in a lower Sharpe ratio as well (0.4940 < 1.2062). This means, within the mean-variance theory approach, that the first portfolio is a better investment than the second one."
+msgstr ""
+
+#: ../../workshops/financial.rst:813
+msgid "The different behavior is clearly observed if we apply a Monte Carlo simulation and visualize it with a graph:"
+msgstr ""
+
+#: ../../workshops/financial.rst:830
+msgid "High volatility does not correspond in most cases with high returns. In fact, there are scenarios in the simulation in which higher expected returns are related to lower expected volatility."
+msgstr ""
+
+#: ../../workshops/financial.rst:834
+msgid "Optimal pharmaceutical stock weights"
+msgstr ""
+
+#: ../../workshops/financial.rst:836
+msgid "Let us now see what are the optimal weights for each stock using the ``optimal_weights`` function."
+msgstr ""
+
+#: ../../workshops/financial.rst:849
+msgid "In addition, we can use these optimal weights to plot the expected and realized returns of this portfolio for each year."
+msgstr ""
+
+#: ../../workshops/financial.rst:861
+msgid "Due to the high volatility of this portfolio, our model has not been able to adequately forecast expected returns in several of the years. Higher than expected returns would have been realized in 2013 and 2017, but in 2015 and 2018 using the model would have generated losses."
+msgstr ""
+
+#: ../../workshops/financial.rst:863
+msgid "Finally, let us look at the differences between the expected and realized means, and the linear correlation between the data."
+msgstr ""
+
+#: ../../workshops/financial.rst:881
+msgid "As we can see, the model with optimal weights predicted a return close to 15% per year, but the realized return would have barely reached 6%. And the negative correlations show, as with portfolio 1, that there does not seem to be any correspondence between these values."
+msgstr ""
+
+#: ../../workshops/financial.rst:883
+msgid "The comparison is then favorable for portfolio 1. But what if we compare portfolio 1 with a \"higher risk\" investment such as cryptocurrencies? Let's discuss it below."
+msgstr ""
+
+#: ../../workshops/financial.rst:889
+msgid "Third portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:892
+msgid "Download cryptocurrencies data"
+msgstr ""
+
+#: ../../workshops/financial.rst:894
+msgid "Our third portfolio will consist of three cryptocurrencies: bitcoin (BTC), ethereum (ETH) and litecoin (LTC). To access historical data, we are going to use a library called **Historic-Crypto**."
+msgstr ""
+
+#: ../../workshops/financial.rst:898
+msgid "If you want to make use of the data without the Historic-Crypto library, you can `download the dataset <https://figshare.com/articles/dataset/Historical_financial_datasets_for_Financial_Analysis_with_Spyder_workshop/14995215>`_ \"crypto_hist.csv\" in your working directory, and load it in memory with the instruction ``crypto_hist = pd.read_csv(\"crypto_hist.csv\")``, and skip to section `Monthly data`_."
+msgstr ""
+
+#: ../../workshops/financial.rst:900
+msgid "Import the libraries:"
+msgstr ""
+
+#: ../../workshops/financial.rst:907
+msgid "We are going to use the ``Cryptocurrencies`` class to obtain a list of available cryptocurrencies."
+msgstr ""
+
+#: ../../workshops/financial.rst:915
+msgid "If you want more information about the use of this library you can make a quick query using the Spyder Help panel (type in the console ``Cryptocurrencies`` and use :kbd:`Ctrl-I` or :kbd:`Cmd-I` to display it). Or you can read the documentation in their `official repository <https://github.com/David-Woroniuk/Historic_Crypto>`_"
+msgstr ""
+
+#: ../../workshops/financial.rst:917
+msgid "A new variable has appeared in the Variable Explorer: ``crypto_list``. It is a Pandas DataFrame that has a basic description of the types of cryptocurrency transactions. For example, we can look up which token is the token for ethereum transactions in US dollars."
+msgstr ""
+
+#: ../../workshops/financial.rst:923
+msgid "In this case, we are interested in the symbol with ID 171: ETH-USD."
+msgstr ""
+
+#: ../../workshops/financial.rst:925
+msgid "We can use the HistoricalData class of Historic-Crypto to download the history of transactions done in the cryptocurrencies of our portfolio, in US dollars."
+msgstr ""
+
+#: ../../workshops/financial.rst:946
+msgid "Let's merge the resulting dataframes to have all the data in a single table."
+msgstr ""
+
+#: ../../workshops/financial.rst:953
+msgid "We will not present the procedures and code in this section, but only the results of the analysis. You can follow the steps in the previous sections to recreate these results."
+msgstr ""
+
+#: ../../workshops/financial.rst:957
+msgid "Use all this section on portfolio 3 to check your understanding of the concepts and code we have presented until now. If you have any questions, you can consult the :download:`code <financial-analysis.py>` code that accompanies this workshop. But we encourage you to try as much as possible to solve the code on your own."
+msgstr ""
+
+#: ../../workshops/financial.rst:961
+msgid "Monthly data"
+msgstr ""
+
+#: ../../workshops/financial.rst:963
+msgid "Let's take a look at the monthly history of cryptocurrency price growth."
+msgstr ""
+
+#: ../../workshops/financial.rst:968
+msgid "We can note that the scale here is much larger. And the proportion of ETH growth over the other two coins is quite remarkable."
+msgstr ""
+
+#: ../../workshops/financial.rst:972
+msgid "Return, volatility and Sharpe ratio"
+msgstr ""
+
+#: ../../workshops/financial.rst:974
+msgid "Let's consider the return, volatility and Sharpe ratio of this portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:976
+msgid "Return: 0.6203"
+msgstr ""
+
+#: ../../workshops/financial.rst:977
+msgid "Volatility: 0.7587"
+msgstr ""
+
+#: ../../workshops/financial.rst:978
+msgid "Sharpe: 0.8176"
+msgstr ""
+
+#: ../../workshops/financial.rst:980
+msgid "These numbers are higher than those obtained for portfolios 1 and 2, except for the Sharpe ratio. This is a very volatile portfolio (in fact three times more volatile than that of the technology companies), and that makes it ultimately not as profitable as portfolio 1. The returns are higher (almost double) but the risk may not compensate for it."
+msgstr ""
+
+#: ../../workshops/financial.rst:984
+msgid "Monte carlo simulation"
+msgstr ""
+
+#: ../../workshops/financial.rst:986
+msgid "The Monte Carlo simulation also shows the non-linear correlation between risk and returns (as you can see, sometimes high risk involves only modest profits):"
+msgstr ""
+
+#: ../../workshops/financial.rst:991
+msgid "As can be seen, there are points (bottom right) that show a very high volatility and yet have a very low expected return. In this sense, portfolio 1 represents a safer investment because the higher risk is consistently offset by higher returns."
+msgstr ""
+
+#: ../../workshops/financial.rst:995
+msgid "Optimal cryptocurrency weights"
+msgstr ""
+
+#: ../../workshops/financial.rst:1000
+msgid "The optimal portfolio weights, if calculated annually, suggest that our portfolio should have been quite polarized in some years: the recommendation is to have bought only bitcoins before the start of 2016 and 2019, and only ethereum in 2018. Starting 2017 and 2020, on the other hand, our weights recommended a more balanced investment between bitcoin and ethereum. Litecoin is not recommended by our model."
+msgstr ""
+
+#: ../../workshops/financial.rst:1004
+msgid "Expected and realized returns"
+msgstr ""
+
+#: ../../workshops/financial.rst:1009
+msgid "In this graph we can see that in 2017 and 2020 the earnings obtained would have exceeded the expected earnings (with our calculated weights). In 2019 our model predicted a sharp drop in the portfolio, but in reality the portfolio did not make either annualized gains or losses that year. In contrast, in 2018, our model would have brought us heavy losses, as the value of cryptocurrencies declined sharply that year."
+msgstr ""
+
+#: ../../workshops/financial.rst:1011
+msgid "The mean expected return for our portfolio is 0.6972, which is higher than the realized return of 0.4181 that we would have obtained. Having invested in this portfolio over the long term (from 2016 to the present) would have been a very good deal. Due to the high variability, investing in the short term would have been very risky. In terms of gross profits, the realized returns of this portfolio were more than double those of portfolio 1 (0.4181 > 0.1997)."
+msgstr ""
+
+#: ../../workshops/financial.rst:1017
+#: ../../workshops/plugin-development.rst:1394
+#: ../../workshops/scientific-computing.rst:751
+msgid "Final words"
+msgstr ""
+
+#: ../../workshops/financial.rst:1019
+msgid "The mean-variance portfolio (MVP) theory is one of the many tools available to financial analysis. In recent years, machine learning algorithms have even been used to predict the behavior of stock prices more accurately than can be achieved with any standard financial theory."
+msgstr ""
+
+#: ../../workshops/financial.rst:1021
+msgid "The examples given during this workshop are not intended to serve as guidelines for you to invest your money. It is only a first step towards learning financial analysis using Python and a scientific IDE."
+msgstr ""
+
+#: ../../workshops/financial.rst:1023
+#: ../../workshops/plugin-development.rst:1402
+#: ../../workshops/scientific-computing.rst:759
+msgid "In this workshop you have learned how to:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1025
+#: ../../workshops/scientific-computing.rst:761
+msgid "Set up a Conda environment."
+msgstr ""
+
+#: ../../workshops/financial.rst:1026
+msgid "Use the Spyder Editor to write and run code."
+msgstr ""
+
+#: ../../workshops/financial.rst:1027
+msgid "Write and test code with the IPython Console."
+msgstr ""
+
+#: ../../workshops/financial.rst:1028
+msgid "Obtain financial data using an API."
+msgstr ""
+
+#: ../../workshops/financial.rst:1029
+msgid "Graphing data."
+msgstr ""
+
+#: ../../workshops/financial.rst:1030
+#: ../../workshops/scientific-computing.rst:764
+msgid "Inspect objects in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:1031
+#: ../../workshops/scientific-computing.rst:766
+msgid "Browse between plots using the Plots pane."
+msgstr ""
+
+#: ../../workshops/financial.rst:1032
+#: ../../workshops/scientific-computing.rst:768
+msgid "Manipulate data in a Pandas DataFrame."
+msgstr ""
+
+#: ../../workshops/financial.rst:1033
+msgid "Build a financial portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:1034
+msgid "Calculate returns and volatility of a portfolio over time."
+msgstr ""
+
+#: ../../workshops/financial.rst:1035
+msgid "Obtain the optimal weights of the stocks in a portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:1037
+msgid "With the skills learned here, you will be able to approach more complex topics of financial analysis such as those you will find in the references in the next section."
+msgstr ""
+
+#: ../../workshops/financial.rst:1039
+#: ../../workshops/scientific-computing.rst:774
+msgid "Thank you for reaching the end of this workshop! We hope you found it helpful and informative."
+msgstr ""
+
+#: ../../workshops/financial.rst:1041
+#: ../../workshops/plugin-development.rst:1422
+msgid "If you are interested in an introduction to scientific computing with Spyder, you can visit the workshop :doc:`Scientific Computing and Visualization with Spyder <../workshops/scientific-computing>`."
+msgstr ""
+
+#: ../../workshops/financial.rst:1045
+#: ../../workshops/plugin-development.rst:1429
+#: ../../workshops/scientific-computing.rst:780
+msgid "Homework"
+msgstr ""
+
+#: ../../workshops/financial.rst:1047
+msgid "If you want to check what you have learned, we suggest you try to obtain the results presented for the third portfolio. If you have any questions, you can consult the code that accompanies this workshop in our repository."
+msgstr ""
+
+#: ../../workshops/financial.rst:1053
+#: ../../workshops/plugin-development.rst:1436
+#: ../../workshops/scientific-computing.rst:788
+msgid "Further reading"
+msgstr ""
+
+#: ../../workshops/financial.rst:1055
+msgid "Much of the math used to apply MVP was the mathematics outlined in Yves Hilpisch's excellent book, which we recommend to you:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1057
+msgid "Yves Hilpisch, Y. (2020). *Artificial Intelligence in Finance*. O'Reilly.*"
+msgstr ""
+
+#: ../../workshops/financial.rst:1059
+msgid "A classic that has been with us for decades and is one of Warren Buffett's favorites:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1061
+msgid "Graham, B. (1949). *The Intelligent Investor*. HarperCollins."
+msgstr ""
+
+#: ../../workshops/financial.rst:1063
+msgid "Another good resource for financial analysis with Python is the following book by James Ma Weiming:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1065
+msgid "Ma Weiming, J. (2019). *Mastering Python for Finance*. Packt"
+msgstr ""
+
+#: ../../workshops/index.rst:3
+msgid "Workshops"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:3
+msgid "Plugin Development with Spyder"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:5
+msgid "This workshop reviews the features and possibilities of the API offered by `Spyder`_ 5—the recently released version of our favorite IDE for scientific Python—for plugin development and to extend its functionality."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:7
+msgid "As a practical exercise, we will develop a simple plugin that incorporates a configurable pomodoro timer in the status bar and some toolbar buttons to interact with it."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:17
+#: ../../workshops/scientific-computing.rst:13
+msgid "You will need to have Spyder installed. Visit our :doc:`installation guide<../installation>` for more information."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:21
+msgid "Spyder now offers :ref:`install-standalone` for Windows and macOS, making it easier to get up and running with the application without having to download Anaconda or manually install it in your existing environment. However, readers of this workshop should install Spyder using Anaconda or Miniconda, as standalone installers currently do not allow to add extra packages like the plugin we are going to develop in this workshop."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:26
+#: ../../workshops/scientific-computing.rst:22
+msgid "Basic level of Python. You can visit `The Python Tutorial`_ to learn the basics of this programming language."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:27
+msgid "Know the basics of Qt application development using Python, either with `PyQT`_ or `PySide`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:29
+msgid "To quickly get started in desktop application development with Qt and Python here is a set of open access resources:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:31
+msgid "`Tutorials Point - PyQt tutorial`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:32
+msgid "`Real Python - PyQt entries`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:33
+msgid "`Guru99 - PyQt tutorial`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:34
+msgid "`Python GUIs - PyQt and PySide tutorials`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:46
+msgid "Learning Goals"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:48
+msgid "By the end of this workshop participants will know:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:50
+msgid "The basics to develop plugins for Spyder, and get a general idea of its inner workings."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:51
+msgid "What types of plugins can be developed with Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:52
+msgid "The structure of a plugin and the functionality of each component and how it connects to Spyder to extend its features."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:53
+msgid "How to package and publish our plugin so that it can be easily installed and used by others."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:59
+msgid "Spyder for developers"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:61
+msgid "The best place to find information about contributing to Spyder or developing for Spyder is its Github repository, in particular the `contribution guide`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:66
+msgid "The core of **Spyder** is `Spyder-IDE`_ , a desktop application developed in *Qt*, which requires for its operation two packages with it is closely related (and without which it cannot work): *spyder-kernels* and *python-lsp-server*."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:68
+msgid "`Qt`_ is an open source multiplatform widget toolkit for creating native graphical user interfaces. Qt is a very complete development framework that offers utilities for building applications, and has extensions for Networking, Bluetooth, Charts, 3D rendering, Navigation (as GPS), among others."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:70
+msgid "Spyder uses `qtpy`_ which is an abstraction layer that allows you to work with Qt from Python regardless of whether you use either of the two reference libraries: PyQt or PySide."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:72
+msgid "`spyder-kernels`_ provide Jupyter kernels to Spyder, for use within its consoles."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:76
+msgid "Spyder is currently developed in such a way that most of its features are implemented as plugins."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:89
+msgid "Types of plugins we can develop in Spyder"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:97
+msgid "A plugin is a component that adds functionality to an application, it can be a graphical component, for example, to display maps, or a non-graphical one that adds additional syntax coloring schemes."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:99
+msgid "Formally, plugins are instances of Qt classes that modify the behavior of Spyder. Aside from a few fundamental components, most of Spyder's functionality arises from the interaction of plugins of two types:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:104
+msgid "SpyderDockablePlugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:106
+msgid "It is a plugin that works as a `QDockWidget`_, this is a Qt class that provides a graphical control that can be docked inside a `QMainWindow`_ or floated as a top-level window on the desktop."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:113
+msgid "SpyderPluginV2"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:115
+msgid "``SpyderPluginV2`` is a plugin that does not create a new dock widget on Spyder's main window. In fact, ``SpyderPluginV2`` is the parent class of ``SpyderDockablePlugin``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:120
+msgid "Discovering Spyder plugins"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:124
+msgid "If we look at the Spyder interface, we can find a number of different panes on the right side (with the default layout), such as *Help*, *Variable Explorer*, *Plots*, *Files* and *History*."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:126
+msgid "Each of these panes is a ``SpyderDockablePlugin`` that offers an *Undock* option by clicking the hamburger menu button in the upper right corner."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:128
+msgid "These plugins can also be hidden or shown via their entry in the *View > Panes* menu, or using its corresponding keyboard shortcut displayed there."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:132
+msgid "High-level interface elements that do not offer an undocking option are basically instances of ``SpyderPluginV2``. These are typically used to handle more abstract functionality."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:134
+msgid "Examples of this are the *appearance* and *layout* plugins that manage Spyder's code color schemes and window layouts respectively."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:136
+msgid "Other examples of this type of plugins are the *main menu* and keyboard *shortcuts*. Some graphical elements, such as the main toolbar and the status bar are also instances of the ``SpyderPluginV2`` class."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:142
+msgid "What will we do?"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:144
+msgid "Our practical work will consist in the implementation of the Pomodoro technique for time management in the Spyder interface."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:151
+msgid "The `Pomodoro Technique`_, designed by Francesco Cirillo, is a time management practice used to increase your focus and productivity when trying to complete assignments or meet deadlines. Choosing to use a Pomodoro Timer can help to give a task your full, undivided attention."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:154
+msgid "The typical process of the Pomodoro Technique consists of the following six steps:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:157
+msgid "Choose a task to be done."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:158
+msgid "Set the Pomodoro Timer (default is 25 minutes)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:159
+msgid "Work only on that task until the timer ends."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:160
+msgid "When the timer rings, put a checkmark on a piece of paper, this is called \"a pomodoro\"."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:161
+msgid "If you have less than 3 checkmarks take a short break (by default, 5 minutes), and return to step 2."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:162
+msgid "When you have completed four Pomodoro cycles, you deserve a longer break (our default is 15 minutes). Checkmarks are reset to zero, go back to step 1."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:168
+msgid "Steps"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:170
+msgid "These are the general steps that we will be following throughout this workshop:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:172
+msgid "Select the most suitable plugin type and create its initial structure using `cookiecutter`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:173
+msgid "Install the plugin in development mode in the virtual environment from which we run Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:174
+msgid "Implement the functionality of our plugin using the Spyder classes and following the guidelines indicated in the plugin structure."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:175
+msgid "Build a configuration page for our plugin, which would appear in Tools > Preferences."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:180
+msgid "Location of Spyder Pomodoro Timer widgets in Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:185
+msgid "Spyder Pomodoro Timer in the preferences window."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:189
+msgid "Features"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:191
+msgid "A minimal planning to organize ideas."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:193
+msgid "Pomodoro Timer"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:195
+msgid "Status bar widget: to display the time for the current pomodoro interval."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:196
+msgid "State: we have three activity states: *pomodoro*, *short-break* and *long-break*. We can show a message (with `QMessageBox`_) to tell users that the time to take a break has arrived."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:197
+msgid "Interactions: the user could use Start, Stop and Reset buttons to handle the Pomodoro Timer. This can be implemented adding `QAction`_ instances in a menu on the toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:199
+msgid "Tasks Logger - Counter: We need a variable to count the number of pomodoros completed."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:202
+msgid "Notifications"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:204
+msgid "Dialog: Each time a pomodoro or break interval is completed, a message should appear to prompt the user to start working on a task or take a break."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:206
+msgid "When working on a plugin for any system, we must check the data structures and functions available in that system that can facilitate our development. This involves spending considerable time understanding its inner workings."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:219
+msgid "Set up a development environment"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:221
+msgid "In principle, we could use any Spyder installed within a `conda environment`_ according to the instructions given in the `installation guide`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:223
+msgid "However, if you use a working environment that has other dependencies and you want to keep your plugin development independent of them, it is recommended to create a new environment which only has Spyder with the minimum dependencies needed for your plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:228
+msgid "We can install it in the following way:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:240
+msgid "`Anaconda Individual Edition`_ is a Python distribution for data science and machine learning to be used in a single machine."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:241
+msgid "`Conda`_ is an Anaconda tool that manages virtual environments and their packages."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:242
+msgid "Conda can work with *channels* that allow the use of packages that are not part of the official distribution. The most important channel is `conda-forge`_, where a more extensive and updated list of packages than those offered by Anaconda Individual Edition are maintained."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:243
+msgid "Finally, `mamba`_, is an optimized implementation of conda's package management features, that resolves dependencies and installs packages much faster than conda."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:256
+msgid "Create a repository"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:258
+msgid "Now that we have our local virtual environment, it is good practice to manage our source code with a version control system, and the most widely used web service for this purpose is currently Github. Here you can find, for example, the Spyder and Python repositories."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:263
+msgid "To create a git repository on Github, we need to follow these steps:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:265
+msgid "Log in to your Github account."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:266
+msgid "Click on the \"New repository\" option in the \"+\" menu at the top right next to your profile picture."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:267
+msgid "A dialog will appear where you can insert the repository name and some basic options, e.g. to initialize the repository with a README or license files."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:268
+msgid "Click the “Create repository” button."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:269
+msgid "In the main window of the recently created repository, click on the green \"Code\" button an copy the clone link."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:270
+msgid "In your local command line run ``$ git clone [repo-link]``. You must have git installed and configured on your computer. If you don't have experience using git we recommend The Carpentries workshop `Version control with git`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:272
+msgid "A detailed description of `repository creation`_ could be found in the official Github documentation, and a `hello world`_ tutorial with basic git operations from the Github interface."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:282
+msgid "Let's get started"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:284
+msgid "We already have a git repository and a virtual environment where Spyder 5 is installed."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:286
+msgid "Let's activate our environment and go into the local folder of our repository."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:293
+msgid "Then we need to use ``cookiecutter`` to create the initial structure of our plugin. `cookiecutter`_ is a tool made in Python specifically designed to create project templates. We have developed one of these templates to generate the basic structure of a plugin, it can be found at: https://github.com/spyder-ide/spyder5-plugin-cookiecutter"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:301
+msgid "Let's run cookiecutter to generate our"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:331
+msgid "The plugin structure"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:334
+msgid "After ``cookicutter`` finishes its job, you'll get the following tree structure in your repository"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:356
+msgid "In the root folder you'll find two important files:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:358
+msgid "The Makefile, which has several useful commands:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:375
+msgid "``setup.py``, which helps you to install, package and distribute your plugin with ``setuptools``, the standard for distributing Python Modules. On this file the ``entry_points`` parameter of ``setup`` is quite important, as it is the one that allows Spyder to identify this package as a plugin, and to know how to access its functionalities."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:380
+msgid "The ``spyder-pomodoro-timer`` folder has the name you introduced when running ``cookiecutter``. Inside this you'll see a folder called ``spyder``, where we will place the code of our plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:382
+msgid "In the ``spyder`` directory you'll find the following files:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:384
+msgid "``api.py``: where the functionality of the plugin is exposed to the rest of Spyder. That would allow additional functionality to be added from other plugins."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:386
+msgid "``plugin.py``: is the core of the plugin. Depending on the type of plugin we created, here you'll see an instance of ``SpyderDockablePlugin`` or ``SpyderPluginV2``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:388
+msgid "If it is a ``SpyderPluginV2`` you should set a constant class named ``CONTAINER_CLASS`` with an instance of ``PluginMainContainer``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:389
+msgid "If it is a ``SpyderDockablePlugin`` you should set a constant class named ``WIDGET_CLASS`` with an instance of ``PluginMainWidget``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:391
+msgid "``container.py``: only used for ``SpyderPluginV2`` plugins. This file contains an instance of ``PluginMainContainer`` that holds a reference to all graphical elements (or widgets) that the plugin is going to add to the interface. This is necessary because Qt requires widgets to be children of other widgets before using them (otherwise they appear as floating windows). Since ``SpyderPluginV2`` is not a widget, we need a data structure (i.e. the container) that is a widget for that."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:393
+msgid "``widgets.py``: in this file we will add the graphical components of our plugin. If it is of type ``SpyderPluginV2`` and it does not have widgets, then it is not necessary. We can also place here the instance of ``PluginMainWidget`` necessary for ``SpyderDockablePlugin``, if we are developing that kind of plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:396
+msgid "``confpage.py``: this is where you specify the configuration page that will be displayed in ``Preferences``, so that the user can adjust the options of our plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:402
+msgid "Building our first plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:404
+msgid "From now on we will be building the plugin step by step. In the `spyder pomodoro timer repository`_ you will find the final version of the code for you to take a look at it, in case we are missing any detail."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:409
+#: ../../workshops/qt_fundamentals.rst:45
+msgid "Widgets"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:411
+msgid "The best way to start building our plugin is by implementing its graphical components first in ``widgets.py``"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:413
+msgid "Let's call the initial version, without any editing ``INITIAL``. In `INITIAL`_, widgets.py is as follows:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:431
+msgid "The preset imports are a guide to what we will need in our plugin. The ``on_conf_change`` decorator will allow us to propagate the changes in configuration. ``get_translation`` helps us to generate translation strings for the plugin and ``SpyderWidgetMixin`` adds to any widget the attributes and methods needed to integrate it with Spyder (icon, style, translation, actions and extra options)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:433
+msgid "When taking a look at the Spyder ``api`` module, we can find that in Spyder there are two types of predefined components for the status bar:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:435
+msgid "``StatusBarWidget``, a class derived from ``QWidget`` and ``SpyderWidgetMixin``, which contains an icon, a label and a spinner (to show the plugin loading)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:436
+msgid "``BaseTimerStatus``, a class derived from ``StatusBarWidget`` with an internal ``QTimer`` to periodically update its content."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:440
+msgid "Below, we will be indicating links in github with the diffs between the tags, this as an aid to check the progressive changes that will be made in the code."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:442
+msgid "The first version that we are going to reach after the first editions will be called ``HELLO WORLD``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:444
+msgid "`INITIAL -> HELLO WORLD widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:448
+msgid "Since we want a widget that shows the pomodoro countdown and is periodically updated, we will use a ``BaseTimerStatus`` instance."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:450
+msgid "So, we can substitute"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:456
+msgid "with"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:463
+msgid "Add an initial import:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:470
+msgid "With that, we can write our first widget like this"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:493
+msgid "Spyder needs ``ID`` to be defined for ``BaseTimerStatus``. Its constructor calls the parent class constructor and initializes the label with ``value``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:495
+msgid "We add a tooltip to verify the presence of our widget. Since Spyder uses ``qtawesome`` (another of our projects that eases the incorporation of iconic fonts into PyQt applications), we can select an appropriate icon by running the ``qta-browser`` command on a terminal."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:501
+msgid "From here we can select and copy the name of the icon of our preference."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:506
+msgid "To finish the implementation of our widget, we need to add the following method:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:516
+msgid "``BaseTimerStatus`` requires this method to be implemented to update its content every time it is requested by the internal timer."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:520
+msgid "The container"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:522
+msgid "The next step in the development of our plugin is to create an instance of the widget we wrote above, so we can add it to Spyder's status bar. For that, we need to use a container. Due to Qt specifics, we need an instance of ``QWidget`` (the container) to be the parent of all other widgets part of our plugin (as mentioned above)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:524
+msgid "Thus, the `COOKIECUTTER`_ version of ``container.py`` is:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:547
+msgid "`INITIAL -> HELLO WORLD container.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:551
+msgid "In this case ``SpyderPomodoroTimerContainer`` is already defined, and we must implement the ``setup`` and ``update_actions`` methods."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:553
+msgid "Now we are going to add the widget created earlier to the container. To do so, first we need to import the widget."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:560
+msgid "Then we edit the ``setup`` method to add an instance of our widget."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:570
+msgid "Plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:572
+msgid "Finally, we define our plugin so that it is registered within Spyder. The `INITIAL`_ version (i.e. the one created by cookiecutter)  for ``plugin.py`` is:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:575
+msgid "Imports:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:592
+msgid "Plugin class:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:633
+msgid "`INITIAL -> HELLO WORLD plugin.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:637
+msgid "First, we need to declare the dependencies of our plugin, by defining the ``REQUIRES`` class constant. Since we're going to add a status bar widget, we require the ``StatusBar`` plugin, as shown below."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:643
+msgid "Then we need to set the icon for our plugin. For that, we substitute"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:651
+#: ../../workshops/plugin-development.rst:668
+msgid "and"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:658
+#: ../../workshops/plugin-development.rst:871
+msgid "by"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:676
+msgid "Due to recent changes to the Spyder API, we need to add to the spyder imports"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:683
+msgid "And add the following after the ``on_initialize`` method:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:693
+msgid "With these changes, Spyder will be aware of the presence of our plugin, and that this plugin adds a new widget to the status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:695
+msgid "Finally, we add the following method to our plugin:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:704
+msgid "In this way, ``SpyderPomodoroTimer`` can access ``pomodoro_timer_status`` of ``SpyderPomodoroTimerContainer`` as if it were its own property."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:706
+msgid "In summary, we did the following:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:711
+msgid "We created a widget, then we added it to the container, which is registered in the plugin through the ``CONTAINER_CLASS`` constant. In the plugin, we accessed the instance of that widget and added it to the status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:717
+msgid "How to test our plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:719
+msgid "Now it is time to see how our plugin looks in the Spyder interface."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:721
+msgid "**From the root folder of our plugin**, we activate the environment where Spyder is installed, and run:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:729
+msgid "Now we can see two outputs. The first one is shown in the command line:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:736
+msgid "And in Spyder you'll see our plugin in the status bar with the tooltip \"I am the Pomodoro tooltip\"."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:741
+msgid "Keep in mind that every time we make a change to our code, it is necessary to restart Spyder so that the plugin is reloaded and we can check the changes."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:747
+msgid "Enhancing our plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:749
+msgid "From now on we are going to go into details of how things are implemented in Qt. So in case you have any doubts, the Qt documentation will be your best guide. We created an annex to this workshop that quickly explains way the fundamental concepts of Qt for those in a hurry: :ref:`qt-fundamentals`"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:754
+msgid "Timer updates"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:756
+msgid "The first problem with our plugin is that its pomodoro timer is not being updated. To activate it we can use the ``QTimer`` in ``PomodoroTimerStatus``, which is present because it's an instance of ``BaseTimerStatus``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:758
+msgid "The second version where the value in the status bar is updated is called ``TIMER``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:760
+msgid "Let's go back to ``widgets.py`` and add this constant below the import lines (line 22)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:762
+msgid "`HELLO WORLD -> TIMER widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:774
+msgid "``POMODORO_DEFAULT`` is to set the pomodoro time limit in milliseconds, and ``INTERVAL`` to the timer update rate."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:776
+msgid "Now, in the ``__init__`` method of ``PomodoroTimerStatus`` we need to add:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:788
+msgid "Up to this point, we created a default value (``POMODORO_DEFAULT``) for the timer duration during pomodoros; we added it to the ``pomodoro_limit`` attribute to be able to configure it; and with that value we initialized the ``countdown`` attribute that will be modified over time. As for the update interval of the timer, we set it to to the value of ``INTERVAL``, which corresponds to 1 second (one thousand milliseconds)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:791
+msgid "The function of ``self.timer`` is to update our timer periodically. This is done through the method ``timeout.connect()``, to which we pass as parameter the reference to the ``update_timer`` function that will perform the required adjustments."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:793
+msgid "Now let's implement ``update_timer`` at the end of the file:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:813
+msgid "Here we rely on the ``display_time`` method that converts the current ``countdown`` value, which is measured in milliseconds, into a human-readable format. And ``update_timer`` simply keeps updating the countdown until it reaches zero."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:815
+msgid "If we run Spyder again we will find that our timer has come to life."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:824
+msgid "Timer controls"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:826
+msgid "Now we need a way to control our timer. We can achieve this by adding some buttons to Spyder's toolbar, which will be useful to learn how to work with toolbars, menus and actions in Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:830
+msgid "PomodoroTimerToolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:832
+msgid "The next version where actions are added to the toolbar is called ``ACTIONS``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:834
+msgid "`TIMER -> ACTIONS widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:838
+msgid "Let's go back to ``widgets.py`` and import the Spyder application toolbar class:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:844
+msgid "And create an instance of it by adding the following code before the definition of ``PomodoroTimerStatus``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:853
+msgid "As you can see, this statement is very simple. It only needs to declare an ``ID``, that serves to identify our toolabr among the rest."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:855
+msgid "It is possible to include other Qt widgets in our toolbar, but in this case it's better to use the appropriate Spyder methods for that in order to maintain their relationship with the rest of the application. In other words, as long as the widget you need exists in ``spyder.api.widgets``, use it!"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:858
+msgid "Next, we need to declare a boolean variable in our status widget to indicate if the countdown is paused or not. For that, let's add the following inside the ``__init__`` method of ``PomodoroTimerStatus``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:864
+msgid "And inside the ``update_timer`` method, substitute"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:880
+msgid "Create the Pomodoro Toolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:882
+msgid "Now we are going to create a new section in our toolbar and associate some functionality to it by means of actions. This particular information is recommended to be included in the ``api.py`` file because this way we can offer endpoints to the rest of Spyder and new plugins for tweaking the behavior of our plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:884
+msgid "`TIMER -> ACTIONS api.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:888
+msgid "Let's add the following to the end of ``api.py``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:904
+msgid "With these we are telling the rest of Spyder, and our own plugin, that we are going to have a new toolbar section called \"pomodoro_timer\". This section will consist of a button containing a menu (with a single section \"main_section\") and actions identified as \"start_timer\", \"pause_timer\" and \"stop_timer\", to start, pause and stop (resetting) our timer, respectively."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:906
+msgid "Note that these are simple class definitions with class constants, to ease the encapsulation and exchange of this information in a simple way."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:909
+msgid "Add actions to the toolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:911
+msgid "`TIMER -> ACTIONS container.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:915
+msgid "Now let's go to ``container.py``, where we are going to implement the behavior of our new toolbar and its actions. In this case, we are not going to specify the internal behavior of our plugin, but the relationship between its widgets and other areas of Spyder, so it is more convenient to do it in the container."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:918
+msgid "As we did with ``PomodoroTimerStatus``, we are going to use ``qtawesome`` icons for our actions. For this purpose, let's add at the beginning of our imports:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:926
+msgid "We also imported ``QToolButton`` because it will be used to set the button that we will add in our toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:928
+msgid "At the end of the Spyder imports we also need:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:934
+msgid "Now, let's include ``PomodoroTimerToolbar`` and the actions and sections we just declared in ``api.py`` in our local imports:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:948
+msgid "Next, we need to do following things in the ``setup`` method of ``SpyderPomodoroTimerContainer``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:950
+msgid "The first one is to create an instance of the toolbar class we declared earlier:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:957
+msgid "The second one is to create the actions corresponding to Start, Pause and Stop our pomodoro timer:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:986
+msgid "The third one is to create the menu that will contain our actions and add them to it."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1004
+msgid "The fourth one is to create a button that will contain the menu and configure it as ``PopupMode``, so that it is displayed when clicked."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1017
+msgid "And finally, the fifth one is to add the button to our toolbar:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1028
+msgid "When creating the actions, we indicate by means of the ``triggered`` parameter the methods to be executed when they are activated, i.e. when the corresponding buttons on the toolbar are clicked."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1030
+msgid "We can insert these methods at the end of the ``SpyderPomodoroTimerContainer`` declaration, in the section that our cookiecutter template indicates as ``# --- Public API``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1050
+msgid "These methods simply manipulate the ``pause`` field of ``pomodoro_timer_status``, and in the case of ``stop_pomodoro_timer`` the countdown is restarted."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1053
+msgid "Register the toolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1055
+msgid "`TIMER -> ACTIONS plugin.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1059
+msgid "A final mandatory step is to go to ``plugin.py`` and register this new toolbar component."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1061
+msgid "To do this, add ``Plugins.Toolbar`` to the plugin requirements:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1067
+msgid "And use this plugin's API to add the toolbar we have created in the container to Spyder's toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1078
+msgid "Review the changes"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1080
+msgid "The first thing we can notice is that we already have the corresponding buttons in the toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1085
+msgid "The strings that were entered as the ``tip`` parameter in the creation of the actions are shown here as the buttons' tooltips."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1087
+msgid "Also, if we check the menu \"View > Toolbars\", we find that there is a new entry there corresponding to our toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1093
+msgid "Finally, let's check how the new Pomodoro Timer control buttons in the toolbar interact with the component in the status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1102
+msgid "Add a Configuration Page"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1104
+msgid "Another feature of Spyder plugins is that they can have configurable options that appear in Spyder's Preferences window."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1107
+msgid "Configuration defaults"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1109
+msgid "The final version in which we add a configurable parameter will be called ``CONFPAGE``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1111
+msgid "The first step is to define what options we want to offer to our users. For this we must create a new file, which we can call ``conf.py``. In this file we will write the following:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1113
+msgid "`ACTIONS -> CONFPAGE config.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1138
+msgid "We must highlight the declaration of ``CONF_SECTION``, which is the internal name of the section in Preferences corresponding to our plugin; and the dictionary keys associated with ``CONF_DEFAULTS``. In this case, we are indicating that ``pomodoro_limit`` is a configurable parameter within the ``spyder_pomodoro_timer`` section."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1140
+msgid "At the end of this file it is necessary to set another important constant, ``CONF_VERSION``, which must be updated when adding, removing or renaming configurable parameters in successive versions of the plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1153
+msgid "Note that we are moving the definition of ``POMODORO_DEFAULT`` from ``widgets.py`` to ``conf.py``, since we now have a dedicated place for default configuration values."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1156
+msgid "Configuration page"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1158
+msgid "Now, we need to build the page that will appear in the Preferences window. For this, we edit the ``confpage.py`` file generated by cokkiecutter as follows:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1160
+msgid "`ACTIONS -> CONFPAGE confpage.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1206
+msgid "This mostly corresponds to the regular code for user interfaces based on Qt widgets. In this case, our options section corresponds to a ``QGroupBox``, where the parameters are organized vertically using a ``QVBoxLayout``, and each parameter corresponds to a ``QGridLayout`` where labels and inputs are distributed (in this case a ``QSpinBox``)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1208
+msgid "Configuration pages in Spyder provide some helper methods to facilitate this work. For instance, ``create_spinbox`` allows to instantiate and initialize in a single step the widgets corresponding prefix an suffix labels together with the spinbox."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1211
+msgid "Propagate configuration changes"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1213
+msgid "Since we moved all the configuration information to ``conf.py``, now we have to import it from there into ``widgets.py``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1215
+msgid "`ACTIONS -> CONFPAGE widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1228
+msgid "Now we can access the configuration options from anywhere in our plugin using the ``get_conf`` method. In this case we use it to access the value of ``pomodoro_limit`` from the configuration instead of the constant ``POMODORO_DEFAULT``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1236
+msgid "Now we can add a method that updates our configurable parameter ``pomodoro_limit``. The ``@on_conf_change`` decorator is the one in charge of capturing the signal that is generated when applying the change of a specific option."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1247
+msgid "Registering preferences"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1249
+msgid "Finally, it is necessary to activate the use of preferences in ``plugin.py``, by requiring the Preferences plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1251
+msgid "`ACTIONS -> CONFPAGE plugin.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1262
+msgid "and registering our plugin in a method with the decorator ``@on_plugin_available``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1271
+msgid "Now we can access the Preferences window either from the toolbar or from the \"Tools > Preferences\" menu. There we will find a section called *Spyder Pomodoro Timer* and inside it is the *Pomodoro timer limit* parameter. If we change that value, we will see how the corresponding label in the status bar changes."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1276
+msgid "Now your plugin is in an initial version ready to publish..."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1282
+msgid "Publishing your plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1284
+msgid "Since the recommended way to install Spyder is through conda, the obvious choice would be to publish our plugin through a channel like conda-forge, but this is a task that is beyond the scope of this workshop due to its complexity."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1286
+msgid "However, the tools used to publish packages in conda are usually based on the packages published in PyPI. So let's see how to publish our plugin there."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1293
+msgid "PyPI and TestPyPI"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1295
+msgid "The first thing we have to do is to create an account on the `PyPI`_ and `TestPyPI`_ websites. Although our package will be finally published in PyPI, it is advisable to use TestPyPI to test that our package can be published properly without generating additional load to the PyPI servers or affecting their logs."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1297
+msgid "Next, we need edit the ``setup.py`` file at the root of our project with our own data. Fortunately, cookiecutter created one for us."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1299
+msgid "To upload our package to PyPI we have to use a tool called `Twine`_ that makes this task much easier. And we can install it in our conda environment using:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1306
+msgid "Build and check the package"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1308
+msgid "Before publishing our plugin we must package it. To do it we must write the following from the root folder of our project (where ``setup.py`` is placed):"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1314
+msgid "After that we will see that the following files are generated in the ``dist`` folder:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1323
+msgid "On Linux and macOS we can check that the newly built distribution packages contain the expected files by inspecting the contents of the ``tar`` file:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1329
+msgid "You can also use ``twine`` to run a check on the created files in ``dist``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1338
+msgid "Upload to PyPI"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1340
+msgid "Now we can use twine to upload the distribution packages we have built. First, we will upload them to TestPyPI to make sure everything works:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1346
+msgid "This command will prompt you for the username and password with which you registered in TestPyPI."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1348
+msgid "If we open https://test.pypi.org/project/spyder-pomodoro-timer/ in the browser we will be able to see the package we have just published."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1350
+msgid "There we'll see that some details are missing, like the package description, and that our package is marked as ``Development Status 5-Stable``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1352
+msgid "To fix the first one, we can follow the instructions in `Making a PyPI-friendly README`_. Since we already have a README file, we simply add the following lines to the beginning of our ``setup.py`` file:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1368
+msgid "We can also change the classifiers of our package using the following site as a guide: https://pypi.org/classifiers. Here we can simply copy the classifiers we consider appropriate and then paste them into our code. Specifically in ``setup.py``, within the list that enters as the ``classifier`` argument in the call to function ``setup``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1371
+msgid "With these changes, and by bumping our plugin's version in the ``__init__.py`` file inside the ``spyder_pomodoro_timer`` folder, we can repeat the cycle of building a new version of our package, loading it into TestPyPI for checking, and finally loading it into PyPI by using:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1377
+msgid "And check the result in https://pypi.org/project/spyder-pomodoro-timer/"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1379
+msgid "Once this is done, anyone can install our plugin in their environments simply by running:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1396
+msgid "The possibility of making a tool extensible through plugins, extensions or addons, as they are usually called, is a fundamental feature that allows taking advantage of the talent of third-party developers to respond to needs and enhancements that are beyond the scope of the application's core development team."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1398
+msgid "Similarly, a plugin-based system makes the application much easier to maintain. Eventually, the ability to enable and disable plugins makes it more adaptable to different use cases. For instance, at present it would be inconceivable to think of a web browser that does not have extensions to block advertising or organize links, even if those features don't come by default on them."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1400
+msgid "In Spyder we have put special interest in consolidating an API that allows the development of plugins in a consistent way. The main focus of the development effort between versions 4 and 5 was in this direction and we are at a key moment where we expect to capitalize on all this work."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1404
+msgid "Identify the basic building blocks in Spyder development."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1405
+msgid "Identify the different types of plugins that can be implemented in Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1406
+msgid "Recognize the types of plugins that are part of Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1407
+msgid "Plan the development of a new Spyder plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1408
+msgid "Build a development environment for Spyder plugin development."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1409
+msgid "Generate the basic structure of a Spyder plugin using Cookiecutter."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1410
+msgid "Understand the file structure of a Spyder plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1411
+msgid "Add and register Qt widgets in the Spyder status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1412
+msgid "Add and register Qt widgets in the Spyder toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1413
+msgid "Add a menu with actions in the toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1414
+msgid "Add configuration options to our plugin and display them appear in the Preferences window."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1415
+msgid "Edit the description and classifiers of the installable package of our plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1416
+msgid "Publish our plugin to TestPyPI and PyPI."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1418
+msgid "With these skills we hope to ease the way for you to develop your own Spyder plugins."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1420
+msgid "If you have ideas for plugin development feel free to contact us through the `Spyder-IDE`_ Github organization space."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1424
+#: ../../workshops/scientific-computing.rst:776
+msgid "If you are interested in an introduction to financial analysis with Spyder, you can visit the workshop :doc:`Financial Data Analysis with Spyder<../workshops/financial>`."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1431
+msgid "As you may have noticed, there were some features left to implement such as notifications when pomodoros are completed. Try to implement them and do not hesitate to contact us if you have any doubts."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1438
+msgid "In the `plugin-examples`_ repository you can find additional examples that will surely be useful for you to further understand Spyder plugin development."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1440
+msgid "A more in-depth review of the Spyder repository itself, especially its simpler plugins, such as History, Plots or Working directory, may help you understand it better. As well as a review of the various helper functions, widgets and mixins present in ``spyder.api``."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:5
+msgid "Qt Fundamentals"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:9
+msgid "**Qt** is a multiplatform widget toolkit for creating native graphical user interfaces. Qt is also a very complete development framework that offers utilities for building applications, and libraries of extensions for Networking, Bluetooth, Charts, 3D rendering, Navigation (as GPS), among others."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:14
+msgid "Basic Qt Components"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:16
+msgid "As mentioned before, Spyder's plugin development consists of extending the functionality of its Qt-based graphical interface."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:18
+msgid "To develop a GUI we will add graphical elements of interaction known as widgets, arrange them using layouts. Then, we interconnect those widgets using customized procedures implemented as functions or methods, allowing to trigger behavior from user interaction. In the following, we will develop these ideas in more detail."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:20
+msgid "Each type of Qt component is a class starting with the letter ``Q`` followed by a name related to its functionality."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:22
+msgid "The core component of Qt is the ``QApplication`` class. Every Qt application needs a single instance of this class as the base, from where the Qt *event loop* is controlled. Spyder itself is an instance of ``QApplication``, its starting point is in the following two lines of code (spyder/spyder/app/mainwindow.py):"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:30
+msgid "``QMainWindow`` is a pre-built widget that provides many standard window features as toolbars, menus, a status bar, dockable widgets and more, which serves as the basis for the application."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:34
+msgid "Signals & Slots"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:36
+msgid "**Signals** are notifications emitted by widgets when something happens. That something could be different things, from pressing a button, to changing text in an input box, to changing text in the window. Many signals are initiated by user action, but this is not a rule."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:39
+msgid "**Slots** are signal receivers. Functions or methods could be used as slots, by connecting a signal to them. If a signal sends data, the receiver callable will also receive it. Many Qt widgets also have their own built-in slots, so the corresponding widgets are notified automatically."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:47
+msgid "In computer science a *Widget* is a shortened form of “window gadget”. A widget is an element of interaction, such as a button, or a container for other widgets, as panels or tabs. The ``QWidget`` class is the fundamental class for creating interfaces in Qt, it receives events from the window system, and renders its representation on the screen. A widget can provide a container for grouping other widgets, and if it is not embedded in a parent widget, it becomes a window."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:52
+msgid "Layouts"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:54
+msgid "Interfaces are built by embedding widgets inside widgets, and since they are visual components they are visually organized by means of *layouts*. A layout indicates how the widgets fill their container, either as columns, rows, cells in a matrix or stacked so that only one is visible at a time. Those are the 4 basic layouts available in Qt: ``QHBoxLayout``, ``QVBoxLayout``, ``QGridLayout``, and ``QStackedLayout``."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:61
+msgid "Actions, Toolbars & Menus"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:63
+msgid "User interfaces of desktop applications usually use ``QToolbar`` and ``QMenu``. Since these are alternative ways to access the same functionality, Qt provides ``QAction`` as a way to avoid duplication of functions. Thus, each time a menu option or a toolbar button gives access to the same function, they point to the same action."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:67
+msgid "Dialogs"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:69
+msgid "A *Dialog* is a GUI component that communicates with the user. Dialogs are commonly used for functions that do not fit into the main interface. In Qt, by design ``QDialog`` is a modal (or blocking) window that show in front of the main Window until it is dismissed."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:72
+msgid "Qt provides some *special dialogs* for the most common use-cases as *file Open/Save*, *font selection*, *error messages*, *color choosing*, *printing*, among others."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:76
+msgid "Windows"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:78
+msgid "If an application requires additional windows that do not block the main window, these are generated as non-parent ``QWidget`` instances. These are used for tasks that happen in parallel over long-running processes such as displaying graphs or document editing."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:83
+msgid "Events"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:85
+msgid "An *Event* denote every interaction the user has with a Qt application. There are several types of events designed to address different types of interactions. In Qt they are represented by ``QEvent`` instances that contain information about what prompted them, and are passed to specific handlers that are responsible for triggering further actions."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:3
+msgid "Scientific Computing and Visualization with Spyder"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:5
+msgid "This workshop allows you to explore some of Spyder's features that make Spyder an ideal IDE for using the scientific tools offered by Python. Throughout the workshop, we will apply the scientific method to answer some questions related to our preferences and cognitive abilities. By the end of this workshop participants will be able to use Spyder to explore data, analyze it with some statistical tools and plot the relationship between variables."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:23
+msgid "Some knowledge of Statistics (`hypothesis testing`_ , `ANOVA`_, `p-value`_)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:38
+msgid "Apply the scientific method to answer questions related to psychometric variables"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:39
+msgid "Understand how to use Spyder's built-in scientific computing tools"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:47
+msgid "This workshop is intended for people who want to learn how to answer questions scientifically from a dataset. We have also designed it to serve as a tutorial for learning how to use Spyder as a research tool."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:55
+msgid "In this workshop we will explore a data set and use it to answer some questions using the scientific method."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:59
+msgid "Why do scientific research with Python?"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:61
+msgid "Python is a mature programming language that has been chosen by much of the scientific community to support the research process. There are a few reasons for this:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:63
+msgid "It is versatile and easy to learn and use"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:64
+msgid "It allows for multiple ways to handle inputs and outputs. No matter what format your data is in, in Python there is always a way to import it (and export it in the format of your choice)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:65
+msgid "It is interpreted. You don't have to write code from start to finish to see partial results. This makes it especially easy and fast to explore data"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:66
+msgid "It has built-in support for scientific computing tasks: `SciPy <https://scipy.org>`_, `NumPy <https://numpy.org>`_, `Pandas <https://pandas.pydata.org>`_, and a vast number of other libraries created by and for scientists"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:67
+msgid "It is the most widely used programming language for Machine Learning (including Keras and TensorFlow)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:69
+msgid "It can be integrated with `Jupyter Notebooks <https://jupyter.org>`_ and implementations of these in the cloud (`Google Colab <https://colab.research.google.com>`_ or `Binder <https://mybinder.org>`_)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:73
+msgid "How can Spyder help me in my scientific research?"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:75
+msgid "Spyder is a Scientific Integrated Development Environment written in Python, and designed by and for scientists, engineers, and data analysts. It features a unique combination of the advanced editing, analysis, debugging, and profiling functionality of a comprehensive development tool with the data exploration, interactive execution, deep inspection, and beautiful visualization capabilities of a scientific package. Together with Python, it provides a very complete set of tools for scientific computing."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:79
+msgid "The basic steps of the scientific method"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:81
+msgid "The `scientific method <https://en.wikipedia.org/wiki/Scientific_method>`_ is a set of good practices used to achieve new knowledge in a valid way. Broadly speaking, the stages of the scientific method are as follows:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:83
+msgid "Observation: first find something that needs an explanation"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:84
+msgid "Search/generate theory: say a thing or two about the state of the world or how it works (an abstract thought about a phenomenon)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:85
+msgid "Hypothesis: identify variables and make predictions"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:86
+msgid "Testing/Experiment/More observation: measure relationship between variables"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:87
+msgid "Analysis: fit a model/graph data"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:88
+msgid "Reporting: share new findings"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:90
+msgid "Throughout this workshop, we will be developing each of these steps in a practical way. We will use Spyder as a research tool and psychometric data from an online dating site to make it easy and fun."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:94
+msgid "Introduction to scientific research with Spyder"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:100
+msgid "If you already have experience with Spyder, you can skip to `Preparation work`_ section."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:122
+msgid "The Variable Explorer is one of the most frequently used components in this workshop. **This is the pane where we will observe the data and most of the results of the scientific analysis, except for the plots**."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:128
+msgid "The :doc:`Plots pane <../panes/plots>` shows all the static graphs and images created in your IPython Console session. **All plots generated by the code will appear in this component**. You will also be able to save each graphic in a local file or copy it to the clipboard to share it with other researchers."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:132
+msgid "Code Analysis (share a stylish code!)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:134
+msgid "Wouldn't it be great to have a tool to be able to detect code errors, stylistic problems, bad practices, inconsistencies and other issues? This is precisely the task of the  :doc:`Code Analysis<../panes/pylint>`. Your code can run, but if you are going to share it with other researchers it would be great if it is both readable and neat as well."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:146
+msgid "Setting up the Conda environment"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:154
+msgid "We recommend creating the virtual environment with `Anaconda <https://www.anaconda.com/products/individual>`_ (or `Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_) as it integrates seamlessly with Spyder. You can find installation instructions in `Anaconda documentation`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:160
+msgid "1. With commands"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:162
+msgid "Just run the following command in your Anaconda Prompt (Windows) or terminal (other platforms), for a minimal install of Spyder into a new environment called ``scientific-computing``:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:168
+msgid "To install Spyder's optional dependencies as well for full functionality, use the following command instead:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:176
+msgid "Spyder now offers :ref:`install-standalone` for Windows and macOS, making it easier to get up and running with the application without having to download Anaconda or manually install it in your existing environment. If you use the standalone installer, there is no need to install ``spyder=5`` with conda."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:180
+msgid "2. From an environment.yml file"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:182
+msgid "You can also install the virtual environment easily using the environment file (``scientific-computing.yml``) that we share with you. Just run the following command in the terminal (you must have the environment file in the current directory):"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:190
+msgid "Activate environment"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:192
+msgid "You can now enter the newly created virtual environment in this way:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:200
+msgid "Downloading the dataset"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:202
+msgid "We are going to work with a public dataset called OKCupid, collected by Kirkegaard and Bjerrekaer. The dataset is composed of 68,371 records and 2,626 variables."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:204
+msgid "Download the `OKCupid dataset`_ to a directory of your choice."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:210
+msgid "Setting up the working directory"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:212
+msgid "The virtual environment and the data file are now ready. The only thing that remains is to create a directory to work in. In your operating system, create a new directory with the name of your choice. Then copy and unzip the dataset file there."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:214
+msgid "Here is an example (on Linux or macOS):"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:221
+msgid "Keep in mind that in this new directory you must have the data file unzipped."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:223
+msgid "Launch Spyder:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:229
+msgid "Let's make sure Spyder is ready. First, check that the working directory is correct. You should see in the upper right corner the path to the directory where you have the dataset. Something like this:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:234
+msgid "Second, let's check that the virtual environment we created is enabled in Spyder. Go to :guilabel:`Preferences` > :guilabel:`Python interpreter`, and use the dropdown under :guilabel:`Use the following Python interpreter` to select the path to your virtual environment. You should see something like this:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:245
+msgid "Although the workshop is designed for you to write the code in the IPython Console, we have created a file that you can :download:`download <scientific-computing.py>`. This script provides all the code you will write in this workshop, and you can use it as a guide if you get lost."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:251
+msgid "The dataset"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:253
+msgid "OKCupid is a dataset that gathers information obtained from the online dating site OKCupid. It consists of 68,371 records collected automatically employing a scraper that extracted public information."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:255
+msgid "The dataset contains demographic data (e.g., gender, sexual orientation and age). It also includes answers to general questions used by the website's algorithm to calculate some personality indicators to help find compatible matches."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:257
+msgid "If you want more information about how this dataset was collected and what kind of information it contains you can get it in this paper: `The OKCupid dataset`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:266
+msgid "You can also write your code or in the Editor (the pane that occupies the entire left side of Spyder). If you use the Editor, you can run the code by selecting it and pressing the :guilabel:`Run selection or current line` button in the :guilabel:`Run toolbar` or by pressing the F9 button."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:280
+msgid "The data you downloaded earlier is in `parquet <https://arrow.apache.org/docs/python/parquet.html>`_ format. This format is very convenient because it is smaller and faster than CSV or JSON files."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:282
+msgid "Load data:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:288
+msgid "You should now be able to see the data you have imported in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:293
+msgid "You can see that the object is of type DataFrame and the number of rows and columns of the object."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:299
+msgid "Explore the dataset"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:303
+msgid "Age"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:305
+msgid "Now, let's explore one of the variables, in this case, the numeric variable age (``d_age``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:309
+msgid "In the OKCupid dataset, all demographic variables are prefixed with \"d\\_\" and profile variables with \"p\\_\"."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:318
+msgid "What happened? We called the ``data`` object and used Python's dot notation to pick the ``d_age`` column. This has a `Pandas Series <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.html>`_ type object. To this object we pass the ``describe()`` method that shows a summary of some indicators: count of values, mean, standard deviation, maximum value, minimum value, among others. With these figures we can see that the sample is mainly constituted of young people (the average is 31.65 years old)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:320
+msgid "The return of a function, method or the attribute of an object can be stored as a variable to have it at hand in the Variable Explorer:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:330
+msgid "The values are floats. The lowest age is 18.0 years and the highest is 100.0 years."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:334
+msgid "Notice also that each type of variable has a different color to quickly distinguish them."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:336
+msgid "We already know the minimum and maximum age, and that the mean is around 32 years old. A good way to further explore this variable is to plot a histogram, a type of graph that shows the frequency distributions. In this way we can see if the groups of young people on the platform are more numerous than the older ones."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:338
+msgid "We can plot a histogram directly from the dataframe. To do this we select the variable (as we did with the ``.describe()``) and invoke the ``.plot.hist()`` method. In this method we will pass as arguments the number of bins and the transparency of the plot (``alpha``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:348
+msgid "Another way to generate a simple histogram in Spyder is to use a context menu on an array in the Variable Explorer. But first we must store these values in a list and call that variable ``age``."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:360
+msgid "Frequency distributions come in different sizes and shapes. The shape of a histogram reveals very interesting things about the data. A symmetrical, bell-shaped histogram might indicate that the distribution is normal (most of the scores are close to the center of the distribution). In the age histogram, you can see that it has a \"tail\" to the right (towards the older ages). Technically this is called \"positively `skewed`_\". It is also noticeable that it is somewhat pointy (positive `kurtosis`_ or leptokurtic). These two things could suggest that age is not a random variable."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:365
+msgid "Although we can create the histogram directly from the dataframe, we are going to use a Python library called Seaborn to do the same, because this library will allow us to do more interesting things later."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:372
+msgid "We call ``sns.histplot()`` with three arguments. The first one (``data.d_age``) is a Pandas Series with the **quantitative** variable we want to plot. The second (``kde=True``) adds a curve showing an ideal model of the age distribution (using a method called *Kernel Density Estimator*). And the third one (``bins=25``) indicates that we want 25 bins in the graph."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:377
+msgid "The second line (``plt.show()``) is intended to show all the figures not displayed so far. If you have any doubts about how to utilize an object, method or function, you can use the ``help()`` tool in the console. For example:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:383
+msgid "Or you can also take advantage of the Help pane included in Spyder to get on-screen help:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:388
+msgid "With Seaborn, we can add a line representing the mean of the histogram. To do this we will use the ``axvline()`` method and add a text with the value of the mean where ``text()``, ``min_ylim`` and ``max_ylim`` are used to mark the position of the text."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:405
+msgid "Religion seriosity"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:407
+msgid "We know the extent of the dataframe and we have seen how to explore a quantitative variable. Now let's move on to a qualitative variable. The ``columns`` attribute shows a list of column names in the dataframe. We also know that demographic variables are prefixed with \"d\\_\", so we can look for variable names that correspond to this prefix."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:413
+msgid "In the Variable Explorer you will see a new variable ``demograph``. If you double click on it you will see a list of the demographic variables in the dataset. At the end of the list you will see a value ``d_religion_seriosity``. If you right click on it, several options will appear on the screen. You can rename the column, delete it or insert a new one. Let's click on :guilabel:`Copy` to copy the column name into memory."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:415
+msgid "In the IPython Console, type ``data.`` and then copy the column name. Type a period at the end (no spaces) and hit tab. You should see something like the following:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:420
+msgid "You can then see a list of all relevant methods and attributes of the class. Right at the end you will see ``value_counts`` that could be used to summarize the variable. It is a method so it must end in parentheses:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:432
+msgid "In addition to demographic and profile variables, the dataset includes responses to questions on a variety of topics. These questions are coded with a prefix \"q\" followed by an integer. The text of the questions is stored in a file called :file:`question_data.csv` (which you can download as part of the `OKCupid dataset`_)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:434
+msgid "We can examine this file in the Variable Explorer:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:440
+msgid "Double click on \"question_data\" in the Variable Explorer to display each question aligned with its code (\"q\" + number)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:442
+msgid "Now that we have learned how to explore the data we can ask interesting questions and try to answer them with the help of the dataset and Spyder."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:448
+msgid "Think of a theory and write a hypothesis"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:450
+msgid "A theory is nothing more than an explanation of something. For example, we could get involved in the eternal conflict between cats and dogs. I, as a dog person, might have a theory (unscientific, of course) that those who prefer to have the companionship of a dog are smarter people than those who prefer a wicked (but lovable) kitty. To test the support of a theory, one can make a prediction based on it and see how this prediction behaves in an experiment or a concrete situation. We call this prediction a hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:452
+msgid "A hypothesis is a statement that can be tested employing the scientific method. They must be verifiable using empirical evidence or data. For example, *green is the best color* is not a hypothesis since it cannot be proven or disproven."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:454
+msgid "Concerning the above theory of a person's pet preferences, to explore it we should find two variables to relate. The first variable would be related to a **self-identification as a cat person or dog person**. The second variable would be related to a person's **ability to solve problems and situations**."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:456
+msgid "The OKCupid dataset has useful variables that we can use to investigate this theory. For example, question **q997** (*Are you a cat person or a dog person?* ) provides information about a person's pet preferences. The second variable is slightly more difficult to come up with, as it is somewhat more complex. Fortunately, the researchers who collected the dataset have also selected 14 questions that can serve as a proxy for a cognitive ability test. This selection of questions can be found in the file :file:`test_items.csv` in the `OKCupid dataset`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:462
+msgid "So, let's try to see if there is any evidence in the OKCupid dataset to support the following hypothesis:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:464
+msgid "*People who prefer dogs to cats would score higher on tests of cognitive ability*."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:468
+msgid "SPOILER ALERT: If you are a cat person, and feel you should immediately leave this workshop, I suggest you stay. If you're not a cat person, stay too."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:474
+msgid "Build the test"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:476
+msgid "We already know which questions will be part of the cognitive ability test. Now we are going to process this data to obtain the scores for each person."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:478
+msgid "First, we make a copy of the original dataset:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:484
+msgid "Then, we find the correct answer to each test question (these answers are in ``test_items``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:493
+msgid "The correct answers have been stored in the ``test_items`` dataframe."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:495
+msgid "Next, we will indicate, in the ``ca_test`` dataframe, whether the person answered correctly to each question selected in the cognitive ability test. These answers will be entered as a boolean in new variables with the prefix \"resp\\_\" followed by the corresponding question code. The Boolean is calculated with the function ``lambda row: row[q] == a, axis=1``."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:510
+msgid "Some ``test_items`` questions are not in the data but don't worry about that. We use a ``try... except`` block to ignore these errors. Answering these questions was optional, so many OkCupid site users did not answer all of them. So we have removed from the records the users who did not answer the 14 questions we have chosen for the cognitive ability test. This reduced the sample size considerably. There are other ways to avoid this reduction, but they are outside the scope of this workshop."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:512
+msgid "We want to sum the correct answers for each person, but some integer results were stored as strings, so let's fix that:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:524
+msgid "Now that we have the correct answer for each test question, let's add up each correct answer for each person. There are 14 questions, so the maximum score will also be 14:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:531
+msgid "How do we add up these responses? Remember that each answer was stored as a boolean (True or False) with the prefix \"resp\\_\". So we search in the ``ca_test`` dataframe for the answers of each column starting with \"resp\" (we use the regular expression ``regex=\"^resp\"`` and the method ``filter``) and sum the True values of each row with ``sum(axis=1)``. Then we store these results in the \"cognitive_score\" column of the ``ca_test`` dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:533
+msgid "You can see the results of these operations by typing in the IPython Console ``ca_test.cognitive_score.describe()``. If you do so, in *count* you will see that the new number of records has been reduced to 479 (the rest of the 68,371 users did not answer all of these questions)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:537
+msgid "Cognitive ability distribution"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:539
+msgid "Let's draw a histogram of this variable to see the frequency distribution."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:549
+msgid "As you can see, in this case, the distribution is not symmetrical but has a long \"tail\" on the left (negatively skewed). This means that most of the users who answered all the questions did quite well and that only a few users answered most of the questions in the wrong way."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:553
+msgid "The values we have calculated in this section were already in the data (``data.CA_items``). However, we have chosen to obtain these results again using code because it is a good way to learn how to use the tools provided by Python and Pandas for data manipulation."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:559
+msgid "Relate variables"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:561
+msgid "Remember that the hypothesis relates two variables: which pet do you prefer and cognitive ability. The measurement of pet preferences will be made from question **q997** (categorical or qualitative variable) and cognitive ability will be measured from the sum of the correct answers on the test (quantitative interval variable). With this type of variable we can make some box plots to see if there are differences between the means."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:563
+msgid "But first, let's change the standard Seaborn palette, to get prettier plots."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:573
+msgid "Seaborn allows you to choose from different styles of graphics and color palettes. More information is available at https://seaborn.pydata.org/tutorial/color_palettes.html"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:575
+msgid "Now, we are going to create box plots to observe the relationship between variables. To do this, we will use the ``catplot`` class of Seaborn. The first argument will be the x-axis, which in this case will be the qualitative variable (question **q997**). The second argument will be the y-axis, where we will place the quantitative variable (cognitive score). With the parameter ``kind`` we indicate that it is a box plot. The parameters ``height`` and ``aspect`` regulate the appearance of the graph. The last parameter, ``data``, indicates where the data comes from."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:586
+#, python-format
+msgid "Box plots or box-whisker diagrams display, near the center of the box, the **mean** of the data as a horizontal line. The lines bordering the box represent **50% of the observations** (*interquartile range* ). Outside the box, upwards and downwards, we find two whiskers: the lower one represents the **mean of the values in the lower part of the dataset**, and the upper one represents the **mean of the values in the upper part of the dataset**. The points beyond the whiskers are **outliers**."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:590
+msgid "An outlier is a value that is very different from the rest of the data values. They must be taken into account because they can often create a bias in the model we are trying to fit to the data."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:592
+msgid "The graph shows four boxes measuring cognitive ability for the following groups:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:594
+msgid "Those who prefer dogs"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:595
+msgid "Those who define themselves as cat people and dog people indistinctly."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:596
+msgid "Those who prefer cats"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:597
+msgid "Those who like neither cats nor dogs."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:599
+msgid "The lowest mean is that of those who prefer dogs only, but by very little. The box (and boundaries) representing dog lovers is also \"wider,\" implying a larger variability in the individual test results for this group. But this is not a very different dispersion from that of those who prefer cats. All the means are within the limits of the other boxes (interquartiles), which seems to indicate that, in fact, there are not really important differences in the intelligence test scores for these groups. This seems to undermine support for the initial hypothesis we posed above."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:603
+msgid "If you want to see the figures, enter ``dog_or_cat = ca_test.groupby(\"q997\")[\"cognitive_score\"].describe()`` in the IPython Console and look at the results in the Variable Explorer. This way you can see how many people prefer cats or dogs, and the means and standard deviation of the cognitive ability test results for each group."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:605
+msgid "To appreciate in context the real difference in the averages, let's create some bar charts. We are now going to use Seaborn's barplot class. On the x-axis we put again the qualitative variable (**q997**) and on the y-axis the quantitative variable (cognitive_score). The data parameter takes as argument the entire dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:620
+msgid "If the box plots indicated that the means did not show significant differences (possibly due to chance), the bar plot confirms that these differences are, in proportion, quite modest."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:626
+msgid "ANOVA test"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:628
+msgid "To make sure that the differences between the means are statistically significant, we will perform an ANOVA (analysis of variance) because we are going to compare the means of more than two groups."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:630
+msgid "How does ANOVA work? This analysis tells us whether three or more means are equal. If so, this would support the null hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:634
+msgid "The *null hypothesis* is an alternative prediction to the one we have stated in our hypothesis. The null hypothesis simply states that the observed differences in means are due to random variations that occur when samples are collected."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:636
+msgid "An ANOVA produces an *F-ratio* (also called F-statistic) that compares the amount of systematic variation in the data (variation that can be explained by the model or hypothesis) with the amount of unsystematic variance (variation that cannot be explained by our hypothesis or model). This means that F is the ratio of the model to its error. ANOVA also produces a *p-value* that indicates the probability that the variation can be attributed to the null hypothesis. The smaller the p-value, the less likely it is that the observed variation is due to chance."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:640
+msgid "Formatting the data"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:642
+msgid "To perform an ANOVA, let's start by pivoting the dataset with the cognitive ability test results. The pet preferences values will now be the column names, and each row will represent a person."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:646
+msgid "To perform an ANOVA, certain requirements or assumptions must be met. For example, the distributions of the residuals must be normal. This is not the case here. There are more appropriate statistical tests for this example, and the possibility of performing certain transformations on the data in order to apply ANOVA in this case. However, we use ANOVA because it is a fairly popular test, and because the purpose of this workshop is to serve as an introduction to scientific computing with Spyder. We do not intend here to obtain scientific results for publication."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:652
+msgid "You will see that one of the columns includes the answers to the test made by people who did not specify their preferences towards pets. Let's delete that column."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:661
+msgid "Now let's rename the column names (for simplicity) and remove the records that have missing values (with ``dropna``). The argument ``inplace=True`` allows you to directly modify a dataframe without having to create a new one."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:671
+msgid "In the variable ``dog_or_cat_col_names`` we have stored the names of the values in order. This implies that: A = Both, B = Cats, C = Dogs, and D = Neither."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:673
+msgid "To perform ANOVA, we are going to use a Python library called \"stats\", in particular the ``f_oneway`` function. You can find more information about this library by typing ``stats`` in the Help Pane or learn more about the function by typing ``stats.f_oneway``."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:678
+msgid "The help notes that this function requires an array-like with the measurements for each group as an input (in our case, one sample for A, one for B, one for C, and one for D). Since we have empty cells in each column, let's remove them from each column (the ``f_oneway`` function does not support missing values)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:684
+msgid "In the above line of code we are creating a list with 4 elements: the test results of each column A, B, C, and D, without the missing values (they are removed with ``dropna()``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:688
+msgid "Run ANOVA"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:690
+msgid "Now, let's run ANOVA and store the output in two variables: ``f_value`` and ``p_value``. Notice that since ``dog_or_cat_samples`` is a list, we must pass the argument with an asterisk (``*dog_or_cat_samples``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:696
+msgid "With the help of ``stats.f_oneway`` in the Help Pane you can read a description of the output of this function, some interesting notes about the test, and some references that you can use to better understand the nature of this analysis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:700
+msgid "In the Help pane you will read that ANOVA requires certain assumptions to be satisfied. In this workshop we have not checked those assumptions because our goal is merely to show some Spyder functions that make the research work easier. Thus, the results obtained in this example with ANOVA should not be taken too rigorously."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:702
+msgid "In the Variable Explorer you can find these two new variables: ``f_value`` and ``p_value``. ``p_value`` (0.6275) is well over 0.05, which gives support to the null hypothesis (detracting support from our hypothesis). To know if the F value obtained is greater than the theoretically expected value, a **F critical value** must be calculated. This can be estimated using the ``stats`` library, a significance level (*q* ), and the degrees of freedom (*df* ) for the number of groups and the number of observations:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:713
+msgid "The value of ``f_critical`` (2.6241) is larger than that of ``f_value`` (0.5813). This means that the variance between the means of these groups is not significantly different. Since the *p* value indicates that we cannot rule out random variations, then we have to discard our hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:715
+msgid "What is the conclusion of all this? There seems to be little or no evidence in our data to think that there is indeed a correlation between a person's pet preferences and his or her ability to solve practical or abstract problems. Cat and dog owners, rejoice!"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:721
+msgid "Report and share"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:723
+msgid "In science, sharing results, good and bad, is critical. Today, in scientific computing, it is also crucial to share data, and the code used to process and analyze it. To help with this, we will use Spyder's Code Analysis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:727
+msgid "Code Analysis"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:729
+msgid "When you share code, you want it to be readable, clean, and not overly complex. The Code Analysis component can help us detect these issues and even bugs that can affect the performance of our code."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:731
+msgid "To see an example, you can open the :download:`scientific-computing-astro.py <scientific-computing-astro.py>` file and run the :guilabel:`Code Analysis` (open the file in the pane and click on the green triangular button in the upper right corner)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:736
+msgid "You can see four categories that can help you improve your code:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:738
+msgid "Convention: programming standard violations"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:739
+msgid "Refactor: refactoring related checks"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:740
+msgid "Warning: Python-specific problems"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:741
+msgid "Error: probable bugs in the code"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:743
+msgid "Each of these categories indicates the type of alert and the line on which the potential issue occurs. For example, it tells us that line 129 is too long, or that we imported numpy but did not use it at all in the code."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:745
+msgid "These suggestions can contribute to sharing clean code. We recommend using this panel to polish your code before publishing it."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:753
+msgid "In this workshop we have taken the first steps to use Spyder for scientific computing. We have seen how from a question or doubt a hypothesis is raised. This question can also emerge from the exploration of some data, which can be done by calculating some measures (such as mean, median, standard deviation) or by drawing some plots."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:755
+msgid "Often, in order to answer the question, we must process some data (for example, for the construction of a cognitive ability test)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:757
+msgid "Finally, we try to establish a relationship between variables with some statistical tests. The results of these tests will support or not our initial hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:762
+msgid "Write and test code with the IPython Console and Editor."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:763
+msgid "Download a dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:765
+msgid "Graphically explore a dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:767
+msgid "Explore data and relate it to a hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:769
+msgid "Perform a statistical test with a specialized library on the data."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:770
+msgid "Improve code readability with Code Analysis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:772
+msgid "Spyder has many features that can help you do data analysis. You can find more information in our `official documentation <https://docs.spyder-ide.org/5/index.html>`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:782
+msgid "If you want to check what you have learned, we suggest you analyze the data to try to answer the following question: *Do the different zodiac signs influence the results of a cognitive ability test?,* you can check the Python script :download:`scientific-computing-astro.py <scientific-computing-astro.py>` if you have any doubts."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:790
+msgid "For a description of the dataset used, see the following `paper <https://openpsych.net/paper/46/>`__:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:792
+msgid "Kirkegaard, E. O. W., & Bjerrekær, J. D. (2016). *The OKCupid dataset: A very large public dataset of dating site users*. Open Differential Psychology. doi:10.26775/odp.2016.11.03*"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:794
+msgid "A very fun book for learning statistics with R is the following:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:796
+msgid "Field, A., Miles, J., & Field, Z. (2012). *Discovering statistics using R*. SAGE Publications."
+msgstr ""
+

--- a/doc/locales/pot/faq.pot
+++ b/doc/locales/pot/faq.pot
@@ -1,0 +1,477 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../faq.rst:3
+msgid "Frequently Asked Questions"
+msgstr ""
+
+#: ../../faq.rst:7
+msgid "Installing and updating"
+msgstr ""
+
+#: ../../faq.rst:12
+msgid ""
+"The easiest way to install Spyder is with the Anaconda Python "
+"distribution, which comes with everything you need to get started in an "
+"all-in-one package. Download it from its `webpage`_."
+msgstr ""
+
+#: ../../faq.rst:17
+msgid "For more information, visit our :doc:`/installation`."
+msgstr ""
+
+#: ../../faq.rst:23
+msgid ""
+"If you already installed Spyder on your Windows machine, you do not need "
+"to reinstall it on a WSL2-based Linux environment if your code must run "
+"there."
+msgstr ""
+
+#: ../../faq.rst:25
+msgid ""
+"Instead, just install `Miniconda`_ inside WSL2 and create a new conda "
+"environment (or use an existing conda- or virtualenv), then install "
+"Spyder-Kernels into that environment with e.g. ``conda install spyder-"
+"kernels``. You must manually install ``ipython_genutils`` with e.g. "
+"``conda install ipython_genutils``."
+msgstr ""
+
+#: ../../faq.rst:30
+msgid ""
+"Windows creates a network path located at ``\\\\wsl$`` that points to the"
+" partitions of your WSL2 machines, e.g. ``\\\\wsl$\\Ubuntu-20.04``. You "
+"**must** map a network drive letter to your machine path, e.g. ``W:``, "
+"for Spyder to correctly see its files and folders."
+msgstr ""
+
+#: ../../faq.rst:33
+msgid "To start a Spyder kernel, from your Linux terminal run"
+msgstr ""
+
+#: ../../faq.rst:39
+msgid ""
+"It will run the kernel as a subprocess and create a file named "
+":file:`remotemachine.json` in your WSL home folder."
+msgstr ""
+
+#: ../../faq.rst:41
+msgid ""
+"Finally, under the options menu of Spyder's :doc:`panes/ipythonconsole`, "
+"select :guilabel:`Connect to an existing kernel` as described in :ref"
+":`connecting-external-kernel`. Insert the absolute path of "
+":file:`remotemachine.json` into the :guilabel:`Connection file` field. If"
+" you mapped ``W:`` as mentioned in above note, the path should be "
+":file:`W:/home/{username}/remotemachine.json`. A new console will open in"
+" Spyder, running in the Linux environment. Try running ``os.system('ls "
+"-la')`` and see if it lists your WSL home folder. If you run ``exit()`` "
+"from Spyder, the kernel running on Linux will be stopped."
+msgstr ""
+
+#: ../../faq.rst:52
+msgid "From the command line (or Anaconda prompt on Windows), run:"
+msgstr ""
+
+#: ../../faq.rst:59
+msgid ""
+"If this results in an error or does not update Spyder to the latest "
+"version, try:"
+msgstr ""
+
+#: ../../faq.rst:69
+msgid ""
+"Open the \"gear\" menu in Spyder's section under :guilabel:`Home` in "
+"Navigator. Go to :guilabel:`Install specific version` and select the "
+"version of Spyder you want to use. We strongly recommend the latest "
+"available, to benefit from new features, bug fixes, performance "
+"improvements and usability enhancements."
+msgstr ""
+
+#: ../../faq.rst:80
+msgid "Running Spyder"
+msgstr ""
+
+#: ../../faq.rst:85
+msgid "You can launch it in any of the following ways:"
+msgstr ""
+
+#: ../../faq.rst:87
+msgid ""
+"**From the command line**: Type ``spyder`` in your terminal (or Anaconda "
+"prompt on Windows)."
+msgstr ""
+
+#: ../../faq.rst:89
+msgid ""
+"**From Anaconda Navigator**: Scroll to :guilabel:`Spyder` under "
+":guilabel:`Home`, and click :guilabel:`Launch`."
+msgstr ""
+
+#: ../../faq.rst:94
+msgid "***Windows Only***: Launch it via the Start menu shortcut."
+msgstr ""
+
+#: ../../faq.rst:103
+msgid ""
+"Yes! With `Binder`_, you can work with a fully functional copy of Spyder "
+"that runs right in your web browser. Try it `here`_."
+msgstr ""
+
+#: ../../faq.rst:114
+msgid ""
+"Spyder works on modern versions of Windows, macOS and Linux (see the "
+"table below for recommended versions) via Anaconda, as well as other "
+"methods. It typically uses relatively minimal CPU when idle, and 0.5 GB -"
+" 1 GB of RAM, depending on how long you've been using it and how many "
+"files, projects, panes and consoles you have open. It should work on any "
+"system with a dual-core or better x64 processor and at least 4 GB of RAM,"
+" although 8 GB is *strongly* recommended for best performance when "
+"running other applications. However, the code you run, such as scientific"
+" computation and deep learning models, may require additional resources "
+"beyond this baseline for Spyder itself."
+msgstr ""
+
+#: ../../faq.rst:122
+msgid "Operating system"
+msgstr ""
+
+#: ../../faq.rst:122
+msgid "Version"
+msgstr ""
+
+#: ../../faq.rst:124
+msgid "Windows"
+msgstr ""
+
+#: ../../faq.rst:124
+msgid "Windows 8.1"
+msgstr ""
+
+#: ../../faq.rst:125
+msgid "macOS"
+msgstr ""
+
+#: ../../faq.rst:125
+msgid "High Sierra (10.13)"
+msgstr ""
+
+#: ../../faq.rst:126
+msgid "Linux"
+msgstr ""
+
+#: ../../faq.rst:126
+msgid "Ubuntu 16.04"
+msgstr ""
+
+#: ../../faq.rst:133
+msgid ""
+"Select the environment you want to launch Spyder from under "
+":guilabel:`Applications on`. If Spyder is installed in this environment, "
+"you will see it in Navigator's :guilabel:`Home` window. Click "
+":guilabel:`Launch` to start Spyder in your selected environment."
+msgstr ""
+
+#: ../../faq.rst:144
+msgid ""
+"Activate your conda environment by typing the following in your terminal "
+"(or Anaconda Prompt on Windows):"
+msgstr ""
+
+#: ../../faq.rst:150
+msgid "Then, type ``spyder`` to launch the version installed in that environment."
+msgstr ""
+
+#: ../../faq.rst:158
+msgid "Using Spyder"
+msgstr ""
+
+#: ../../faq.rst:163
+msgid ""
+"The first approach for installing a package should be using conda. In "
+"your system terminal (or Anaconda Prompt on Windows), type:"
+msgstr ""
+
+#: ../../faq.rst:170
+msgid ""
+"If your installation is not successful, follow steps 3 through 5 of Part "
+"2 in our video on solving and avoiding problems with pip, Conda and "
+"Conda-Forge."
+msgstr ""
+
+#: ../../faq.rst:184
+msgid ""
+"To work with an existing environment in Spyder, change the default Python"
+" interpreter for new :doc:`/panes/ipythonconsole`\\s to point to this "
+"environment."
+msgstr ""
+
+#: ../../faq.rst:186
+msgid ""
+"To do so, open the :guilabel:`Python interpreter` section of Spyder's "
+"preferences (:menuselection:`Tools --> Preferences`, or "
+":menuselection:`Spyder --> Preferences` on macOS). Here, select the "
+"option :guilabel:`Use the following Python interpreter`, and use the "
+"dropdown below to select your preferred environment. If it's not listed, "
+"see :ref:`the note below <faq-env-not-listed>`."
+msgstr ""
+
+#: ../../faq.rst:197
+msgid ""
+"If you installed Miniconda (or another Conda-based distribution) to a "
+"non-default path, or are using a virtual environment managed by a tool "
+"other than ``pyenv``, your environments likely won't be listed."
+msgstr ""
+
+#: ../../faq.rst:199
+msgid ""
+"Instead, use the text box or the :guilabel:`Select file` button to enter "
+"the path to the Python interpreter you want to use. You can find this "
+"path by activating the venv or Conda env you want to use in your terminal"
+" (Anaconda Prompt on Windows), and running the command:"
+msgstr ""
+
+#: ../../faq.rst:206
+msgid ""
+"Finally, click :guilabel:`Restart kernel` in the :guilabel:`Consoles` "
+"menu for this change to take effect. If ``spyder-kernels`` is not already"
+" installed, the :doc:`/panes/ipythonconsole` will display instructions on"
+" how to install the right version. Execute the given command in your "
+"terminal (the Anaconda Prompt on Windows) with the environment activated,"
+" and finally restart the kernel once more."
+msgstr ""
+
+#: ../../faq.rst:216
+msgid ""
+"Watch our video on using additional packages or follow the instructions "
+"below."
+msgstr ""
+
+#: ../../faq.rst:224
+msgid ""
+"If you want to use other packages in Spyder that don't come with our "
+"installer, you need to have your own Python distribution installed; we "
+"recommend `Miniconda`_ or another Conda-based option. For Spyder to "
+"recognize it automatically, you should use a Conda-based distribution "
+"with its default install path."
+msgstr ""
+
+#: ../../faq.rst:229
+msgid ""
+"Create a new conda environment containing ``spyder-kernels`` and the "
+"packages that you want to use. For example, if you want to use ``scikit-"
+"learn``, open your terminal (or Anaconda prompt on Windows) and run the "
+"following command:"
+msgstr ""
+
+#: ../../faq.rst:236
+msgid ""
+"Finally, connect Spyder to this ``my-env`` environment by changing "
+"Spyder's default Python interpreter, following the instructions in "
+":ref:`the above answer <using-existing-environment>`."
+msgstr ""
+
+#: ../../faq.rst:242
+msgid ""
+"Either use the :guilabel:`Reset Spyder to factory defaults` under "
+":guilabel:`Tools` in Spyder's menu bar, the :guilabel:`Reset Spyder "
+"settings` Start menu shortcut (Windows), or run ``spyder --reset`` in "
+"your system terminal (Anaconda prompt on Windows)."
+msgstr ""
+
+#: ../../faq.rst:251
+msgid ""
+"Under :guilabel:`General` in Spyder's :guilabel:`Preferences`, go to the "
+":guilabel:`Advanced settings` tab and select your language from the "
+"options displayed under :guilabel:`Language`."
+msgstr ""
+
+#: ../../faq.rst:260
+#, python-format
+msgid ""
+"To create a cell in Spyder's :doc:`/panes/editor`, type ``#%%`` in your "
+"script. Each ``#%%`` will make a new cell. To run a cell, press :kbd"
+":`Shift-Enter` (while your cursor is focused on it) or use the "
+":guilabel:`Run current cell` button in Spyder's toolbar."
+msgstr ""
+
+#: ../../faq.rst:271
+msgid ""
+"Spyder plugins are available in the ``conda-forge`` conda channel. To "
+"install one, type on the command line (or Anaconda Prompt on Windows):"
+msgstr ""
+
+#: ../../faq.rst:278
+msgid ""
+"Replace ``<PLUGIN>`` with the name of the plugin you want to use. For "
+"more information on a specific plugin, go to the its repository:"
+msgstr ""
+
+#: ../../faq.rst:281
+msgid "`spyder-unittest`_"
+msgstr ""
+
+#: ../../faq.rst:282
+msgid "`spyder-terminal`_"
+msgstr ""
+
+#: ../../faq.rst:283
+msgid "`spyder-notebook`_"
+msgstr ""
+
+#: ../../faq.rst:284
+msgid "`spyder-memory-profiler`_"
+msgstr ""
+
+#: ../../faq.rst:285
+msgid "`spyder-line-profiler`_"
+msgstr ""
+
+#: ../../faq.rst:297
+msgid ""
+"Check the option :guilabel:`Remove all variables before execution` in the"
+" :guilabel:`Configuration per file...` dialog under the :guilabel:`Run` "
+"menu."
+msgstr ""
+
+#: ../../faq.rst:306
+msgid ""
+"Select the appropriate option in the :guilabel:`Configuration per "
+"file...` dialog under the :guilabel:`Run` menu."
+msgstr ""
+
+#: ../../faq.rst:315
+msgid ""
+"Go to :guilabel:`Preferences` and select the theme you want under "
+":guilabel:`Syntax highlighting theme` in the :guilabel:`Appearance` "
+"section."
+msgstr ""
+
+#: ../../faq.rst:324
+msgid "Troubleshooting"
+msgstr ""
+
+#: ../../faq.rst:329
+msgid ""
+"You should first follow the steps in our :doc:`troubleshooting "
+"guide</troubleshooting/first-steps>`. If you can't solve your problem, "
+"open an issue by following the instructions in our "
+":doc:`/troubleshooting/submit-a-report` section."
+msgstr ""
+
+#: ../../faq.rst:336
+msgid ""
+"First, make sure the error you are seeing is not a bug in your code. To "
+"confirm this, try running it in any standard Python interpreter. If the "
+"error still occurs, the problem is likely with your code and a site like "
+"`Stack Overflow`_ might be the best place to start. Otherwise, start at "
+"the :doc:`/troubleshooting/basic-first-aid` section of our "
+"troubleshooting guide."
+msgstr ""
+
+#: ../../faq.rst:347
+msgid ""
+"If nothing is displayed in the calltip, hover hint or :doc:`/panes/help` "
+"pane, make sure the object you are inspecting has a docstring, and try "
+"executing your code in the :doc:`/panes/ipythonconsole` to get help and "
+"completions there. If this doesn't work, try restarting PyLS by right-"
+"clicking the :guilabel:`LSP Python` label item in the statusbar at the "
+"bottom of Spyder's main window, and selecting the :guilabel:`Restart "
+"Python Language Server` option."
+msgstr ""
+
+#: ../../faq.rst:350
+msgid ""
+"For more information, go to the :ref:`code-completion-problems-ref` "
+"section in the :doc:`/troubleshooting/common-illnesses` page of our "
+"troubleshooting guide."
+msgstr ""
+
+#: ../../faq.rst:356
+msgid ""
+"First, make sure your version of Spyder-Kernels is compatible with that "
+"of Spyder. See the table in the :ref:`spyder-kernels-version-ref` section"
+" of the troubleshooting guide to check."
+msgstr ""
+
+#: ../../faq.rst:359
+msgid ""
+"To install the right version, type the following on the command line (or "
+"Anaconda Prompt on Windows)"
+msgstr ""
+
+#: ../../faq.rst:365
+msgid ""
+"For more information, go to the :ref:`starting-kernel-problems-ref` "
+"section in the :doc:`/troubleshooting/common-illnesses` page of our "
+"troubleshooting guide."
+msgstr ""
+
+#: ../../faq.rst:371
+msgid ""
+"Spyder is in the final stages of being updated for full compatibility "
+"with macOS 11 Big Sur, which will be released by the end of 2020 as part "
+"of version 4.2.1. However, you can get it working right now with the "
+"workaround below. Make sure you have the Anaconda or Miniconda "
+"distribution installed, and run the following commands in the Terminal to"
+" install Spyder from Conda-Forge in a clean environment:"
+msgstr ""
+
+#: ../../faq.rst:381
+msgid ""
+"Then, whenever you want to start Spyder, run the following from the "
+"Terminal:"
+msgstr ""
+
+#: ../../faq.rst:393
+msgid "About Spyder"
+msgstr ""
+
+#: ../../faq.rst:398
+#, python-format
+msgid ""
+"Spyder is 100% free and open source; there is no paid version or "
+"prohibition on commercial use. It is developed by its international user "
+"community, and supported by its users through `OpenCollective`_ and by "
+"its generous sponsoring organizations, including `Quansight`_ and "
+"`NumFOCUS`_. Our source code, standalone installers and most of our "
+"distribution methods (Pip/PyPI, Linux distros, MacPorts, WinPython, etc) "
+"can be freely redistributed, used and modified by anyone, for any "
+"purpose, including commercial use. For more details about the situation "
+"with Anaconda, see `that question`_."
+msgstr ""
+
+#: ../../faq.rst:412
+#, python-format
+msgid ""
+"If you use Spyder with the Anaconda distribution, they `recently "
+"changed`_ their `Terms of Service`_ to add restrictions on large (> 200 "
+"employee) for-profit companies using Anaconda on a large scale. However, "
+"these terms only apply to the package infrastructure (the full Anaconda "
+"distribution and the ``defaults`` conda channel). Instead, you can simply"
+" download the similar `Miniforge distribution`_, which is 100% open "
+"source and identical to full Anaconda (aside from not bundling the Python"
+" packages installed by default in the Anaconda ``base`` environment, "
+"which we recommend you avoid using anyway given any problems here can "
+"break your whole installation). Then, simply install the packages you "
+"need (including Spyder, if you aren't using our recommended :ref"
+":`install-standalone`) with ``conda`` as you usually do. Miniforge will "
+"automatically use the community-maintained Conda-Forge repository, which "
+"has a much wider variety of packages and is generally more up to date "
+"than the Anaconda equivalent, in addition to being free of any commercial"
+" restrictions. For more, see our :doc:`/installation`."
+msgstr ""
+

--- a/doc/locales/pot/index.pot
+++ b/doc/locales/pot/index.pot
@@ -1,0 +1,151 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../index.rst:137
+msgid "Welcome"
+msgstr ""
+
+#: ../../index.rst:137
+msgid "FAQ"
+msgstr ""
+
+#: ../../index.rst:3
+msgid "Welcome to Spyder's Documentation"
+msgstr ""
+
+#: ../../index.rst:9
+msgid ""
+"Spyder is a powerful scientific environment written in Python, for "
+"Python, and designed by and for scientists, engineers and data analysts. "
+"It features a unique combination of the advanced editing, analysis, "
+"debugging, and profiling functionality of a comprehensive development "
+"tool with the data exploration, interactive execution, deep inspection, "
+"and beautiful visualization capabilities of a scientific package."
+msgstr ""
+
+#: ../../index.rst:18
+msgid "Where to go now?"
+msgstr ""
+
+#: ../../index.rst:20
+msgid ""
+"Spyder's documentation provides a variety of resources that will help you"
+" learn how to use the application and explore each one of its panes. "
+"These include video tutorials, in-depth descriptions and how-to guides "
+"covering a wide range of needs and experience levels with Spyder."
+msgstr ""
+
+#: ../../index.rst:33
+msgid ""
+"If you are looking for a summary of its features and interface, check out"
+" the :doc:`quickstart`."
+msgstr ""
+
+#: ../../index.rst:41
+msgid ""
+"If you don't have Spyder installed and want to get started, follow the "
+":doc:`/installation`."
+msgstr ""
+
+#: ../../index.rst:49
+msgid ""
+"If you are completely new to Spyder, watch our basic tutorial series, "
+":doc:`videos/first-steps-with-spyder`."
+msgstr ""
+
+#: ../../index.rst:57
+msgid ""
+"If you are familiar with Spyder and want to explore the functionality of "
+"its panes in more detail, go to :doc:`panes/index`."
+msgstr ""
+
+#: ../../index.rst:65
+msgid ""
+"If you've run into a Spyder problem and need help solving it, take a look"
+" at our :doc:`troubleshooting guide<troubleshooting/first-steps>`."
+msgstr ""
+
+#: ../../index.rst:73
+msgid "If you have a question about Spyder, visit the :doc:`faq` section."
+msgstr ""
+
+#: ../../index.rst:81
+msgid "Join our community"
+msgstr ""
+
+#: ../../index.rst:83
+msgid ""
+"Spyder is open source software, which means that is free for everyone to "
+"use and anyone can contribute to it. We encourage everyone to become a "
+"part of our community and help develop Spyder!"
+msgstr ""
+
+#: ../../index.rst:90
+msgid "Looking to contribute your code?"
+msgstr ""
+
+#: ../../index.rst:92
+msgid ""
+"Spyder is written in the same Python language that you use it to develop,"
+" so its easy to get started contributing to it. You can follow our "
+"`contributing guide`_ to set up a development environment, and you can "
+"get involved with the project through our `Github repository`_. The "
+"easiest way to get started is helping us resolve items on our `issue "
+"tracker`_, either by fixing bugs in Spyder, or helping users troubleshoot"
+" their problems (which doesn't require writing any code)."
+msgstr ""
+
+#: ../../index.rst:106
+msgid "Want to help writing docs?"
+msgstr ""
+
+#: ../../index.rst:108
+msgid ""
+"We welcome your contributions of corrections, additions and enhancements "
+"to these docs. Check out the `docs contributing guide`_ to learn how to "
+"submit a PR with your changes on our `docs repo`_."
+msgstr ""
+
+#: ../../index.rst:119
+msgid "Interested in translating Spyder?"
+msgstr ""
+
+#: ../../index.rst:121
+msgid ""
+"In order to reach more users around the world in need of a powerful "
+"scientific Python environment, we welcome your help translating the "
+"documentation and the interface into different languages."
+msgstr ""
+
+#: ../../index.rst:123
+msgid ""
+"For this purpose we use `Crowdin`_, which provides a simple web based "
+"interface for translators, proofreaders and managers, so everyone can "
+"help us translate Spyder into any language."
+msgstr ""
+
+#: ../../index.rst:131
+msgid "Want to be part of our social media?"
+msgstr ""
+
+#: ../../index.rst:133
+msgid ""
+"Connect with Spyder through our social media channels to stay up to date "
+"with our current developments!"
+msgstr ""
+

--- a/doc/locales/pot/installation.pot
+++ b/doc/locales/pot/installation.pot
@@ -1,0 +1,593 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../installation.rst:5
+msgid "Installation Guide"
+msgstr ""
+
+#: ../../installation.rst:7
+msgid ""
+"Spyder is relatively easy to install on Windows, Linux and macOS. Just "
+"make sure to read and follow these instructions with care."
+msgstr ""
+
+#: ../../installation.rst:10
+msgid ""
+"If you run into problems, before posting a report, *please* consult our "
+"comprehensive :doc:`troubleshooting guide</troubleshooting/first-steps>` "
+"and search the `issue tracker`_ for your error message and problem "
+"description. These methods generally fix or isolate the great majority of"
+" install-related difficulties. Thanks!"
+msgstr ""
+
+#: ../../installation.rst:18
+msgid ""
+"For most users on Windows and macOS, we recommend our :ref:`install-"
+"standalone` as the most straightforward and robust option to obtain "
+"Spyder. For users needing Linux support, third-party Spyder plugins or "
+"Variable Explorer compatibility with custom-installed packages—all "
+"capabilities which the standalone installers currently do not yet "
+"provide—we advise using a :ref:`install-conda`. Linux, plugin and "
+"package/environment management support in the standalone installers are "
+"currently under active development for future Spyder versions."
+msgstr ""
+
+#: ../../installation.rst:27
+msgid "Try Spyder online"
+msgstr ""
+
+#: ../../installation.rst:29
+msgid ""
+"Want to try out Spyder without installing it? With `Binder`_ you can work"
+" with a fully functional copy of Spyder online that runs right in your "
+"web browser, no installation needed. Visit the `Spyder Binder`_ to get "
+"started using Spyder."
+msgstr ""
+
+#: ../../installation.rst:45
+msgid "Standalone installers"
+msgstr ""
+
+#: ../../installation.rst:47
+msgid ""
+"The standalone installers are our recommended method for most users on "
+"Windows and macOS, with experimental Linux support under active "
+"development. They work like any other IDE, where Spyder can be installed "
+"and updated independently of the Python environments you use to run your "
+"code. This avoids the problems with incompatible packages and broken "
+"installations users often face when mixing Spyder with the (Conda, etc) "
+"environments they use to run their code."
+msgstr ""
+
+#: ../../installation.rst:51
+msgid ""
+"The installers include a built-in Python environment with the most common"
+" scientific libraries (e.g. NumPy, Pandas, Matpotlib, etc), which can be "
+"used out of the box for basic data analysis tasks. However, to manage "
+"your own packages and environments, you'll currently need to connect an "
+"external Python distribution (such as `Anaconda`_, `Miniconda`_, "
+"`Miniforge/Mambaforge`_, `WinPython`_ or `Python.org <Python_>`__) to "
+"your standalone copy of Spyder. For more information on this, see our "
+":ref:`FAQ entry on the subject <using-packages-installer>`."
+msgstr ""
+
+#: ../../installation.rst:57
+msgid ""
+"The standalone installers do not yet support installing third-party "
+"Spyder plugins not already bundled with them, though this feature is "
+"currently under development. For now, if you need this capability, we "
+"recommend a :ref:`install-conda`."
+msgstr ""
+
+#: ../../installation.rst:64
+msgid "Downloading and installing"
+msgstr ""
+
+#: ../../installation.rst:66
+msgid ""
+"To download the supported Spyder installer for your platform, simply "
+"click the appropriate link below (for Linux, see the :ref:`install-conda`"
+" section). Then, double-click the downloaded file to open the installer. "
+"If a security warning pops up, you may need to click :guilabel:`Yes`, "
+":guilabel:`OK`, :guilabel:`Open`, :guilabel:`Allow` or similar."
+msgstr ""
+
+#: ../../installation.rst:70
+msgid ""
+"On Windows, if a \"SmartScreen\" dialog appears, click :guilabel:`More "
+"info` followed by :guilabel:`Run anyway`, and then proceed through the "
+"steps in the installer."
+msgstr ""
+
+#: ../../installation.rst:72
+msgid ""
+"On macOS, open the disk image and drag Spyder to your "
+":guilabel:`Applications` folder."
+msgstr ""
+
+#: ../../installation.rst:79
+msgid "`Windows Installer`_"
+msgstr ""
+
+#: ../../installation.rst:79
+msgid "`macOS Installer`_"
+msgstr ""
+
+#: ../../installation.rst:87
+msgid ""
+"\"Lite\" versions of both installers are also available from the "
+"`releases page`_, which are somewhat smaller than the full installers. "
+"These lack a number of optional but recommended dependencies, such as "
+"NumPy, SciPy and Pandas, meaning that a few "
+":doc:`/panes/variableexplorer` features, including graphical data import "
+"wizards and support for rich display and editing of NumPy arrays and "
+"Pandas DataFrames, will not be available. Given this only saves a modest "
+"amount of space while missing out on significant features, we recommend "
+"using the full installers unless minimizing download/install size and "
+"memory usage is a priority."
+msgstr ""
+
+#: ../../installation.rst:97
+msgid "Running from a standalone install"
+msgstr ""
+
+#: ../../installation.rst:99
+msgid ""
+"To run Spyder when installed standalone, you can simply use your "
+"operating system's typical method of launching applications, such as "
+"opening it from the :guilabel:`Start` menu on Windows (or the Taskbar, if"
+" you've pinned it there), or from Launchpad, Spotlight or the "
+":guilabel:`Applications` folder on macOS (or the Dock, if you've added it"
+" there)."
+msgstr ""
+
+#: ../../installation.rst:105
+msgid "Updating a standalone install"
+msgstr ""
+
+#: ../../installation.rst:107
+msgid ""
+"By default, Spyder checks for updates automatically on startup, and you "
+"can also check manually with :menuselection:`Help --> Check for updates`."
+" The standalone installers for Spyder 5.4.0+ include update functionality"
+" built right into Spyder, which after checking for updates will display a"
+" prompt to automatically download and install the current version. On "
+"earlier versions, you'll need to manually download and install the latest"
+" release (if on Windows, make sure to remove the old version first from "
+"Control Panel/System Settings)."
+msgstr ""
+
+#: ../../installation.rst:117
+msgid "Conda-based distributions"
+msgstr ""
+
+#: ../../installation.rst:119
+msgid ""
+"Spyder is included by default in the `Anaconda`_ Python distribution, "
+"which comes with everything you need to get started in an all-in-one "
+"package. It can also be easily installed in the much lighter-weight "
+"`Miniconda`_ and `Miniforge/Mambaforge`_, which include just Python and "
+"the Conda/Mamba package and environment manager by default (with "
+"Miniforge defaulting to the Conda-Forge channel, and Mambaforge using "
+"Mamba, a much faster alternative to Conda). This is our recommended "
+"installation method on Linux and for users with third-party Spyder "
+"plugins, as support for both of these in our standalone installers is "
+"still under active development."
+msgstr ""
+
+#: ../../installation.rst:131
+msgid "Conda environment"
+msgstr ""
+
+#: ../../installation.rst:133
+msgid ""
+"With Miniconda/Miniforge/Mambaforge, or to get a more reliable and up-to-"
+"date Spyder version with Anaconda, we strongly recommend installing "
+"Spyder into its own dedicated Conda environment."
+msgstr ""
+
+#: ../../installation.rst:137
+msgid ""
+"If using Mamba/Mambaforge, substitute ``mamba`` for ``conda`` in the "
+"following commands."
+msgstr ""
+
+#: ../../installation.rst:143
+msgid "Installing with Conda"
+msgstr ""
+
+#: ../../installation.rst:145
+msgid ""
+"For a full install of Spyder and all optional dependencies, run the "
+"following command in your Anaconda Prompt (Windows) or terminal:"
+msgstr ""
+
+#: ../../installation.rst:151
+msgid ""
+"For a minimal install without the optional functionality and integration "
+"with the above packages, you can instead run:"
+msgstr ""
+
+#: ../../installation.rst:157
+msgid ""
+"This installs Spyder into a new environment called ``spyder-env``, using "
+"the more up-to-date, community-run Conda-Forge channel. To make sure "
+"future installs/updates in this environment also use Conda-Forge and are "
+"faster and more reliable, make sure to set it as your environment's "
+"default channel with strict channel priority enabled, if this isn't the "
+"case already (as it is with Miniforge/Mambaforge or if you've manually "
+"configured it):"
+msgstr ""
+
+#: ../../installation.rst:166
+msgid "Here's a summary of the main steps."
+msgstr ""
+
+#: ../../installation.rst:175
+msgid "Running with Conda"
+msgstr ""
+
+#: ../../installation.rst:177
+msgid ""
+"You can then run Spyder by the same methods :ref:`as with Anaconda "
+"<install-anaconda-running>`, except that you need to make sure to launch "
+"the Start menu shortcut with ``(spyder-env)`` in the name, select the "
+"``spyder-env`` environment on the left before launching it with "
+"Navigator, or type ``conda activate spyder-env`` before launching it on "
+"the command line."
+msgstr ""
+
+#: ../../installation.rst:179
+msgid ""
+"See :ref:`our FAQ question <using-existing-environment>` for more "
+"information about how to use Spyder with your existing Conda "
+"environments."
+msgstr ""
+
+#: ../../installation.rst:185
+msgid "Updating with Conda"
+msgstr ""
+
+#: ../../installation.rst:187
+msgid ""
+"With any Conda-based distribution and Spyder installed in its own "
+"environment (recommended), update Conda itself, active the environment, "
+"and finally update Spyder. In your system terminal (or Anaconda Prompt if"
+" on Windows), run:"
+msgstr ""
+
+#: ../../installation.rst:196
+msgid ""
+"In case you get an error trying to update, just remove the existing "
+"environment (if using one other than ``base``):"
+msgstr ""
+
+#: ../../installation.rst:202
+msgid "And then :ref:`recreate a fresh one <install-conda-installing>`."
+msgstr ""
+
+#: ../../installation.rst:208
+msgid "Anaconda base"
+msgstr ""
+
+#: ../../installation.rst:210
+msgid ""
+"While we recommend always using a dedicated environment, with Anaconda "
+"you can also run the bundled copy of Spyder from the built-in ``base`` "
+"environment."
+msgstr ""
+
+#: ../../installation.rst:214
+msgid ""
+"The bundled Spyder version can often be quite out of date, missing new "
+"features and bug fixes from the latest version, and if you install, "
+"change or remove other packages, there is a significant chance of "
+"dependency conflicts or a broken Spyder installation. Therefore, we "
+"recommend :ref:`installing Spyder into a new Conda environment <install-"
+"conda-installing>` to avoid all these issues."
+msgstr ""
+
+#: ../../installation.rst:221
+msgid "Running with Anaconda"
+msgstr ""
+
+#: ../../installation.rst:223
+msgid ""
+"To run the bundled version of Spyder after installing it with Anaconda, "
+"the recommended method on Windows is to launch it via the Start menu "
+"shortcut. On other platforms, open Anaconda Navigator, scroll to Spyder "
+"under :guilabel:`Home` and click :guilabel:`Launch`."
+msgstr ""
+
+#: ../../installation.rst:229
+msgid ""
+"If Spyder does not start via this method or you prefer to use the command"
+" line, open Anaconda Prompt (Windows) or your terminal (other platforms),"
+" type ``conda activate base`` then ``spyder``."
+msgstr ""
+
+#: ../../installation.rst:235
+msgid "Updating with Anaconda"
+msgstr ""
+
+#: ../../installation.rst:237
+msgid ""
+"With Spyder installed in Anaconda's ``base`` environment, first update "
+"the ``anaconda`` meta-package, and then Spyder itself (in case there is a"
+" newer version than that pinned to the ``anaconda`` metapackage). In your"
+" system terminal (or Anaconda Prompt if on Windows), run:"
+msgstr ""
+
+#: ../../installation.rst:247
+msgid ""
+"These commands also update all your other packages, which is one reason "
+"we strongly recommend you use an isolated conda environment to avoid any "
+"potential unintended effects on other installed packages."
+msgstr ""
+
+#: ../../installation.rst:249
+msgid ""
+"In case you get an error resolving dependencies, try uninstalling Spyder "
+"and re-installing it:"
+msgstr ""
+
+#: ../../installation.rst:262
+msgid "Using pip"
+msgstr ""
+
+#: ../../installation.rst:266
+msgid ""
+"While this installation method is a viable option for experienced users, "
+"installing Spyder (and other PyData-stack packages) with pip can "
+"sometimes lead to tricky issues, particularly on Windows and macOS. While"
+" you are welcome to try it on your own, we are typically not able to "
+"provide individual support for installation problems with pip, except to "
+"recommend our :ref:`install-standalone` (Windows and macOS) or a :ref"
+":`install-conda`."
+msgstr ""
+
+#: ../../installation.rst:269
+msgid ""
+"You can install Spyder with the pip package manager, which is included by"
+" default with most Python installations. Before installing Spyder itself "
+"by this method, you need to download the `Python`_ programming language."
+msgstr ""
+
+#: ../../installation.rst:276
+msgid ""
+"Due to a known issue with some DEB-based Linux distributions (Debian, "
+"Ubuntu, Mint), you might also need to install the ``pyqt5-dev-tools`` "
+"package first, with ``sudo apt install pyqt5-dev-tools``."
+msgstr ""
+
+#: ../../installation.rst:278
+msgid ""
+"You'll first want to create and activate a virtual environment in which "
+"to install Spyder, via one of the following methods."
+msgstr ""
+
+#: ../../installation.rst:280
+msgid "With ``virtualenvwrapper``:"
+msgstr ""
+
+#: ../../installation.rst:287
+msgid "Otherwise, on macOS/Linux/Unix:"
+msgstr ""
+
+#: ../../installation.rst:294
+msgid "or on Windows:"
+msgstr ""
+
+#: ../../installation.rst:301
+msgid ""
+"After activating your environment, to install Spyder and its optional "
+"dependencies, run:"
+msgstr ""
+
+#: ../../installation.rst:307
+msgid "Or for a minimal installation, run:"
+msgstr ""
+
+#: ../../installation.rst:316
+msgid ""
+"To launch Spyder after installing it, ensure your environment is "
+"activated and run the ``spyder`` or ``spyder3`` command."
+msgstr ""
+
+#: ../../installation.rst:318
+msgid "And to update Spyder, with your Spyder environment activated, run:"
+msgstr ""
+
+#: ../../installation.rst:330
+msgid "Alternative methods"
+msgstr ""
+
+#: ../../installation.rst:334
+msgid ""
+"While we describe alternative Spyder installation options for users who "
+"prefer them, as these are third-party distributions that we have no "
+"direct involvement in, we are usually not able to offer useful individual"
+" assistance for problems specific to installing via these alternative "
+"methods."
+msgstr ""
+
+#: ../../installation.rst:336
+msgid ""
+"Also, the Spyder versions they install may be out of date relative to the"
+" current release, and thus be missing the latest features and bug fixes."
+msgstr ""
+
+#: ../../installation.rst:338
+msgid ""
+"Therefore, we recommend you switch to our :ref:`install-standalone` "
+"(Windows and macOS) or a :ref:`install-conda` if you encounter "
+"installation issues you are unable to solve on your own."
+msgstr ""
+
+#: ../../installation.rst:344
+msgid "Windows"
+msgstr ""
+
+#: ../../installation.rst:346
+msgid ""
+"Spyder is included in the `WinPython`_ scientific Python distribution, "
+"along with many other common numerical computing and data analysis "
+"packages. You can use Spyder immediately after installing, similar to "
+"Anaconda."
+msgstr ""
+
+#: ../../installation.rst:355
+msgid "macOS"
+msgstr ""
+
+#: ../../installation.rst:357
+msgid "Spyder is available as `a cask`_ through `Homebrew`_."
+msgstr ""
+
+#: ../../installation.rst:362
+msgid "To install it using the ``brew`` package manager, run:"
+msgstr ""
+
+#: ../../installation.rst:368
+msgid "It is also available as a `a port`_ through `MacPorts`_."
+msgstr ""
+
+#: ../../installation.rst:373
+msgid "To install it using the ``port`` package manager, run:"
+msgstr ""
+
+#: ../../installation.rst:383
+msgid "Linux"
+msgstr ""
+
+#: ../../installation.rst:385
+msgid ""
+"Spyder can be installed via third-party distro packages on most common "
+"Linux distributions."
+msgstr ""
+
+#: ../../installation.rst:387
+msgid ""
+"Running Spyder installed this way will generally be the same as any other"
+" distro-installed application. Alternatively, it can be launched from the"
+" terminal with ``spyder`` (or ``spyder3``, on older versions of some "
+"distros)."
+msgstr ""
+
+#: ../../installation.rst:394
+msgid "Ubuntu/Debian"
+msgstr ""
+
+#: ../../installation.rst:396
+msgid "Spyder is available as `a Ubuntu package`_ and `a Debian package`_."
+msgstr ""
+
+#: ../../installation.rst:401
+msgid "To install it using the ``apt`` package manager, run:"
+msgstr ""
+
+#: ../../installation.rst:411
+msgid "Other distributions"
+msgstr ""
+
+#: ../../installation.rst:413
+msgid "Spyder is also available in other GNU/Linux distributions, including:"
+msgstr ""
+
+#: ../../installation.rst:415
+msgid "`Arch Linux`_"
+msgstr ""
+
+#: ../../installation.rst:416
+msgid "`Fedora`_"
+msgstr ""
+
+#: ../../installation.rst:417
+msgid "`Gentoo`_"
+msgstr ""
+
+#: ../../installation.rst:418
+msgid "`openSUSE`_"
+msgstr ""
+
+#: ../../installation.rst:425
+msgid ""
+"Please refer to the links or your distribution's documentation for how to"
+" install Spyder."
+msgstr ""
+
+#: ../../installation.rst:433
+msgid "Development builds"
+msgstr ""
+
+#: ../../installation.rst:435
+msgid ""
+"If you want to try the next Spyder version before it is released, you "
+"can! You may want to do this for fixing bugs in Spyder, adding new "
+"features, learning how Spyder works or just getting a taste of what the "
+"IDE can do. For more information, please see the `Contributing Guide`_ "
+"included with the Spyder source or on Github, and for further detail "
+"consult the `Spyder development wiki`_."
+msgstr ""
+
+#: ../../installation.rst:450
+msgid "Additional help"
+msgstr ""
+
+#: ../../installation.rst:454
+msgid ""
+"*Run in to a problem installing or running Spyder?* Read our "
+"`Troubleshooting Guide and FAQ`_."
+msgstr ""
+
+#: ../../installation.rst:458
+msgid ""
+"*Looking for general information about Spyder and its ecosystem?* See our"
+" `main website`_."
+msgstr ""
+
+#: ../../installation.rst:462
+msgid ""
+"*Need to submit a bug report or feature request?* Check out our `Github "
+"repository`_."
+msgstr ""
+
+#: ../../installation.rst:466
+msgid ""
+"*Want development-oriented help and information?* Consult our `Github "
+"wiki`_."
+msgstr ""
+
+#: ../../installation.rst:470
+msgid ""
+"*Have a help request or discussion topic?* Subscribe to our `Google "
+"Group`_."
+msgstr ""
+
+#: ../../installation.rst:474
+msgid ""
+"*Asking a quick question or want to chat with the dev team?* Stop by our "
+"`Gitter chatroom`_."
+msgstr ""
+
+#: ../../installation.rst:478
+msgid ""
+"*Seeking personalized help from expert Spyder consultants?* Visit "
+"`OpenTeams`_."
+msgstr ""
+

--- a/doc/locales/pot/panes.pot
+++ b/doc/locales/pot/panes.pot
@@ -1,0 +1,2138 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../panes/debugging.rst:3
+msgid "Debugger"
+msgstr ""
+
+#: ../../panes/debugging.rst:5
+msgid ""
+"**Debugging** in Spyder is supported through integration with the "
+"enhanced ``ipdb`` debugger in the :doc:`ipythonconsole`. This allows "
+"breakpoints and the execution flow to be viewed and controlled right from"
+" the Spyder GUI, as well as with all the familiar IPython console "
+"commands."
+msgstr ""
+
+#: ../../panes/debugging.rst:15
+msgid "Debugging with ipdb"
+msgstr ""
+
+#: ../../panes/debugging.rst:17
+msgid ""
+"You can fully control debugger execution from the :guilabel:`Debug` menu,"
+" :guilabel:`Debug toolbar` and via configurable keyboard shortcuts, along"
+" with the standard ``ipdb`` `console commands`_."
+msgstr ""
+
+#: ../../panes/debugging.rst:22
+msgid ""
+"Additionally, the  :doc:`editor` shows the line of code the debugger is "
+"currently stopped on with an arrow."
+msgstr ""
+
+#: ../../panes/debugging.rst:29
+msgid ""
+"Spyder's debugger offers syntax highlighting, code completion and command"
+" history, which work exactly like they do in the normal interactive "
+"interpreter."
+msgstr ""
+
+#: ../../panes/debugging.rst:31
+msgid ""
+"Use the up and down arrows to recall previous commands, and press "
+":kbd:`Tab` to trigger autocomplete suggestions."
+msgstr ""
+
+#: ../../panes/debugging.rst:36
+#, python-format
+msgid ""
+"Furthermore, IPython's `magic functions`_ are available in debugging "
+"mode. You can, for example, run ``%ls`` to list the contents of your "
+"current working directory or ``%timeit`` to check how fast a given "
+"snippet of code is."
+msgstr ""
+
+#: ../../panes/debugging.rst:44
+msgid ""
+"Finally, you can enter and execute multiline statements in Spyder's "
+"debugger just like with the regular IPython prompt, to easily run complex"
+" code."
+msgstr ""
+
+#: ../../panes/debugging.rst:54
+msgid "Breakpoints"
+msgstr ""
+
+#: ../../panes/debugging.rst:56
+msgid ""
+"Spyder's debugger is integrated with the :guilabel:`Breakpoints` pane, "
+"which lists the file, line, and condition (if any) of every breakpoint "
+"defined. To open it, select :menuselection:`Debug --> List breakpoints`, "
+"or press :kbd:`Ctrl-Shift-B` (:kbd:`Cmd-Shift-B` on macOS)."
+msgstr ""
+
+#: ../../panes/debugging.rst:62
+msgid "There are several different ways to set and clear breakpoints:"
+msgstr ""
+
+#: ../../panes/debugging.rst:64
+msgid "With the :guilabel:`Set/clear breakpoint` option in the Debug menu."
+msgstr ""
+
+#: ../../panes/debugging.rst:65
+msgid ""
+"Through pressing the configurable keyboard shortcut (:kbd:`F12` for "
+"normal, or :kbd:`Shift-F12` for conditional breakpoints by default)."
+msgstr ""
+
+#: ../../panes/debugging.rst:66
+msgid ""
+"By clicking to the left of the line number in an open file in the Editor "
+"(adding :kbd:`Shift` for a conditional breakpoint)."
+msgstr ""
+
+#: ../../panes/debugging.rst:67
+msgid "With the ``breakpoint()`` builtin function in your code."
+msgstr ""
+
+#: ../../panes/debugging.rst:68
+msgid "Interactively, using the ``b`` command in a debugging session."
+msgstr ""
+
+#: ../../panes/debugging.rst:73
+msgid ""
+"You can access and edit local and global variables at each breakpoint "
+"through the :doc:`variableexplorer`."
+msgstr ""
+
+#: ../../panes/debugging.rst:82
+msgid "Advanced features"
+msgstr ""
+
+#: ../../panes/debugging.rst:84
+msgid ""
+"You can avoid stepping through other Python packages while debugging by "
+"enabling the new :guilabel:`Ignore Python libraries while debugging` "
+"option in Spyder's preferences, under :menuselection:`IPython Console -->"
+" Debugger --> Debug`. This will skip all the built-in and third-party "
+"Python modules you have installed."
+msgstr ""
+
+#: ../../panes/debugging.rst:90
+msgid ""
+"If your code has variables with the same names as Pdb commands (e.g. "
+"``b`` or ``step``), you can still refer to them as normal while "
+"debugging. To call the respective Pdb command, just add an exclamation "
+"point before it (e.g. ``!b`` or ``!step``)."
+msgstr ""
+
+#: ../../panes/debugging.rst:96
+msgid ""
+"You can have Spyder automatically execute a custom snippet of code every "
+"time the debugger stops. For example, you can use this to set specific "
+"variables, or import commonly-used modules so they are always available "
+"while debugging. To set this up, go to :menuselection:`Preferences --> "
+"IPython Console --> Debugger --> Run code while debugging`, and enter the"
+" code that you want to be executed with each step."
+msgstr ""
+
+#: ../../panes/debugging.rst:107
+msgid "Matplotlib support"
+msgstr ""
+
+#: ../../panes/debugging.rst:109
+msgid ""
+"Generating Matplotlib figures is fully supported while the debugger is "
+"active, including all the different graphics backends. Use the "
+"``%matplotlib`` magic to change to an interactive backend (e.g. "
+"``%matplotlib qt5``) to pan, zoom and adjust your plots in a separate "
+"window, or switch back to the default ``inline`` (``%matplotlib inline``)"
+" to see them displayed right in the :doc:`plots` pane."
+msgstr ""
+
+#: ../../panes/debugging.rst:116
+msgid ""
+"To avoid showing plots while debugging, deactivate the :guilabel:`Process"
+" execute events while debugging` option in :menuselection:`Preferences "
+"--> IPython console --> Debugger`."
+msgstr ""
+
+#: ../../panes/debugging.rst:122 ../../panes/editor.rst:313
+#: ../../panes/fileexplorer.rst:99 ../../panes/findinfiles.rst:65
+#: ../../panes/help.rst:80 ../../panes/historylog.rst:51
+#: ../../panes/ipythonconsole.rst:185 ../../panes/onlinehelp.rst:86
+#: ../../panes/outline.rst:54 ../../panes/plots.rst:85
+#: ../../panes/profiler.rst:99 ../../panes/projects.rst:62
+#: ../../panes/pylint.rst:91 ../../panes/variableexplorer.rst:194
+msgid "Related panes"
+msgstr ""
+
+#: ../../panes/debugging.rst:124 ../../panes/fileexplorer.rst:101
+#: ../../panes/findinfiles.rst:67 ../../panes/help.rst:82
+#: ../../panes/ipythonconsole.rst:188 ../../panes/outline.rst:56
+#: ../../panes/projects.rst:64 ../../panes/pylint.rst:93
+msgid ":doc:`editor`"
+msgstr ""
+
+#: ../../panes/debugging.rst:125 ../../panes/editor.rst:317
+#: ../../panes/help.rst:83 ../../panes/historylog.rst:53
+#: ../../panes/plots.rst:87 ../../panes/profiler.rst:101
+#: ../../panes/variableexplorer.rst:197
+msgid ":doc:`ipythonconsole`"
+msgstr ""
+
+#: ../../panes/debugging.rst:126 ../../panes/ipythonconsole.rst:191
+#: ../../panes/plots.rst:88
+msgid ":doc:`variableexplorer`"
+msgstr ""
+
+#: ../../panes/editor.rst:3
+msgid "Editor"
+msgstr ""
+
+#: ../../panes/editor.rst:5
+msgid ""
+"Spyder's multi-language **Editor** pane is the key element of the IDE, "
+"where you can create, open, and modify source files. The Editor offers a "
+"variety of core features, such as autocompletion, real-time analysis, "
+"syntax highlighting, horizontal and vertical splitting, and much more. In"
+" addition, it integrates a number of powerful tools for an easy to use, "
+"efficient editing experience."
+msgstr ""
+
+#: ../../panes/editor.rst:16
+msgid "Key components"
+msgstr ""
+
+#: ../../panes/editor.rst:18
+msgid "The Editor pane consists of the following areas:"
+msgstr ""
+
+#: ../../panes/editor.rst:23
+msgid ""
+"The left sidebar shows line numbers and displays any code analysis "
+"warnings that exist in the current file. Clicking a line number selects "
+"the text on that line, and clicking to the right of it sets a "
+":ref:`breakpoint <debugging-breakpoints>`."
+msgstr ""
+
+#: ../../panes/editor.rst:25
+msgid "The scrollbars allow vertical and horizontal navigation in a file."
+msgstr ""
+
+#: ../../panes/editor.rst:26
+msgid ""
+"The context (right-click) menu displays actions relevant to whatever was "
+"clicked."
+msgstr ""
+
+#: ../../panes/editor.rst:27
+msgid ""
+"The options menu (\"Hamburger\" icon at top right) includes useful "
+"settings and actions relevant to the Editor."
+msgstr ""
+
+#: ../../panes/editor.rst:28
+msgid ""
+"The location bar at the top of the Editor pane shows the full path of the"
+" current file."
+msgstr ""
+
+#: ../../panes/editor.rst:29
+msgid ""
+"The tab bar displays the names of all opened files. It also has a "
+":guilabel:`Browse tabs` button (at left) to show every open tab and "
+"switch between them—which comes in handy if many are open."
+msgstr ""
+
+#: ../../panes/editor.rst:36
+msgid "Interface"
+msgstr ""
+
+#: ../../panes/editor.rst:39
+msgid "Tabs"
+msgstr ""
+
+#: ../../panes/editor.rst:41
+msgid ""
+"You can browse and navigate between open files in the Editor with tabs. "
+"Click the :guilabel:`Browse tabs` button on the left of the tab bar to "
+"display a list of open files, with the active tab checked."
+msgstr ""
+
+#: ../../panes/editor.rst:47
+msgid ""
+"Reorder files by dragging and dropping, or with :guilabel:`Sort tabs "
+"alphabetically` in the options menu, which also allows closing all tabs "
+"to the right of, or all tabs but the active one."
+msgstr ""
+
+#: ../../panes/editor.rst:54
+msgid "File switcher"
+msgstr ""
+
+#: ../../panes/editor.rst:56
+msgid ""
+"The Editor features a file switcher, which enables you to navigate and "
+"switch between multiple open files. The file switcher is helpful for "
+"locating any file when there are several files opened."
+msgstr ""
+
+#: ../../panes/editor.rst:62
+msgid ""
+"It can be accessed from the :menuselection:`File --> File Switcher` menu "
+"or :kbd:`Ctrl-P`, and includes a search function. You can type in any "
+"part of an open file's name and—if exists—it can be switched to by "
+"pressing :kbd:`Enter`."
+msgstr ""
+
+#: ../../panes/editor.rst:70
+msgid "Split panels"
+msgstr ""
+
+#: ../../panes/editor.rst:72
+msgid ""
+"The Editor can be split horizontally and vertically into as many distinct"
+" panels as desired. This allows viewing and editing the contents of "
+"several files (or different parts of the same file) at the same time."
+msgstr ""
+
+#: ../../panes/editor.rst:78
+msgid ""
+"Split the Editor with the :guilabel:`Split vertically` (:kbd:`Ctrl-"
+"Shift-{`) and :guilabel:`Split horizontally` (:kbd:`Ctrl-Shift--`) "
+"commands in the options menu, and use :guilabel:`Close this panel` (:kbd"
+":`Alt-Shift-W`) to close the selected split panel."
+msgstr ""
+
+#: ../../panes/editor.rst:80
+msgid ""
+":menuselection:`Close this panel` closes a split panel, while "
+":menuselection:`Close` hides the entire Editor *pane* (including all "
+"splits, which are restored when the Editor is re-opened)."
+msgstr ""
+
+#: ../../panes/editor.rst:86
+msgid "Editing features"
+msgstr ""
+
+#: ../../panes/editor.rst:89
+msgid "Syntax highlighting"
+msgstr ""
+
+#: ../../panes/editor.rst:91
+msgid ""
+"To improve the readability of your code, Spyder has a syntax highlighting"
+" feature that determines the color and style of text in the Editor, as "
+"well as in the :doc:`ipythonconsole`."
+msgstr ""
+
+#: ../../panes/editor.rst:93
+msgid ""
+"You can configure and preview syntax highlighting themes and fonts under "
+":menuselection:`Preferences --> Appearance`. The :guilabel:`Syntax "
+"highlighting theme` section allows you to change the color and style of "
+"the syntax elements and background to match your preferences. You can "
+"switch between available themes in the drop-down menu, modify the "
+"selected theme, create a new theme, and more. The :guilabel:`Fonts` "
+"section lets you change the text font and size."
+msgstr ""
+
+#: ../../panes/editor.rst:101
+msgid ""
+"Changes made to the syntax highlighting theme and font settings are "
+"common to all source files, regardless of their language."
+msgstr ""
+
+#: ../../panes/editor.rst:105
+msgid "Code cells"
+msgstr ""
+
+#: ../../panes/editor.rst:107
+msgid ""
+"A \"code cell\" in Spyder is a block of lines, typically in a script, "
+"that can be easily executed all at once in the current "
+":doc:`ipythonconsole`. This is similar to \"cell\" behavior in Jupyter "
+"Notebook and MATLAB. You can divide your scripts into as many cells as "
+"needed, or none at all—the choice is yours."
+msgstr ""
+
+#: ../../panes/editor.rst:114
+msgid "You can separate cells by lines starting with either:"
+msgstr ""
+
+#: ../../panes/editor.rst:116
+#, python-format
+msgid "``# %%`` (standard cell separator), or"
+msgstr ""
+
+#: ../../panes/editor.rst:117
+msgid "``# <codecell>`` (IPython notebook cell separator)"
+msgstr ""
+
+#: ../../panes/editor.rst:119
+#, python-format
+msgid ""
+"Providing a description to the right of the separator will give that cell"
+" its own name in the :doc:`outline`. You can also create \"subsections\" "
+"by adding more ``%`` signs to the cell separator, e.g. ``# %%%`` to "
+"create a level 2 subsection, ``# %%%%`` for level 3, etc. This displays "
+"multiple levels in the :doc:`outline` pane."
+msgstr ""
+
+#: ../../panes/editor.rst:126
+msgid ""
+"This only affects how the cell is displayed in the :doc:`outline`, and "
+"doesn't affect running it in the Editor."
+msgstr ""
+
+#: ../../panes/editor.rst:128
+msgid ""
+"To run the code in a cell, use :menuselection:`Run --> Run cell`, the "
+":guilabel:`Run cell` button in the toolbar or the keyboard shortcut (:kbd"
+":`Ctrl-Enter`/:kbd:`Cmd-Return` by default). You can also run a cell and "
+"then jump to the next one, letting you quickly step through multiple "
+"cells, using :menuselection:`Run --> Run cell and advance` (:kbd:`Shift-"
+"Enter` by default)."
+msgstr ""
+
+#: ../../panes/editor.rst:133
+msgid "Automatic formatting"
+msgstr ""
+
+#: ../../panes/editor.rst:135
+msgid ""
+"The Editor has built-in support for automatically formatting your code "
+"using several popular tools, including `Autopep8 "
+"<https://github.com/hhatto/autopep8>`_ and `Black "
+"<https://black.readthedocs.io/en/stable/>`_. The :guilabel:`Format file "
+"or selection with {tool}` command in the :guilabel:`Source` or context "
+"menu will format either the selected fragment (if text is selected) or "
+"the entire active file."
+msgstr ""
+
+#: ../../panes/editor.rst:141
+msgid ""
+"You can have the Editor automatically autoformat a file every time you "
+"save your work. To set this up, go to :menuselection:`Preferences --> "
+"Completion and linting --> Code style and formatting --> Code formatting`"
+" and check the :guilabel:`Autoformat files on save` option."
+msgstr ""
+
+#: ../../panes/editor.rst:151
+msgid "Running code"
+msgstr ""
+
+#: ../../panes/editor.rst:153
+msgid ""
+"The Editor lets you run an entire file as well as specific lines, "
+"selections or cells."
+msgstr ""
+
+#: ../../panes/editor.rst:155
+msgid "As your code is running,"
+msgstr ""
+
+#: ../../panes/editor.rst:157
+msgid "The :doc:`ipythonconsole` will display output and errors."
+msgstr ""
+
+#: ../../panes/editor.rst:158
+msgid ""
+"The :doc:`variableexplorer` allows you to browse and interact with the "
+"objects generated."
+msgstr ""
+
+#: ../../panes/editor.rst:159
+msgid "The :doc:`plots` pane renders the figures and images created."
+msgstr ""
+
+#: ../../panes/editor.rst:163
+msgid "Run file"
+msgstr ""
+
+#: ../../panes/editor.rst:165
+msgid ""
+"Run an entire Editor file using the :menuselection:`Run --> Run` menu "
+"item, the :guilabel:`Run file` toolbar button or the :kbd:`F5` key. Use "
+":menuselection:`Run --> Re-Run last script` to re-run the most recent "
+"file executed with the above."
+msgstr ""
+
+#: ../../panes/editor.rst:170
+msgid "Run line/selection"
+msgstr ""
+
+#: ../../panes/editor.rst:172
+msgid ""
+"You can execute the current line—or multiple selected lines—using the "
+":guilabel:`Run selection or current line` option from the toolbar or the "
+":menuselection:`Run` menu, as well as with the :kbd:`F9` key. After "
+"running the current line, the cursor automatically advances to the next "
+"one, so you can step through your code line by line. Unlike "
+":guilabel:`Run file`, the executed lines are shown in the "
+":doc:`ipythonconsole`."
+msgstr ""
+
+#: ../../panes/editor.rst:178
+msgid "Run cell"
+msgstr ""
+
+#: ../../panes/editor.rst:180
+msgid ""
+"To run a cell, place your cursor inside it and use the "
+":menuselection:`Run --> Run cell` menu item, the :guilabel:`Run current "
+"cell` toolbar button or the :kbd:`Ctrl-Enter` / :kbd:`Cmd-Return` "
+"keyboard shortcut. Use :guilabel:`Run cell and advance` in the "
+":guilabel:`Run` menu/toolbar or :kbd:`Shift-Enter` to jump to the next "
+"cell after running, useful for stepping through cells quickly."
+msgstr ""
+
+#: ../../panes/editor.rst:185
+msgid "Run configuration"
+msgstr ""
+
+#: ../../panes/editor.rst:187
+msgid ""
+"You can use the :guilabel:`Run configuration per file` dialog to set each"
+" file's working directory, console mode (current, dedicated or external),"
+" command line arguments, execution options (clear all variables, run in "
+"an existing/empty namespace, debug on error), and more."
+msgstr ""
+
+#: ../../panes/editor.rst:192
+msgid ""
+"To access it, click :menuselection:`Run --> Configuration per file...` or"
+" press :kbd:`Ctrl-F6` / :kbd:`Cmd-F6`."
+msgstr ""
+
+#: ../../panes/editor.rst:198
+msgid "Code navigation"
+msgstr ""
+
+#: ../../panes/editor.rst:201
+msgid "Find and replace"
+msgstr ""
+
+#: ../../panes/editor.rst:203
+msgid ""
+"To search for text in the current file, use :menuselection:`Search --> "
+"Find text` or :kbd:`Ctrl-F` / :kbd:`Cmd-F`, and to replace it, use "
+":menuselection:`Search --> Replace text` or :kbd:`Ctrl-R` / :kbd:`Cmd-R`."
+" Typing your search string in the resulting panel below the Editor "
+"highlights each result and counts the total. Navigate between matches "
+"with the :guilabel:`Find Previous` and :guilabel:`Find Next` buttons in "
+"the find/replace panel, their corresponding entries in the "
+":guilabel:`Search` menu, or use the :kbd:`F2` and :kbd:`F3` keys. Use the"
+" :guilabel:`.*` button to process search text as a `regular expression "
+"<https://docs.python.org/3/library/re.html>`_, :guilabel:`Aa` to treat it"
+" as case-sensitive and :guilabel:`[–]` to only match whole words (e.g. "
+"for ``data``, match ``data()`` but not ``dataframe``)."
+msgstr ""
+
+#: ../../panes/editor.rst:213
+msgid "Go to line"
+msgstr ""
+
+#: ../../panes/editor.rst:215
+msgid ""
+"The :guilabel:`Go to line` dialog allows jumping to a specific line in "
+"the active file. Open it with :menuselection:`Search --> Go to line` or "
+":kbd:`Ctrl-L` / :kbd:`Cmd-L`, type the line number you want to scroll to "
+"and press :kbd:`Enter` (or click :guilabel:`OK`)."
+msgstr ""
+
+#: ../../panes/editor.rst:221
+msgid "It also shows the current line number and total line count in the file."
+msgstr ""
+
+#: ../../panes/editor.rst:225
+msgid "Class/function selector"
+msgstr ""
+
+#: ../../panes/editor.rst:227
+msgid ""
+"This panel, activated under :menuselection:`Source --> Show selector for "
+"classes and functions`, displays (as applicable) the name of the cell, "
+"function/method and class the Editor cursor is located inside. Use its "
+"dropdowns to view and jump to the functions, methods and classes in the "
+"current file."
+msgstr ""
+
+#: ../../panes/editor.rst:237
+msgid "Code analysis and completions"
+msgstr ""
+
+#: ../../panes/editor.rst:239
+msgid ""
+"Spyder uses the `Language Server Protocol <https://microsoft.github.io"
+"/language-server-protocol/>`_ (LSP) to provide code completion and "
+"linting for the Editor, similar to VSCode, Neovim, and other popular "
+"editors/IDEs."
+msgstr ""
+
+#: ../../panes/editor.rst:243
+msgid ""
+"Many issues with completion and linting are outside of Spyder's control, "
+"and are either limitations with the LSP or the code that is being "
+"introspected, but some can be worked around. See :ref:`code-completion-"
+"problems-ref` for troubleshooting steps."
+msgstr ""
+
+#: ../../panes/editor.rst:246
+msgid ""
+"Python is supported out of the box, and advanced users can add completion"
+" and linting support for other languages by setting up LSP servers for "
+"them under :menuselection:`Preferences --> Completion and Linting --> "
+"Other languages`."
+msgstr ""
+
+#: ../../panes/editor.rst:250
+msgid "Code completion"
+msgstr ""
+
+#: ../../panes/editor.rst:252
+msgid ""
+"Automatic code completion as you type is enabled by default in the "
+"Editor, and can also be triggered manually with :kbd:`Ctrl-Space`/:kbd"
+":`Cmd-Space`, showing you possible completions (with pop-up help for "
+"each) and available code snippets. For example, typing ``cla`` will "
+"display the keyword ``class``, the decorator ``classmethod`` and two "
+"built-in snippets with class templates. Select the desired completion "
+"with the arrow keys and :kbd:`Enter`, or by double clicking."
+msgstr ""
+
+#: ../../panes/editor.rst:259
+msgid ""
+"You can enable or disable on-the-fly code completion, as well as modify "
+"when it is triggered and what results are shown, under "
+":menuselection:`Preferences --> Completion and Linting --> General --> "
+"Completions`. Spyder also allows you to define custom completion snippets"
+" to use, in addition to the ones offered by the LSP, under "
+":menuselection:`Preferences --> Completion and Linting --> Advanced`."
+msgstr ""
+
+#: ../../panes/editor.rst:264
+msgid "Linting and code style"
+msgstr ""
+
+#: ../../panes/editor.rst:266
+msgid ""
+"Spyder can optionally highlight syntax errors, style issues, and other "
+"potential problems with your code in the Editor, which can help you spot "
+"bugs quickly and make your code easier to read and understand."
+msgstr ""
+
+#: ../../panes/editor.rst:271
+msgid ""
+"The Editor's basic linting, powered by `Pyflakes "
+"<https://github.com/PyCQA/pyflakes>`_, warns of syntax errors and likely "
+"bugs in your code. It is on by default, and can be disabled or customized"
+" under :menuselection:`Preferences --> Completion and Linting --> "
+"Linting`."
+msgstr ""
+
+#: ../../panes/editor.rst:277
+msgid ""
+"Code style analysis, powered by `Pycodestyle "
+"<https://pycodestyle.pycqa.org/en/stable/>`_, flags deviations from the "
+"style conventions in :pep:`8`. It is not active by default, but you can "
+"enable it and customize the `Pycodestyle error codes "
+"<https://pycodestyle.pycqa.org/en/stable/intro.html#error-codes>`_ shown "
+"with the options under :menuselection:`Preferences --> Completion and "
+"Linting --> Code style and formatting --> Code Style`."
+msgstr ""
+
+#: ../../panes/editor.rst:285
+msgid "Introspection features"
+msgstr ""
+
+#: ../../panes/editor.rst:287
+msgid ""
+"If there's a function, class or variable for which you would like to "
+"check its definition, you need to :kbd:`Ctrl`/:kbd:`Cmd`-click its name "
+"in the Editor (or click its name and press :kbd:`Ctrl-G` / :kbd:`Cmd-G` "
+"to jump to the file and line where it is declared."
+msgstr ""
+
+#: ../../panes/editor.rst:292
+msgid ""
+"You can hover over the name of an object for pop-up help, as "
+":ref:`described in the Help pane docs <help-hover-hints>`."
+msgstr ""
+
+#: ../../panes/editor.rst:297
+msgid ""
+"Finally, if you type the name of a function, method or class constructor "
+"and then an open parenthesis, a calltip will pop up which shows the "
+"function's parameters as you type them, as well as a summary of its "
+"documentation. These features can be enabled and customized under "
+":menuselection:`Preferences --> Completion and Linting --> "
+"Introspection`."
+msgstr ""
+
+#: ../../panes/editor.rst:304
+msgid "Keyboard shortcuts"
+msgstr ""
+
+#: ../../panes/editor.rst:306
+msgid ""
+"To view the Editor's primary keyboard shortcuts, consult its section "
+"under :menuselection:`Help --> Shortcuts Summary`. The full list can be "
+"browsed, searched and customized (on double-click) in "
+":menuselection:`Preferences --> Keyboard shortcuts`."
+msgstr ""
+
+#: ../../panes/editor.rst:315 ../../panes/findinfiles.rst:68
+#: ../../panes/outline.rst:57 ../../panes/projects.rst:65
+msgid ":doc:`fileexplorer`"
+msgstr ""
+
+#: ../../panes/editor.rst:316 ../../panes/fileexplorer.rst:102
+msgid ":doc:`findinfiles`"
+msgstr ""
+
+#: ../../panes/editor.rst:318 ../../panes/fileexplorer.rst:103
+#: ../../panes/outline.rst:58
+msgid ":doc:`projects`"
+msgstr ""
+
+#: ../../panes/editor.rst:319 ../../panes/profiler.rst:102
+msgid ":doc:`pylint`"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:3
+msgid "Files"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:5
+msgid ""
+"The **Files** pane is a filesystem and directory browser built right into"
+" Spyder. You can view and filter files according to their type and "
+"extension, open them with the :doc:`editor` or an external tool, and "
+"perform many common operations."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:17
+msgid "File operations"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:19
+msgid ""
+"To browse the files on your system, use the arrows at the top of the "
+"pane. You can expand/collapse the folders in the pane to display the "
+"files and subdirectories hierarchically. Double-clicking a folder will "
+"open it, showing the files inside and making it your working directory."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:26
+msgid ""
+"To open a file in the :guilabel:`Editor` from the :guilabel:`Files` pane,"
+" double-click its name. If you right-click over it, you will see a "
+"context menu that allows you to access a number of functions, including "
+"running scripts; creating, renaming, moving, deleting files; and opening "
+"them in your computer's file manager."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:32
+msgid ""
+"You can copy and paste one or several files to and from the pane, and "
+"copy their absolute or relative paths to the clipboard as text. If "
+"copying the paths for multiple files, they will be automatically "
+"formatted so you can paste them directly into a Python list."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:44
+msgid "Version control support"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:46
+msgid ""
+"The :guilabel:`Files` pane allows you to perform basic operations with "
+"the `Git`_ distributed version control system, like committing your "
+"changes and browsing the repository a given file or folder is part of. "
+"This is :ref:`particularly useful<vcs-section>` when you're working in "
+"Spyder :doc:`projects`."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:58 ../../panes/ipythonconsole.rst:65
+#: ../../panes/outline.rst:16 ../../panes/plots.rst:20
+#: ../../panes/pylint.rst:50 ../../panes/variableexplorer.rst:103
+msgid "Options menu"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:60
+msgid ""
+"The options menu in the top right of the :guilabel:`Files` pane offers "
+"several ways to customize how your files are displayed."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:62
+msgid ""
+"By default, the pane displays the contents of your working directory "
+"without filtering. However, it can filter the list to show only files "
+"matching the patterns set under :guilabel:`Show filenames with these "
+"extensions...`, if you toggle the :guilabel:`Filter filenames` button in "
+"the pane toolbar."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:68
+msgid ""
+"You can also activate the :guilabel:`Show hidden files` option, which "
+"will display files that are invisible by default in your operating "
+"system."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:70
+msgid ""
+"Additionally, you can change which file attributes you want to see by "
+"hiding or displaying the :guilabel:`Type`, :guilabel:`Size` and "
+":guilabel:`Date Modified` columns using the corresponding menu options."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:75
+msgid ""
+"The menu also gives you the option to open files and directories with a "
+"single instead of a double click, to suit your preferences."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:81
+msgid "File associations"
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:83
+msgid ""
+":guilabel:`Files` allows you to associate different external applications"
+" with specific file extensions they can open. Under the :guilabel:`File "
+"associations` tab of the :guilabel:`Files` preferences pane, you can add "
+"file types and set the external program used to open each of them by "
+"default."
+msgstr ""
+
+#: ../../panes/fileexplorer.rst:89
+msgid ""
+"Once you've set this up, files will automatically launch in the "
+"associated application when opened from Spyder's :guilabel:`Files` pane. "
+"Additionally, when you right-click a file, you will find an "
+":guilabel:`Open with...` option that will allow you to select from the "
+"applications associated with this extension."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:3
+msgid "Find"
+msgstr ""
+
+#: ../../panes/findinfiles.rst:5
+msgid ""
+"The **Find** pane allows you to search the content of text files in a "
+"user-defined location, with advanced features to filter your results."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:14
+msgid "Using the Find pane"
+msgstr ""
+
+#: ../../panes/findinfiles.rst:16
+msgid ""
+"To search for text in the Find pane, enter it in the field in the top "
+"left and press the search button. This will allow you to view and "
+"navigate through all the occurrences of your search text in your working "
+"directory. You can expand or collapse the search results to view the "
+"matches in each file. Clicking on a match will automatically open the "
+"file and highlight the line where the text was found."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:24
+msgid ""
+"If you want to change the scope of your search, select another directory,"
+" project or file in the :guilabel:`Search in` menu. The locations that "
+"you select for your search will be stored in the list so you can access "
+"them easily in the future. To erase all of these saved directories, "
+"select the :guilabel:`Clear the list` option from the dropdown menu in "
+"the :guilabel:`Search in` field."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:35
+msgid "Choosing search options"
+msgstr ""
+
+#: ../../panes/findinfiles.rst:37
+msgid ""
+"You can select from a number of options to enable searches as broad or "
+"refined as you need."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:39
+msgid ""
+"To enable case sensitivity, which only returns matches with identical "
+"capitalization to your search text, toggle the :guilabel:`Aa` button on."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:44
+msgid ""
+"To parse your search string as a `regular expression`_, enable the "
+":guilabel:`.*` button."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:51
+msgid ""
+"To exclude certain filenames, extensions or directories from your search,"
+" click the :guilabel:`Plus` button to display the advanced options for "
+"the pane, and then enter them in the :guilabel:`Exclude` text box."
+msgstr ""
+
+#: ../../panes/findinfiles.rst:56
+msgid ""
+"Finally, to change the number of matches displayed, select the "
+":guilabel:`Set maximum number of results` option under the pane's Options"
+" menu in the top right."
+msgstr ""
+
+#: ../../panes/help.rst:3
+msgid "Help"
+msgstr ""
+
+#: ../../panes/help.rst:5
+msgid ""
+"You can use the **Help** pane to find, render and display rich "
+"documentation for any object with a docstring, including modules, "
+"classes, functions and methods. This allows you to access documentation "
+"easily directly from Spyder, without having to interrupt your workflow."
+msgstr ""
+
+#: ../../panes/help.rst:11
+msgid ""
+"You can also access Spyder's tutorial from here, which will guide you "
+"through some basic steps for using its key features."
+msgstr ""
+
+#: ../../panes/help.rst:21
+msgid "Getting help"
+msgstr ""
+
+#: ../../panes/help.rst:23
+msgid ""
+"Help can be retrieved both by static analysis of open files in the "
+":doc:`editor`, or by dynamically inspecting an object in an "
+":doc:`ipythonconsole`. You can trigger help manually by pressing the "
+"configurable help shortcut (:kbd:`Ctrl-I` by default)."
+msgstr ""
+
+#: ../../panes/help.rst:29
+msgid ""
+"You can also manually enter the object's name into the :guilabel:`Object`"
+" textbox at the top of the pane, if :guilabel:`Console` is selected as "
+"the :guilabel:`Source`."
+msgstr ""
+
+#: ../../panes/help.rst:34
+msgid ""
+"Automatic help can be individually enabled for both the "
+":guilabel:`Editor` and the :guilabel:`Console` under "
+":menuselection:`Preferences --> Help --> Automatic Connections`, and "
+"turned on and off dynamically via the lock icon in the top right corner "
+"of the :guilabel:`Help` pane. If enabled, simply typing a left "
+"parenthesis (``(``) after a function or method name will show its "
+"associated help."
+msgstr ""
+
+#: ../../panes/help.rst:44
+msgid "Understanding help modes"
+msgstr ""
+
+#: ../../panes/help.rst:46
+msgid ""
+"You can use the options menu (:guilabel:`Hamburger` icon) in the top "
+"right of the :guilabel:`Help` pane to toggle the help display mode."
+msgstr ""
+
+#: ../../panes/help.rst:48
+msgid ""
+":guilabel:`Rich Text` mode renders the object's docstrings with "
+"``Sphinx``, :guilabel:`Plain Text` mode displays the docstring without "
+"formatting while :guilabel:`Show Source` displays the docstring inline "
+"with the code for the selected object, or any Python portion of it (if "
+"the object is not pure Python). The latter can be useful when docstrings "
+"are not available or insufficient to document the object."
+msgstr ""
+
+#: ../../panes/help.rst:59
+msgid "Getting help by hovering"
+msgstr ""
+
+#: ../../panes/help.rst:61
+msgid ""
+"You can also get summary help for objects by hovering over them in the "
+":guilabel:`Editor`. Clicking the hover popup will open the full "
+"documentation in the :guilabel:`Help` pane."
+msgstr ""
+
+#: ../../panes/help.rst:71
+msgid "Control automatic import"
+msgstr ""
+
+#: ../../panes/help.rst:73
+msgid ""
+"When you get help in the :guilabel:`IPython Console` for an object that "
+"has not been previously imported, it is automatically loaded in Spyder's "
+"own internal interpreter so that documentation can be shown when "
+"available. This can be disabled in the :guilabel:`Help` pane's top-right "
+"options menu so that only documentation from imported objects is "
+"displayed."
+msgstr ""
+
+#: ../../panes/help.rst:84
+msgid ":doc:`onlinehelp`"
+msgstr ""
+
+#: ../../panes/historylog.rst:3
+msgid "History"
+msgstr ""
+
+#: ../../panes/historylog.rst:5
+msgid ""
+"With the **History** pane, you can view the recent code and commands "
+"you've entered into any :doc:`ipythonconsole`, along with their "
+"timestamp."
+msgstr ""
+
+#: ../../panes/historylog.rst:14
+msgid "Using the History pane"
+msgstr ""
+
+#: ../../panes/historylog.rst:16
+msgid ""
+"Navigating the :guilabel:`History` pane is very straightforward. Each "
+"Spyder session is marked by a date and timestamp, making it easy to "
+"remember when you executed a certain command. Statements can be selected "
+"and copied from the context menu or with the normal system shortcuts. "
+"Just like in the Editor, selecting a word or phrase displays all other "
+"occurrences, and full syntax highlighting is also supported. The last "
+"≈1000 lines entered are stored in the pane."
+msgstr ""
+
+#: ../../panes/historylog.rst:26
+msgid "Options Menu"
+msgstr ""
+
+#: ../../panes/historylog.rst:28
+msgid ""
+"The top-right options menu (:guilabel:`Hamburger` icon) allows you to "
+"toggle wrapping of long lines (:guilabel:`Wrap lines`), and whether the "
+"line number is displayed to the left of the text (:guilabel:`Show line "
+"numbers`)."
+msgstr ""
+
+#: ../../panes/historylog.rst:37
+msgid "Advanced usage"
+msgstr ""
+
+#: ../../panes/historylog.rst:39
+msgid ""
+"The list of commands shown in the :guilabel:`History` pane are stored in "
+":file:`history.py` in the :file:`.spyder-py3` directory in your user home"
+" folder (by default, :file:`C:/Users/{username}` on Windows, "
+":file:`/Users/{username}` for macOS, and typically "
+":file:`/home/{username}` on GNU/Linux). You might need to show invisible "
+"files in order to see it on a non-Windows operating system."
+msgstr ""
+
+#: ../../panes/historylog.rst:45
+msgid ""
+"While there is currently no built-in way to clear history from the Spyder"
+" interface aside from resetting preferences, you can do so by closing "
+"Spyder, deleting this file and restarting Spyder again."
+msgstr ""
+
+#: ../../panes/index.rst:3
+msgid "Panes in Depth"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:3
+msgid "IPython Console"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:5
+msgid ""
+"The **IPython Console** allows you to execute commands and interact with "
+"data inside `IPython`_ interpreters."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:12
+msgid ""
+"To launch a new IPython instance, go to :guilabel:`New console (default "
+"settings)` under the :guilabel:`Consoles` menu, or use the keyboard "
+"shortcut :kbd:`Ctrl-T` (:kbd:`Cmd-T` on macOS) when the console is "
+"focused."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:17
+msgid ""
+"From the same menu, you can stop currently executing code with "
+":guilabel:`Interrupt kernel`, clear a console's namespace with "
+":guilabel:`Remove all variables`, or relaunch a fresh one with "
+":guilabel:`Restart kernel`. As each console is executed in a separate "
+"process, this won't affect any others you've opened, and you will be able"
+" to easily test your code in a clean environment without disrupting your "
+"primary session."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:26
+msgid "Supported features"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:28
+msgid ""
+"Any :guilabel:`IPython Console`, whether :ref:`external<connecting-"
+"external-kernel>` or started by Spyder, supports:"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:30
+msgid "Automatic code completion"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:31
+msgid "Real-time function calltips"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:32
+msgid "Full GUI integration with the enhanced Spyder :doc:`Debugger<debugging>`."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:33
+msgid ""
+"The :doc:`variableexplorer`, with GUI-based editors for many built-in and"
+" third-party Python objects."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:34
+msgid ""
+"Display of Matplotlib graphics in Spyder's :doc:`plots` pane, if the "
+":guilabel:`Inline` backend is selected under :menuselection:`Preferences "
+"--> IPython console --> Graphics --> Graphics backend`, and inline in the"
+" console if :guilabel:`Mute inline plotting` is unchecked under the "
+":guilabel:`Plots` pane's options menu."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:39
+msgid ""
+"For information on the features, commands and capabilities built into "
+"IPython itself, see the `IPython documentation`_."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:47
+msgid "Special consoles"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:49
+msgid ""
+"Spyder also supports several types of specialized consoles. A `Sympy "
+"console`_ enables creating and displaying symbolic math expressions right"
+" inside Spyder. A `Cython console`_ allows you to use the Cython language"
+" to speed up your code and call C functions directly from Python. "
+"Finally, a `Pylab console`_ loads common Numpy and Matplotlib functions "
+"by default; while this is deprecated and strongly discouraged for new "
+"code, it can still be used if necessary for legacy scripts that need it."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:67
+msgid ""
+"The options menu allows you to inspect your current environment variables"
+" (:guilabel:`Show environment variables`), and the contents of your "
+"system's ``PATH`` (:guilabel:`Show sys.path contents`). In addition, you "
+"can have each console display how long it has been running with "
+":guilabel:`Show elapsed time`."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:73
+msgid ""
+"You can also change the name of the current :guilabel:`IPython console` "
+"tab with the :guilabel:`Rename tab` option, or by simply double-clicking "
+"it."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:84
+msgid "Using external kernels"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:86
+msgid ""
+"You can connect to external local and remote kernels (including those "
+"managed by Jupyter Notebook or QtConsole) through the :guilabel:`Connect "
+"to an existing kernel` dialog under the :guilabel:`Consoles` menu. For "
+"this feature to work, a compatible version of the ``spyder-kernels`` "
+"package :ref:`must be installed <starting-kernel-problems-ref>` in the "
+"environment or machine in which the external kernel is running."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:94
+msgid "Connect to a local kernel"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:96
+msgid ""
+"To connect to a local kernel that is already running (e.g. one started by"
+" Jupyter notebook),"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:98
+#, python-format
+msgid ""
+"Run ``%connect_info`` in the notebook or console you want to connect to, "
+"and copy the name of its kernel connection file, shown after ``jupyter "
+"<app> --existing``."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:103
+msgid ""
+"In Spyder, click :guilabel:`Connect to an existing kernel` from the "
+":guilabel:`Consoles` menu, and paste the name of the "
+":guilabel:`Connection file` from the previous step."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:105
+msgid ""
+"As a convenience, kernel ID numbers (e.g. ``1234``) entered in the "
+"connection file path field will be expanded to the full path of the file,"
+" i.e. :file:`{jupyter/runtime/dir/path}/kernal-{id}.json`."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:110
+msgid "Click :guilabel:`OK` to connect to the kernel."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:117
+msgid "Connect to a remote kernel"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:119
+msgid "To connect to a kernel on a remote machine,"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:121
+msgid ""
+"Launch a Spyder kernel on the remote host if one is not already running, "
+"with ``python -m spyder_kernels.console``."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:126
+msgid ""
+"Copy the kernel's connection file "
+"(:file:`{jupyter/runtime/dir/path}/kernel-{pid}.json`) to the machine "
+"you're running Spyder on."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:128
+msgid ""
+"You can get :file:`{jupyter/runtime/dir/path}` by executing ``jupyter "
+"--runtime-dir`` in the same Python environment as the kernel. Usually, "
+"the connection file you are looking for will be one of the newest in this"
+" directory, corresponding to the time you started the external kernel."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:134
+msgid ""
+"Click :guilabel:`Connect to an existing kernel` from the "
+":guilabel:`Consoles` menu, and browse for or enter the path to the "
+"connection file from the previous step."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:136
+msgid ""
+"As a convenience, kernel ID numbers (e.g. ``1234``) entered in the "
+"connection file path field will be expanded to "
+":file:`{jupyter/runtime/dir/path}/kernal-{id}.json` on your local "
+"machine, if you've copied the connection file there."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:141
+msgid ""
+"Check the :guilabel:`This is a remote kernel (via SSH)` box and enter the"
+" :guilabel:`Hostname` or IP address, username and port to connect to on "
+"the remote machine. Then, enter *either* :file:`{username}`'s password on"
+" the remote machine, or browse to an SSH keyfile (typically in the "
+":file:`.ssh` directory in your home folder on the local machine, often "
+"called :file:`id_rsa` or similar) registered on it; only one is needed to"
+" connect. If you check :guilabel:`Save connection settings`, these "
+"details will be remembered and filled for you automatically next time you"
+" open the dialog."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:145
+msgid ""
+"Note that :guilabel:`Port` is the port number on your remote machine that"
+" the SSH daemon (``sshd``) is listening on, typically 22 unless you or "
+"your administrator has configured it otherwise."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:150
+msgid "Click :guilabel:`OK` to connect to the remote kernel"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:155
+msgid ""
+"For more technical details about connecting to remote kernels, see the "
+"`Connecting to a remote kernel`_ page in the IPython Cookbook."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:165
+msgid "Reload changed modules"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:167
+msgid ""
+"When working in an interactive session, Python only loads a module from "
+"its source file once, the first time it is imported."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:169
+msgid ""
+"Spyder's :guilabel:`User Module Reloader` (UMR) automatically reloads "
+"modules right in your existing IPython consoles whenever they are "
+"modified and re-imported. With the UMR enabled, you can test changes to "
+"your code without restarting the kernel."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:175
+msgid ""
+"UMR is enabled by default, and it will provide you with a red ``Reloaded "
+"modules:`` message in the console listing the files it has refreshed when"
+" it is activated. If desired, you can turn it on or off, and prevent "
+"specific modules from being reloaded, under :menuselection:`Preferences "
+"--> Python interpreter --> User Module Reloader (UMR)`."
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:187 ../../panes/variableexplorer.rst:196
+msgid ":doc:`debugging`"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:189 ../../panes/onlinehelp.rst:88
+msgid ":doc:`help`"
+msgstr ""
+
+#: ../../panes/ipythonconsole.rst:190
+msgid ":doc:`historylog`"
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:3
+msgid "Online Help"
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:5
+msgid ""
+"The **Online Help** pane provides a built-in web browser to explore "
+"dynamically generated Python documentation on installed modules—including"
+" your own—rendered by a `pydoc`_ server running in the background."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:16
+msgid "Using the Online Help"
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:18
+msgid ""
+"The Online Help's home shows an index where you can browse the "
+"documentation of standard library modules, third party packages installed"
+" in your Python environment, and your own local code. Click on the name "
+"of any module to open its documentation."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:24
+msgid ""
+"Enter the name of the item you'd like help on in the :guilabel:`Package` "
+"field to load its documentation directly."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:29
+msgid ""
+"The module's file location is linked to the right of the doc's title, "
+"which you can click to view its source code."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:34
+msgid ""
+"Standard library modules also have a link to the corresponding `Python "
+"docs`_, which can be viewed right inside of the pane."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:41
+msgid ""
+"If you're not sure of the name of the object you want help on, or are "
+"looking for a specific keyword, use the :guilabel:`Search` field to get a"
+" list of results."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:46
+msgid ""
+"Links above the search field provide an index of topics with general help"
+" and a list of Python keywords linked to their corresponding docs."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:55
+msgid "Toolbar items"
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:57
+msgid ""
+"Just like in a web browser, the forward and back buttons move through the"
+" pages you have visited, and the home button (house icon) returns you to "
+"the module index."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:62
+msgid ""
+"Perform a realtime search within a page's content with the "
+":guilabel:`Find` button (magnifying glass icon top left) or "
+":kbd:`Ctrl-F`, navigate through matches with the Up and Down buttons, and"
+" make matching case sensitive with the :guilabel:`Aa` button."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:67
+msgid ""
+"You can view and re-run previous searches from the drop-down menu in the "
+":guilabel:`Package` field."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:72
+msgid ""
+"You can also use the zoom in/out buttons (:guilabel:`-` and "
+":guilabel:`+`, top right) to change the font size to suit your "
+"preferences."
+msgstr ""
+
+#: ../../panes/onlinehelp.rst:77
+msgid ""
+"To cancel searching or page loading, click the stop button (red square), "
+"and to reload the page (such as when you change your own package's "
+"documentation), press the refresh button (circular arrow)."
+msgstr ""
+
+#: ../../panes/outline.rst:3
+msgid "Outline"
+msgstr ""
+
+#: ../../panes/outline.rst:5
+msgid ""
+"The **Outline** pane allows you to view and navigate the functions, "
+"classes, methods, cells and comments in open Python files. To show or "
+"hide the Outline pane, use :menuselection:`View --> Panes --> Outline` or"
+" :kbd:`Ctrl-Shift-O` / :kbd:`Cmd-Shift-O`. Click an entry in the outline "
+"to jump to its source file location, and use the :guilabel:`Go to cursor "
+"position` toolbar button to highlight the item corresponding to the "
+"current :doc:`editor` position."
+msgstr ""
+
+#: ../../panes/outline.rst:18
+msgid ""
+"The options menu in the top-right of the pane allows customizing how the "
+"outline is displayed."
+msgstr ""
+
+#: ../../panes/outline.rst:23
+msgid "These customization settings include:"
+msgstr ""
+
+#: ../../panes/outline.rst:25
+msgid ""
+":guilabel:`Show absolute path`: Display the full path to each file "
+"instead of just the name."
+msgstr ""
+
+#: ../../panes/outline.rst:26
+msgid ""
+":guilabel:`Show all files`: List every open file rather than just the "
+"current one. This allows using the Outline as a file switcher."
+msgstr ""
+
+#: ../../panes/outline.rst:28
+msgid ""
+":guilabel:`Group code cells`: Group code cells in multiple nested levels "
+"in the outline rather than showing all cells in one level. You can create"
+" subsections by adding more ``%`` signs to the cell separator."
+msgstr ""
+
+#: ../../panes/outline.rst:30
+msgid ""
+":guilabel:`Display variables and attributes`: Display top-level "
+"variable/constant definitions and class attributes in the outline."
+msgstr ""
+
+#: ../../panes/outline.rst:31
+msgid ""
+":guilabel:`Follow cursor position`: Automatically highlight and expand "
+"the entry corresponding to the current cursor position in the "
+":doc:`editor`."
+msgstr ""
+
+#: ../../panes/outline.rst:32
+msgid ""
+":guilabel:`Show special comments`: List special comments in the outline, "
+"which start with ``# ----``."
+msgstr ""
+
+#: ../../panes/outline.rst:33
+msgid ""
+":guilabel:`Sort files alphabetically`: Sort the file list in alphabetical"
+" order. When disabled, all tabs will be sorted by the tab order of the "
+"currently selected Editor panel."
+msgstr ""
+
+#: ../../panes/outline.rst:40
+msgid "Icons"
+msgstr ""
+
+#: ../../panes/outline.rst:42
+msgid "The following icons are used for outline elements:"
+msgstr ""
+
+#: ../../panes/outline.rst:44
+msgid ":guilabel:`m` for methods"
+msgstr ""
+
+#: ../../panes/outline.rst:45
+msgid ":guilabel:`f` for functions"
+msgstr ""
+
+#: ../../panes/outline.rst:46
+msgid ":guilabel:`c` for classes"
+msgstr ""
+
+#: ../../panes/outline.rst:47
+msgid ":guilabel:`%` for code cells"
+msgstr ""
+
+#: ../../panes/outline.rst:48
+msgid ":guilabel:`#` for comments"
+msgstr ""
+
+#: ../../panes/plots.rst:3
+msgid "Plots"
+msgstr ""
+
+#: ../../panes/plots.rst:5
+msgid ""
+"The **Plots** pane shows the static figures and images created during "
+"your session. It will show you plots from the :doc:`ipythonconsole`, "
+"produced by your code in the :doc:`editor` or generated by the "
+":doc:`variableexplorer` allowing you to interact with them in several "
+"ways."
+msgstr ""
+
+#: ../../panes/plots.rst:11
+msgid ""
+"The figures shown in the Plots pane are those associated with the "
+"currently active :guilabel:`Console` tab; if you switch consoles, the "
+"list of plots displayed (or none at all, if a new console) will change "
+"accordingly."
+msgstr ""
+
+#: ../../panes/plots.rst:22
+msgid ""
+"The options menu in the top right of the :guilabel:`Plots` pane offers "
+"several ways to customize how your plots are displayed."
+msgstr ""
+
+#: ../../panes/plots.rst:26
+msgid "Mute inline plotting"
+msgstr ""
+
+#: ../../panes/plots.rst:28
+msgid ""
+"The :guilabel:`Mute inline plotting` option is enabled by default, "
+"preventing your plots from appearing in the Console. If you deactivate "
+"this option, figures will display in both the Plots pane and the Console."
+msgstr ""
+
+#: ../../panes/plots.rst:36
+msgid "Show plot outline"
+msgstr ""
+
+#: ../../panes/plots.rst:38
+msgid ""
+"The :guilabel:`Show plot outline` option, off by default, shows a thin "
+"stroke surrounding the area of the figure area, which will also appear in"
+" the exported images."
+msgstr ""
+
+#: ../../panes/plots.rst:45
+msgid "Fit plots to window"
+msgstr ""
+
+#: ../../panes/plots.rst:47
+msgid ""
+"The :guilabel:`Fit plots to Window` option, also enabled by default, "
+"sizes the figures to match the pane. Disabling it will display plots at "
+"their native size, and allow you use the zoom buttons at the top of the "
+"pane to scale them manually."
+msgstr ""
+
+#: ../../panes/plots.rst:57
+msgid "Toolbar options"
+msgstr ""
+
+#: ../../panes/plots.rst:59
+msgid ""
+"The toolbar at the top of the Plots pane provides several useful features"
+" that allow you to interact with your figures. For example, you can cycle"
+" sequentially through the plot list with the forward and back arrows."
+msgstr ""
+
+#: ../../panes/plots.rst:65
+msgid ""
+"You can also save one or all the plots in the pane to file(s) by clicking"
+" the respective \"save\"/\"save all\" icons in the toolbar. Plots are "
+"rendered and saved as PNG by default, but SVG can be selected as an "
+"option under :menuselection:`Preferences --> IPython console --> Graphics"
+" --> Inline backend --> Format`."
+msgstr ""
+
+#: ../../panes/plots.rst:71
+msgid ""
+"Additionally, if you want to use a figure in another document, you can "
+"click the \"copy to clipboard\" button and paste your plot wherever you "
+"want, such as a word processor."
+msgstr ""
+
+#: ../../panes/plots.rst:76
+msgid ""
+"Finally, you can use the \"remove\" and \"remove all\" buttons in the "
+"toolbar to clear plots from the list."
+msgstr ""
+
+#: ../../panes/profiler.rst:3
+msgid "Profiler"
+msgstr ""
+
+#: ../../panes/profiler.rst:5
+msgid ""
+"The **Profiler** pane recursively determines the run time and number of "
+"calls for every function and method called in a file, breaking down each "
+"procedure into its smallest individual units. This allows you to easily "
+"identify the bottlenecks in your code, points you toward the exact "
+"statements most critical for optimization, and measures the performance "
+"delta after followup changes."
+msgstr ""
+
+#: ../../panes/profiler.rst:15
+msgid "Running the Profiler"
+msgstr ""
+
+#: ../../panes/profiler.rst:17
+msgid ""
+"You can browse for a file using the open button to the right of the "
+"Profiler's path box (top left of the pane), which will run profiling over"
+" this file automatically."
+msgstr ""
+
+#: ../../panes/profiler.rst:22
+msgid ""
+"You can manually enter the path in the pane's path box and then run the "
+"analysis on the file by pressing :guilabel:`Profile` in the Profiler "
+"pane."
+msgstr ""
+
+#: ../../panes/profiler.rst:24
+msgid ""
+"You can also run profiling for the file that is currently open in the "
+":doc:`editor` by clicking :menuselection:`&Run --> Profile` in the menu "
+"bar, or by using a configurable shortcut (:kbd:`F10` by default)."
+msgstr ""
+
+#: ../../panes/profiler.rst:30
+msgid ""
+"If you'd like to cancel an in-progress run, click the :guilabel:`Stop` "
+"button in the top right, and if profiling fails for any reason, the "
+":guilabel:`Output` dialog will be displayed, indicating the error that "
+"occurred."
+msgstr ""
+
+#: ../../panes/profiler.rst:32
+msgid ""
+"By double-clicking an item in the Profiler, you will be taken to the file"
+" and line in the :doc:`editor` where it was called."
+msgstr ""
+
+#: ../../panes/profiler.rst:37
+msgid ""
+"You can increase the number of levels displayed for a particular object "
+"by clicking the dropdown arrows to the left of the name, and "
+"expand/collapse all the items with the buttons in the top left."
+msgstr ""
+
+#: ../../panes/profiler.rst:42
+msgid ""
+"By clicking the dropdown or press the :kbd:`Down Arrow` key in the "
+"filename field, you can recall paths of previous profiled files."
+msgstr ""
+
+#: ../../panes/profiler.rst:47
+msgid ""
+"Finally, you can save the data for a given run to disk as a file with the"
+" ``.Result`` extension using the :guilabel:`Save data` button. This can "
+"be loaded to compare with a previous run of the same file using the "
+":guilabel:`Load data` button. To remove the loaded data, click the "
+":guilabel:`Clear comparison` button."
+msgstr ""
+
+#: ../../panes/profiler.rst:58
+msgid "Interpreting the results"
+msgstr ""
+
+#: ../../panes/profiler.rst:60
+msgid ""
+"Results are broken down by function/method/statement, with each sub-"
+"element listed hierarchically under the top-level item that called them. "
+":guilabel:`Total Time` is that taken by the specified item and every "
+"function \"underneath\" (*i.e.* called by) it, while :guilabel:`Local "
+"Time` only counts the time spent in the particular callable object's own "
+"scope. The :guilabel:`Calls` column displays the total number of times "
+"the specified object was called at that level inside its parent calling "
+"function (or within the ``__main__`` scope, if a top-level object). "
+"Finally, the numbers in the :guilabel:`Diff` columns for each of the "
+"three appear if a comparison is loaded, and indicate the deltas between "
+"each measurement."
+msgstr ""
+
+#: ../../panes/profiler.rst:68
+msgid ""
+"For example, suppose you ran the :guilabel:`Profiler` on a file calling a"
+" function ``sleep_wrapper()`` that in turn called the ``sleep()`` "
+"function, and the ``sleep_wrapper()`` function took a total of 3.87 ms to"
+" run, with 3.86 ms of that spent executing the ``sleep()`` function "
+"inside it. Therefore, if ``sleep()`` called nothing else itself, its "
+":guilabel:`Total Time` and :guilabel:`Local Time` would both be "
+"identical, at 3.87 ms. Meanwhile, :guilabel:`Total Time` for "
+"``sleep_wrapper()`` would be 3.86 ms, but :guilabel:`Local Time` only "
+"0.01 ms as the rest was spent inside the ``sleep()`` function it called."
+msgstr ""
+
+#: ../../panes/profiler.rst:76
+msgid "Profiler plugins"
+msgstr ""
+
+#: ../../panes/profiler.rst:78
+msgid ""
+"There are two additional plugins that you can install to enable other "
+"types of profiling in Spyder. First, Spyder Line Profiler allows you to "
+"benchmark each line of your code individually. To learn more, visit the "
+"`spyder-line-profiler git repository`_."
+msgstr ""
+
+#: ../../panes/profiler.rst:87
+msgid ""
+"Second, Spyder Memory Profiler measures the memory usage of your code. "
+"For more information, go to the `spyder-memory-profiler git repository`_."
+msgstr ""
+
+#: ../../panes/projects.rst:3
+msgid "Projects"
+msgstr ""
+
+#: ../../panes/projects.rst:5
+msgid ""
+"Spyder allows you to associate a given directory with a **Project**, "
+"which automatically saves and restores the files you have open in the "
+":doc:`editor` from the last time you opened that project. With the "
+":ref:`Project <project-explorer>` pane, you can browse all your project's"
+" files, regardless of your current working directory or "
+":doc:`fileexplorer` location."
+msgstr ""
+
+#: ../../panes/projects.rst:11
+msgid ""
+"In addition, your project's root folder is used to set your working "
+"directory, and automatically added to the ``PYTHONPATH``, so you can "
+"easily ``import`` and work with any modules and packages you create "
+"inside of it."
+msgstr ""
+
+#: ../../panes/projects.rst:15
+msgid ""
+"Projects are completely optional and not imposed on users. All of Spyder'"
+" functionality (code completion, session saving, File Explorer, working "
+"directory, etc) is available without creating a :guilabel:`Project`."
+msgstr ""
+
+#: ../../panes/projects.rst:22
+msgid "Creating a Project"
+msgstr ""
+
+#: ../../panes/projects.rst:24
+msgid ""
+"To create a :guilabel:`Project`, click the :guilabel:`New Project` entry "
+"in the :guilabel:`Projects` menu, choose whether you'd like to associate "
+"a :guilabel:`Project` with an existing directory or make a new one, and "
+"enter the :guilabel:`Project`'s name and path."
+msgstr ""
+
+#: ../../panes/projects.rst:35
+msgid "Using the Projects Pane"
+msgstr ""
+
+#: ../../panes/projects.rst:37
+msgid ""
+"Once a :guilabel:`Project` is opened, the :guilabel:`Project` pane is "
+"shown, presenting a tree view of the current :guilabel:`Project`'s files "
+"and directories. It allows you to perform all the same :ref:`operations"
+"<file-operations>` as Spyder's :doc:`fileexplorer` pane."
+msgstr ""
+
+#: ../../panes/projects.rst:49
+msgid "Working with version control"
+msgstr ""
+
+#: ../../panes/projects.rst:51
+msgid ""
+"The :guilabel:`Project` pane has basic integration with the `Git`_ "
+"distributed version control system, just like :ref:`in the Files pane"
+"<files-vcs-support>`. You can commit or browse a file, directory or the "
+"entire repository via the commands in the context menu."
+msgstr ""
+
+#: ../../panes/projects.rst:56
+msgid ""
+"To use this functionality, the :guilabel:`Project` must be located in a "
+"``git`` repository and the ``git`` and ``gitk`` commands must be on the "
+"system path."
+msgstr ""
+
+#: ../../panes/pylint.rst:3
+msgid "Code Analysis"
+msgstr ""
+
+#: ../../panes/pylint.rst:5
+msgid ""
+"The **Code Analysis** pane detects style issues, bad practices, potential"
+" bugs, and other quality problems in your code, all without having to "
+"actually execute it. Based on these results, it also gives your code an "
+"overall quality score. Spyder's code analyzer is powered by the best-in-"
+"class `Pylint`_ back-end, which can intelligently detect an enormous and "
+"customizable range of potential errors, bad practices, quality issues, "
+"style violations, and more."
+msgstr ""
+
+#: ../../panes/pylint.rst:18
+msgid "Using the code analyzer"
+msgstr ""
+
+#: ../../panes/pylint.rst:20
+msgid ""
+"You can select the desired file to analyze directly in the :doc:`editor` "
+"by clicking anywhere within it. To run the analysis, press the "
+"configurable shortcut (:kbd:`F8` by default), select "
+":menuselection:`Source --> Run code analysis` from the menu bar or click "
+"the :guilabel:`Analyze` button in the Code Analysis pane. If the Code "
+"Analysis pane is not visible, you can open it under :menuselection:`View "
+"--> Panes --> Code Analysis`. All standard checks are run by default. To "
+"go directly to a line in the :doc:`editor` highlighted by a failed check,"
+" just click its name."
+msgstr ""
+
+#: ../../panes/pylint.rst:29
+msgid ""
+"You can also manually enter the path of a file you'd like it to check in "
+"the path entry box in the pane's toolbar. The analyzer works with both "
+"individual scripts and whole Python packages (directories containing an "
+":file:`__init__.py` file)."
+msgstr ""
+
+#: ../../panes/pylint.rst:35
+msgid ""
+"Cancel analyzing a file with the :guilabel:`Stop` button, and if analysis"
+" fails, click the :guilabel:`Output` button to find out why. If Pylint "
+"does succeed, the :guilabel:`Output` will show the raw plain text "
+"analysis results on the selected file, allowing you to easily browse and "
+"copy/paste the full message names and descriptions."
+msgstr ""
+
+#: ../../panes/pylint.rst:41
+msgid ""
+"Finally, you can click the dropdown or press the dropdown arrow in the "
+"filename field to view results of previous analyses."
+msgstr ""
+
+#: ../../panes/pylint.rst:52
+msgid ""
+"The number of recent runs Spyder should remember can be customized in the"
+" :guilabel:`History` dialog, available from the Code Analysis options "
+"menu."
+msgstr ""
+
+#: ../../panes/pylint.rst:57
+msgid ""
+"You can also expand or collapse one or all the sections in the pane by "
+"using the corresponding options in the options menu."
+msgstr ""
+
+#: ../../panes/pylint.rst:66
+msgid "Advanced options"
+msgstr ""
+
+#: ../../panes/pylint.rst:68
+msgid ""
+"You can turn certain messages off at the line, block or file/module level"
+" by adding a ``# pylint: disable=MESSAGE-NAMES`` comment at the "
+"respective `scope`_, where ``MESSAGE_NAMES`` should be replaced with a "
+"comma-separated list (or single value) of `Pylint message names`_. For "
+"example, a directive might look like ``# pylint: disable=invalid-name``, "
+"or ``# pylint: disable=fixme, line-too-long``."
+msgstr ""
+
+#: ../../panes/pylint.rst:78
+msgid ""
+"Or, you can globally suppress specific messages and adjust other Pylint "
+"settings by editing the :file:`.pylintrc` configuration file in your user"
+" folder. If it doesn't exist, you can generate it by running ``pylint "
+"--generate-rcfile > .pylintrc`` in your user directory, from Anaconda "
+"Prompt (on Windows) or your terminal (macOS/Linux). For more details on "
+"configuring Pylint, see the `Pylint documentation`_."
+msgstr ""
+
+#: ../../panes/pylint.rst:94
+msgid ":doc:`profiler`"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:3
+msgid "Variable Explorer"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:5
+msgid ""
+"The **Variable Explorer** allows you to interactively browse and manage "
+"the objects generated running your code."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:10
+msgid ""
+"It shows the namespace contents (including all global objects, variables,"
+" class instances and more) of the currently selected "
+":doc:`ipythonconsole` session, and allows you to add, remove, and edit "
+"their values through a variety of GUI-based editors."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:15
+msgid ""
+"The Variable Explorer gives you information on the name, size, type and "
+"value of each object. To modify a scalar variable, like an number, string"
+" or boolean, simply double click it in the pane and type its new value."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:25
+msgid "Object viewers"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:27
+msgid ""
+"Spyder's :guilabel:`Variable Explorer` offers built in support for "
+"editing lists, strings, dictionaries, NumPy arrays, Pandas DataFrames, "
+"Series and more; as well as being able to plot and visualize them with "
+"one click."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:31
+msgid "Strings"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:33
+msgid ""
+"When a string variable is longer than forty characters, you can double "
+"click it to see its value in a text editor to more easily modify it."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:41
+msgid "Dictionaries"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:43
+msgid ""
+"Double-clicking on dictionaries will show a viewer displaying each of its"
+" keys with its associated value. You can double click any of the values "
+"to modify them, which will open a new viewer if the value is itself an "
+"object."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:52
+msgid "Lists"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:54
+msgid ""
+"For lists, the main Variable Explorer displays a preview of the first ten"
+" values. To see them all, double click the list to open a viewer that "
+"will display the index, type, size and value of each element of the list."
+" Just like dictionaries, you can double-click values to edit them."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:64
+msgid "Numpy arrays"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:66
+msgid ""
+"Like lists, for Numpy arrays the Variable Explorer shows a preview of "
+"their values. Double-clicking them will open a viewer displaying the "
+"array values in a \"heat map\", with each value in a grid cell colored "
+"based on its numeric quantity. You can deactivate the background color by"
+" unchecking the appropriate option in the viewer, which will happen "
+"automatically if the array is too large to improve performance."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:73
+msgid ""
+"If supported by the datatype, you can also change the format of the "
+"array's values, choosing the number of decimals that you want the array "
+"to display. For this, click the :guilabel:`Format` button and and set the"
+" desired formatting in the dialog that appears, using standard `Printf-"
+"style syntax`_."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:78
+msgid ""
+"Additionally, you can adjust the size of the rows and columns of the "
+"array by expanding or contracting their headers. Clicking the "
+":guilabel:`Resize` button will set it automatically."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:86
+msgid "DataFrames"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:88
+msgid ""
+"DataFrames, like Numpy arrays, display in a viewer where you can show or "
+"hide \"heatmap\" colors, change the format and resize the rows and "
+"columns either manually or automatically."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:93
+msgid ""
+"Additionally, starting in Spyder 4, the Variable Explorer has MultiIndex "
+"support in its DataFrame inspector, including for multi-level and multi-"
+"dimensional indices."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:105
+msgid ""
+"The options menu in the top right of the Variable Explorer pane allows "
+"you filter the objects shown by a number of different criteria."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:110
+msgid ""
+"It also allows you to display the min and max of Numpy arrays instead of "
+"a preview of their values."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:120
+msgid "Toolbar buttons"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:122
+msgid ""
+"The Variable Explorer's toolbar includes several useful features that "
+"affect the entire namespace. For example, you can save the current "
+"session's data as a ``.spydata`` file, which can be loaded later to "
+"recover all the variables stored."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:130
+msgid ""
+"You should **not** load any ``.spydata`` file from any source you don't "
+"fully trust (ideally, only those files you've saved yourself). Like with "
+"any `Python pickle`_, it is inherently not secure against malicious code,"
+" as it can load any Python object and can execute arbitrary code on your "
+"machine. Additionally, it is not guaranteed to work reliably across all "
+"Python environments other than the one it was created in, so it should be"
+" only used as a local persistence format, not for interchange."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:136
+msgid ""
+"There is also a button to remove all displayed variables, and a search "
+"box to find objects by  name or type."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:141
+msgid ""
+"Finally, there is a button to refresh the Variable Explorer's contents, "
+"which will update it to show the current state of the code running in the"
+" IPython console."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:147
+msgid "Advanced functionality"
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:149
+msgid ""
+"The context menu, available by right-clicking any variable, provides "
+"numerous additional options to interact with objects of various types. "
+"These include renaming, removing or editing existing variables, as well "
+"as the :guilabel:`duplicate` option to create a new copy of one of them "
+"under a new name you enter in the resulting dialog box."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:155
+msgid ""
+"Furthermore, you can copy and paste the value of a variable, saving it in"
+" the Variable Explorer with any name that you choose. This allows you to "
+"change the type of the variable that you are pasting which can be very "
+"useful, allowing you to, for example, easily copy the elements of a list "
+"into an array."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:161
+msgid ""
+"Additionally, you can create an object from scratch directly in the "
+"Variable Explorer with the :guilabel:`Insert` option, which allows you to"
+" type the key (which should be in quotation marks) and the value for the "
+"item that you want to insert. In addition to adding a new top-level "
+"variable, this feature also allows you to create a new key in a "
+"dictionary, a new element in a list, and much more."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:167
+msgid ""
+"For lists and Numpy arrays, more advanced options are available, "
+"including generating plots and histograms of their values appropriate to "
+"their type and dimensions."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:172
+msgid ""
+"You can even save an array to a ``.npy`` file by simply clicking the "
+"appropriate option, which can later be loaded by Spyder or in your code "
+"via ``numpy.load()``."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:178
+msgid ""
+"For two-dimensional arrays, you can also display them as images, treating"
+" their values as RGB colors. For this, Spyder uses Matplotlib's "
+"colormaps, which can be `easily changed to match your preferences`_."
+msgstr ""
+
+#: ../../panes/variableexplorer.rst:185
+msgid ""
+"Finally, we added a context-menu action to open any object using the new "
+"Object Explorer even if they already have a builtin viewer (DataFrames, "
+"arrays, etc), allowing for deeper inspection of the inner workings of "
+"these datatypes."
+msgstr ""
+

--- a/doc/locales/pot/plugins.pot
+++ b/doc/locales/pot/plugins.pot
@@ -1,0 +1,329 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../plugins/index.rst:3
+msgid "Spyder Plugins"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:3
+msgid "Spyder Line Profiler"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:5
+msgid ""
+"**Spyder-Line-Profiler** is a plugin to run the Python `line profiler`_. "
+"This package profiles the time that individual lines of code take to "
+"execute."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:17
+msgid "Installing the Line Profiler"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:19
+msgid ""
+"If you installed Spyder using conda, the best way to obtain Spyder-Line-"
+"Profiler is to run the following command in your terminal (or Anaconda "
+"prompt on Windows):"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:27
+msgid ""
+"At the moment it is not possible to use this plugin with the Spyder :ref"
+":`install-standalone` for Windows and macOS. We're working to add support"
+" for them in the future."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:30 ../../plugins/notebook.rst:26
+#: ../../plugins/terminal.rst:27
+msgid "Restart Spyder in order to be able to use the plugin."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:36
+msgid "Using the Line Profiler"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:38
+msgid ""
+"When the Line Profiler is installed, it will be available under the menu "
+"item :menuselection:`View --> Panes --> Line Profiler`."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:43
+msgid ""
+"You will see it then as a tab next to the :guilabel:`Files` tab. For the "
+"Line Profiler to work, you must place the ``@profile`` decorator on the "
+"line above any functions that you wish to profile."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:49
+msgid ""
+"Now that the decorators have been added, you can then either select a "
+"script with the button present in the pane or run the profiler from "
+":menuselection:`Run --> Profile line by line`. Your file will then be "
+"profiled line by line."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:55
+msgid ""
+"After running the profiler, either from the button in the pane or the "
+":menuselection:`Run` menu, the results are shown in the :guilabel:`Line "
+"Profiler` pane. The path displayed there is that of the file being "
+"profiled."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:61
+msgid "The Line Profiler pane shows six columns:"
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:63
+msgid "``Line #:`` the number of the line being profiled."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:64
+msgid "``Hits:`` how many times that line is hit in the scope."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:65
+msgid ""
+"``Time (ms):`` time spent running the line in total for all hits, in "
+"milliseconds."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:66
+msgid "``Per hit (ms):`` average time spent per hit, in milliseconds."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:67
+msgid "``% Time:`` percentage of time taken by that line of total scope time."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:68
+msgid "``Line contents:`` the source code in the line."
+msgstr ""
+
+#: ../../plugins/lineprofiler.rst:70
+msgid "Lines with a stronger color take more time to run."
+msgstr ""
+
+#: ../../plugins/notebook.rst:3
+msgid "Spyder Notebook"
+msgstr ""
+
+#: ../../plugins/notebook.rst:5
+msgid ""
+"**Spyder-notebook** is a plugin that allows you to open, edit and "
+"interact with Jupyter Notebooks right inside Spyder."
+msgstr ""
+
+#: ../../plugins/notebook.rst:10
+msgid ""
+"Using notebooks inside Spyder allows you to take advantage of their web "
+"interface alongside Spyder’s powerful features such as the Variable "
+"explorer, console and debugger."
+msgstr ""
+
+#: ../../plugins/notebook.rst:14
+msgid "Installing the Notebook"
+msgstr ""
+
+#: ../../plugins/notebook.rst:16
+msgid ""
+"If you installed Spyder using conda, the best way to install Spyder-"
+"notebook is to run the following command in your terminal or Anaconda "
+"prompt on Windows:"
+msgstr ""
+
+#: ../../plugins/notebook.rst:24 ../../plugins/terminal.rst:25
+msgid ""
+"At the moment it is not possible to use this plugin with the Spyder :ref"
+":`install-standalone` for Windows and macOS. We're working to make that "
+"possible in the future."
+msgstr ""
+
+#: ../../plugins/notebook.rst:30
+msgid "Using the Notebook"
+msgstr ""
+
+#: ../../plugins/notebook.rst:32
+msgid ""
+"When the Notebook is installed, it will be available under the menu item "
+":menuselection:`View --> Panes --> Notebook`."
+msgstr ""
+
+#: ../../plugins/notebook.rst:37
+msgid ""
+"You will see it then as a tab in the bottom of the editor area. When "
+"switching to it, a welcome screen will be displayed, from where you can "
+"create a new notebook by right-clicking it and selecting :guilabel:`New "
+"notebook`."
+msgstr ""
+
+#: ../../plugins/notebook.rst:42
+msgid ""
+"You can also click the :guilabel:`Plus` button at the top right of the "
+"pane. A new Jupyter Notebook will be opened as a tab, ready for user "
+"input in a temporary file. This can serve as a scratch pad where you can "
+"do quick calculations and plots."
+msgstr ""
+
+#: ../../plugins/notebook.rst:47
+msgid ""
+"To save this notebook go to the options menu at the top right of the pane"
+" and click the :guilabel:`Save as...` option. This will store your "
+"notebook locally with the ``ipynb`` extension, which will allow you to "
+"open it then as a Jupyter Notebook outside of Spyder."
+msgstr ""
+
+#: ../../plugins/notebook.rst:52
+msgid ""
+"You can also open any Jupyter Notebook inside Spyder. For this go to the "
+"options menu at the top right of the pane and click :guilabel:`Open`, "
+"which will allow you to look for ``ipynb`` files in your computer. Click "
+"any notebook that you want to open inside Spyder and you will be able to "
+"see it as a new tab in the Notebook pane."
+msgstr ""
+
+#: ../../plugins/notebook.rst:57
+msgid ""
+"The :guilabel:`Open recent` option displays a list of the recent "
+"notebooks you opened in Spyder, from which you can select them and open "
+"them again in Spyder."
+msgstr ""
+
+#: ../../plugins/notebook.rst:61
+msgid "Connecting an IPython Console"
+msgstr ""
+
+#: ../../plugins/notebook.rst:63
+msgid ""
+"You can connect an :doc:`/panes/ipythonconsole` to your notebook, which "
+"will allow you to view your variables in the "
+":doc:`/panes/variableexplorer`. To do so, go to the options menu and "
+"click the :guilabel:`Open console` option. This will open a new console "
+"with the same name of your notebook and display the variables of the "
+"cells that you have executed previously in your Notebook. If you don't "
+"see them, press :kbd:`Enter` in the console."
+msgstr ""
+
+#: ../../plugins/notebook.rst:68
+msgid "You can view, modify and create new ones in the console too."
+msgstr ""
+
+#: ../../plugins/notebook.rst:70
+msgid ""
+"Since the Variable Explorer is associated to each console, closing the "
+"notebook's console will immediately hide the variables from the Variable "
+"Explorer."
+msgstr ""
+
+#: ../../plugins/notebook.rst:74
+msgid "Additional Options"
+msgstr ""
+
+#: ../../plugins/notebook.rst:76
+msgid ""
+"The context menu, available by right-clicking the pane area outside the "
+"notebook, allows you to zoom your notebook in or out."
+msgstr ""
+
+#: ../../plugins/notebook.rst:81
+msgid ""
+"You can also select the code from your Notebook and copy it on your "
+"clipboard to paste this code anywhere you want."
+msgstr ""
+
+#: ../../plugins/notebook.rst:86
+msgid ""
+"Finally, you can see all the server information of your notebook by "
+"clicking the :guilabel:`Server info` option in the context menu."
+msgstr ""
+
+#: ../../plugins/terminal.rst:3
+msgid "Spyder Terminal"
+msgstr ""
+
+#: ../../plugins/terminal.rst:5
+msgid ""
+"**Spyder-terminal** is a plugin that allows you to have integrated system"
+" terminals inside Spyder."
+msgstr ""
+
+#: ../../plugins/terminal.rst:10
+msgid ""
+"Spyder-terminal allows you to use any system shell installed in your "
+"system (e.g. Bash, Zsh or Powershell) rather than just the IPython "
+"console. You can use it to issue commands, interact with version control "
+"or to run programs."
+msgstr ""
+
+#: ../../plugins/terminal.rst:15
+msgid "Installing the Terminal"
+msgstr ""
+
+#: ../../plugins/terminal.rst:17
+msgid ""
+"If you installed Spyder using conda, the best way to install Spyder-"
+"terminal is to run the following command in your Terminal or Anaconda "
+"prompt on Windows:"
+msgstr ""
+
+#: ../../plugins/terminal.rst:31
+msgid "Using the Terminal"
+msgstr ""
+
+#: ../../plugins/terminal.rst:33
+msgid ""
+"When the Terminal is installed, it will be available under the menu item "
+":menuselection:`View --> Panes --> Terminal`."
+msgstr ""
+
+#: ../../plugins/terminal.rst:38
+msgid ""
+"You will see it then as a tab at the bottom of the console area. When "
+"switching to it, a new terminal tab will be created. You can also create "
+"more terminals by clicking in the :guilabel:`+` button at the upper right"
+" corner of the terminal area."
+msgstr ""
+
+#: ../../plugins/terminal.rst:43
+msgid ""
+"Clicking the :guilabel:`Options` button next to the :guilabel:`+` button "
+"will allow you to rename terminals, undock the terminal, and open a "
+"terminal in the directory of the current Editor file."
+msgstr ""
+
+#: ../../plugins/terminal.rst:48
+msgid ""
+"If you right click the terminal area, it's possible to issue commands "
+"such as :guilabel:`Clear Terminal`, :guilabel:`Zoom In/Out` and "
+":guilabel:`Copy/Paste Text`."
+msgstr ""
+
+#: ../../plugins/terminal.rst:55
+msgid "Terminal Preferences"
+msgstr ""
+
+#: ../../plugins/terminal.rst:57
+msgid ""
+"It's also possible to customize the Terminal by going to "
+":menuselection:`python --> Preferences...` and then clicking on the "
+"Terminal tab on the menu to the left. You can select the shell "
+"interpreter, set the buffer limit and the type of cursor."
+msgstr ""
+

--- a/doc/locales/pot/quickstart.pot
+++ b/doc/locales/pot/quickstart.pot
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../quickstart.rst:3
+msgid "Quickstart"
+msgstr ""
+
+#: ../../quickstart.rst:5
+msgid ""
+"Welcome to our Quickstart! Here you will find an interactive tour that "
+"will guide you through Spyder's interface. You'll get familiar with the "
+"most important parts of the IDE, especially those we'll be mentioning "
+"throughout our docs. Finally, you'll get to walk through some of Spyder's"
+" key panes and functionality."
+msgstr ""
+

--- a/doc/locales/pot/troubleshooting.pot
+++ b/doc/locales/pot/troubleshooting.pot
@@ -1,0 +1,1192 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../troubleshooting/basic-first-aid.rst:3
+msgid "Basic First Aid"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:5
+msgid ""
+"These suggestions, while more of a shotgun approach, tend to fix the "
+"majority of reported issues just on their own."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:11
+msgid "Recommended troubleshooting steps"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:13
+msgid "**Restart Spyder**, and try what you were doing before again."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:15
+msgid ""
+"**Upgrade Spyder** to the latest release, and you might find your issue "
+"is resolved (along with new features, enhancements, and other bug fixes)."
+" Minor releases come out every couple months, so unless you've updated "
+"recently, there is a good chance your version isn't the latest. You can "
+"find out with the :guilabel:`Check for updates` command under the "
+":guilabel:`Help` menu."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:22
+msgid ""
+"To perform the update with Conda (strongly recommended), from your "
+"terminal (or Anaconda Prompt on Windows) run:"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:29
+msgid ""
+"**Update Spyder's dependencies and environment**, either by installing "
+"the latest version of your distribution (e.g. the recommended Anaconda), "
+"or with the relevant \"update all\" command in your terminal (or Anaconda"
+" Prompt on Windows). To get the latest stable version of everything using"
+" Conda, you can run:"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:36
+msgid ""
+"**Restart your machine**, in case the problem lies with a lingering "
+"process or another such issue."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:38
+msgid ""
+"**Restore Spyder's config files** to their defaults, which solves a huge "
+"variety of Spyder issues. From your terminal (or Anaconda Prompt on "
+"Windows), run:"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:47
+msgid ""
+"This will reset your preferences, as well as any custom keyboard "
+"shortcuts or syntax highlighting schemes. If you particularly care about "
+"any of those, you should make a copy of the :file:`.spyder-py3` folder in"
+" your user home directory (:file:`C:/Users/YOUR_USERNAME` on Windows, "
+":file:`/Users/YOUR_USERNAME` on macOS, or :file:`/home/YOUR_USERNAME` on "
+"Linux), and restore it afterwards if this doesn't solve the problem."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:50
+msgid ""
+"**Try installing Spyder into a new Conda environment** (recommended) or "
+"``virtualenv``/``venv``, and see if the issue reoccurs."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:52
+msgid ""
+"In your system terminal (or Anaconda Prompt on Windows), run the "
+"following commands to create an a fresh, clean environment and start "
+"Spyder in it:"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:60
+msgid ""
+"If this fixes the issue, the problem was likely due to another package "
+"installed on your system, particularly if done with pip, which can cause "
+"many problems and should be avoided if at all possible."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:62
+msgid ""
+"**Watch our video** on solving and avoiding problems with pip, Conda and "
+"Conda-Forge, and follow its instructions."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:75
+msgid "Reinstalling Spyder"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:77
+msgid ""
+"If none of the previous steps solve your issue, you should do a full "
+"uninstall of Spyder by whatever means you originally installed it."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:79
+msgid ""
+"For Anaconda, follow all the steps under Option B in the `Anaconda "
+"uninstall guide`_, delete the Anaconda directory wherever it was "
+"originally installed, and (on Windows) remove the "
+":file:`%appdata%/python` directory if it exists."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:84
+msgid ""
+"Then, do a clean install of the latest version of the `Anaconda "
+"distribution`_ which is how we recommend you install Spyder and keep it "
+"up to date."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:88
+msgid ""
+"While you are welcome to get Spyder working on your own by one of the "
+"many other means we offer, we are only able to provide individual support"
+" for install-related issues for users of the Anaconda distribution. In "
+"particular, pip installation, while doable, is only really for experts, "
+"as there are many pitfalls involved and different issues specific to your"
+" setup, which is why we recommend using Conda whenever possible. For "
+"further information, please visit our :doc:`/installation`."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:99
+msgid "Isolating problems"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:101
+msgid ""
+"If you get an error while running a specific line, block, or "
+"script/program, it may not be an issue with Spyder, but rather something "
+"lower down in the packages it depends on. Try running it in the following"
+" in order if and until it starts working as you expect. If you manage to "
+"isolate the bug, report it to the last one it *doesn't* work in."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:105
+msgid ""
+"**Spyder** itself, of course! Make sure you can reproduce the error after"
+" closing and reopening it, if possible."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:108
+msgid ""
+"**A bare QtConsole instance**, e.g. launched from Anaconda navigator or "
+"from the Anaconda Prompt/Terminal/command line (Windows/Mac/Linux) with "
+"``jupyter qtconsole``."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:113
+msgid ""
+"QtConsole is the GUI console backend Spyder depends on to run its code, "
+"so most issues involving Spyder's :doc:`/panes/ipythonconsole` are "
+"actually something with QtConsole instead, and can be reported to their "
+"`issue tracker`_."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:115
+msgid ""
+"**An IPython command line shell**, launched with e.g. ``ipython`` from "
+"the Anaconda Prompt/Terminal/command line (Windows/Mac/Linux). "
+"Reproducible bugs can be reported to their `Github page`_, though make "
+"sure to read their guidelines and docs first."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:118
+msgid ""
+"**A standard Python interpreter**, either run as a script file with "
+"``python path/to/your/file.py`` or launched interactively with ``python``"
+" from your Anaconda Prompt/Terminal/command line (Windows/Mac/Linux). "
+"While it is not impossible that you've found Python bug, it is much more "
+"likely to be an issue with the code itself or a package you are using, so"
+" your best sources are the `Python docs`_ and the other resources listed "
+"above."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:127
+msgid ""
+"If the problem reoccurs in a similar or identical way with any of these "
+"methods (other than only Spyder itself), then it is almost certainly not "
+"an issue with Spyder, and would be best handled elsewhere. As we usually "
+"aren't able to do much about issues not related to Spyder, a forum like "
+"`Stack Overflow`_ or the relevant package's docs is a much better place "
+"to get help or report the issue."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:132
+msgid ""
+"See the :doc:`call-for-help` section for other places to look for "
+"information and assistance."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:138
+msgid "Debugging and patching"
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:140
+msgid ""
+"If you know your way around Python, you can often diagnose and even fix "
+"Spyder issues yourself, since the IDE is written in the same language you"
+" use in it. You can explore the error messages you're receiving and "
+"Spyder's inner workings with the :guilabel:`Internal Console`, available "
+"under the menu item :menuselection:`View --> Panes --> Internal Console`."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:146
+msgid ""
+"For more detailed debug output, start Spyder from the command line "
+"(Anaconda Prompt on Windows) with ``spyder --debug-info verbose``."
+msgstr ""
+
+#: ../../troubleshooting/basic-first-aid.rst:148
+msgid ""
+"Even if you don't manage to fix the problem yourself, this output can be "
+"very helpful in aiding us to quickly narrow down and solve your issue for"
+" you."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:3
+msgid "Calling for Help"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:5
+msgid ""
+"Aside from this troubleshooting guide, there are a number of other "
+"sources of documentation and troubleshooting information you can check "
+"before submitting an issue, as they might already offer an answer, or at "
+"least help you better understand the problem. Even if we aren't able to "
+"help you, these places might."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:14
+msgid "Spyder-related platforms"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:19
+msgid "Spyder's FAQ section"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:21
+msgid ""
+"Spyder's documentation has a FAQ section, where you might find the "
+"answers that you are looking for."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:27
+msgid "Spyder's YouTube channel"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:29
+msgid ""
+"Our `YouTube channel`_ contains helpful videos that will guide you "
+"through many of Spyder's features, and provide a starting point for newer"
+" users."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:37
+msgid "Spyder Gitter"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:39
+msgid ""
+"We have a public `Gitter room`_ where you can chat directly with the "
+"Spyder developers. If you've got a quick question to ask the team and are"
+" looking for a quick answer, this is a great place to go."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:48
+msgid "Spyder Google Group"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:50
+msgid ""
+"Our `Google Group`_ is great for help-related questions, particularly "
+"those you aren't sure are a full-on Spyder issue."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:58
+msgid "Spyder website"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:60
+msgid ""
+"The `Spyder site`_ contains basic information about the IDE and links to "
+"many other helpful resources."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:68
+msgid "Stack Overflow tag"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:70
+msgid ""
+"`Stack Overflow`_ is a great place to start searching and posting, "
+"particularly if your question is more programming-related, or has to do "
+"with something specific to your own code. It has an vibrant Spyder "
+"community as well, with new questions posted every day, and the "
+"developers (especially Carlos Cordoba, the lead maintainer) are active in"
+" answering them."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:79
+msgid "OpenTeams support"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:81
+msgid ""
+"On `OpenTeams`_, you can get help from expert Spyder consultants. "
+"OpenTeams offers services from Spyder experts ranging from a brief "
+"consultation to an experienced team to help you with a large scale "
+"implementation project."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:91
+msgid "Python resources"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:96
+msgid "Official Python help page"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:98
+msgid ""
+"The `Python help page`_ is a great resource that lists a number of places"
+" you can get assistance, support and learning resources for the language "
+"and its packages."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:106
+msgid "Python documentation"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:108
+msgid ""
+"The `Python docs`_ can help you understand a number of issues that can be"
+" caused by quirks in the language itself, or misunderstandings as to how "
+"it behaves."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:116
+msgid "Python subreddits"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:118
+msgid ""
+"`r/python`_ and `r/learnpython`_ are resources you can use to ask about "
+"and discuss issues with Python and its packages. The former is aimed more"
+" at general Python usage, and the latter more specifically at beginners."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:130
+msgid "Data science/SciPy resources:"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:136
+msgid "Anaconda help"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:138
+msgid ""
+"The `Anaconda docs`_ site offers free community help and documentation "
+"for the Anaconda applications, installing the Anaconda distribution, and "
+"using the Conda package and environment manager; along with paid support "
+"options."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:145
+msgid "SciPy.org website"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:147
+msgid ""
+"The `Scipy website`_ is the the central home of the SciPy stack, with "
+"information, documentation, help, and bug tracking for many of the core "
+"packages used with Spyder, including NumPy, SciPy, Matplotlib, Pandas, "
+"Sympy and IPython."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:155
+msgid "Project Jupyter"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:157
+msgid ""
+"`Jupyter`_ is the development hub for IPython, Spyder's QtConsole, "
+"Jupyter notebooks used with the `Spyder-Notebook`_ plugin, and more."
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:166
+msgid "Data Science Stack Exchange"
+msgstr ""
+
+#: ../../troubleshooting/call-for-help.rst:168
+msgid ""
+"The `Data Science`_ site in Stack Exchange can be very useful for "
+"questions that relate more to data science than programming specifically."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:3
+msgid "Common Illnesses"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:5
+msgid ""
+"Beyond the general troubleshooting steps, some frequently-reported "
+"problems require more specialized solutions."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:13
+msgid "Errors starting the kernel"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:15
+msgid ""
+"If you receive the message ``An error occurred while starting the "
+"kernel`` in the :doc:`/panes/ipythonconsole`, Spyder was unable to launch"
+" a new Python interpreter in the current working environment to run your "
+"code. There are a number of problems that can cause this, but most can be"
+" fixed fairly quickly with a few easy steps."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:22
+msgid "Spyder-Kernels not installed/incompatible"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:24
+msgid ""
+"Spyder requires a supported version of the ``spyder-kernels`` package to "
+"be present in the working environment you want to run your console in."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:29
+msgid ""
+"It is included by default with Anaconda, but if you want to run your code"
+" in another Python environment or installation, you'll need to make sure "
+"it's installed and updated to the latest version."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:31
+msgid ""
+"Check the required version of spyder-kernels for your version of Spyder "
+"in the following table:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:33
+msgid "Spyder and Spyder-Kernels version compatibility"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:36
+msgid "Spyder"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:36
+msgid "Spyder-Kernels"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:38
+msgid "4.0.0-4.0.1"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:38
+msgid "1.8.1"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:39
+msgid "4.1.0-4.1.2"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:39
+msgid "1.9.0"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:40
+msgid "4.1.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:40
+msgid "1.9.1"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:41
+msgid "4.1.4"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:41
+msgid "1.9.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:42
+msgid "4.1.5-4.1.6"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:42
+msgid "1.9.4"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:43
+msgid "4.2.0"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:43
+msgid "1.10.0"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:44
+msgid "5.0.0-5.0.5"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:44
+msgid "2.0.5"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:45
+msgid "5.1.0-5.1.5"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:45
+msgid "2.1.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:46
+msgid "5.2.0-5.2.1"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:46
+msgid "2.2.0"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:47
+msgid "5.2.2"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:47
+msgid "2.2.1"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:48
+msgid "5.3.0-5.3.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:48
+msgid "2.3.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:49
+msgid "5.4.0-5.4.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:49
+msgid "2.4.3"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:52
+msgid ""
+"To do so, activate the environment, then install ``spyder-kernels``. If "
+"using Anaconda, open a terminal (Anaconda Prompt on Windows) and run:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:60
+msgid ""
+"Otherwise, activate your environment by whatever means you created it, "
+"and execute:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:66
+msgid ""
+"For both of the previous commands, replace ``<VERSION>`` with the "
+"corresponding version in the table."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:70
+msgid "Issue with another dependency"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:72
+msgid ""
+"If the kernel displays a long error traceback that mentions other "
+"packages like ``ipython``, ``ipykernel``, ``jupyter_client``, "
+"``traitlets`` or ``pyzmq``, the problem may be an out of date or "
+"incompatible version of a dependency package. To fix this, activate the "
+"environment and update the key dependencies."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:75
+msgid "In an Anaconda environment:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:82
+msgid ""
+"Otherwise, activate your environment by whatever means you created it, "
+"and run:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:90
+msgid "AttributeError/ImportError"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:92
+msgid ""
+"Check the last few lines of the error message, and see if its an "
+"``AttributeError`` or ``ImportError``, or refers to a file you created in"
+" your current working directory or your home folder "
+"(:file:`C:/Users/YOUR_USERNAME` on Windows, :file:`/Users/YOUR_USERNAME` "
+"on macOS, or :file:`/home/YOUR_USERNAME` on Linux)."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:97
+msgid ""
+"If so, the the error is likely due to your file being named the same as a"
+" Python standard library module, such as ``string.py`` or ``time.py``, "
+"which overrides the built-in module that Spyder-Kernels is trying to "
+"load. To fix this, simply rename your file to something other than one of"
+" these names, and try restarting the kernel. To check the names of these "
+"modules, see the list in the `Python standard library documentation`_."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:109
+msgid "Completion/help not working"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:111
+msgid ""
+"To provide code completions, help and real-time analysis in the Editor, "
+"Spyder uses the Python Language Server (PyLS), an implementation of the "
+"Language Server Protocol specification used by VSCode, Atom and other "
+"popular editors/IDEs. Most help and completion issues lie outside of "
+"Spyder's control, and are either limitations with PyLS or the code that "
+"is being introspected, but some can be worked around."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:116
+msgid "Object missing docstring"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:118
+msgid ""
+"If nothing is displayed in the calltip, hover hint or help pane, the "
+"object you're trying to introspect may not have a docstring."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:124
+msgid ""
+"In this case, the only solution is to add one in the source code of the "
+"original function, method or class."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:128
+msgid "Object cannot be found"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:130
+msgid ""
+"Some objects, whether due to being written in C, Cython or another "
+"language; generated dynamically at runtime; or being a method of an "
+"object you create, cannot be easily found without executing the code."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:136
+msgid ""
+"However, once you run your code in the :doc:`/panes/ipythonconsole`, you "
+"might be able to get help and completions on the object there."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:140
+msgid "LSP has stopped working"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:142
+msgid ""
+"Occasionally, especially after using Spyder for a while, code completion,"
+" help and analysis may stop working. If this is the case, you can check "
+"LSP status with the :guilabel:`LSP Python` item in Spyder's status bar at"
+" the bottom of the screen, and restart it by right-clicking it and "
+"selecting the :guilabel:`Restart Python Language Server` item."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:150
+msgid "Spyder bug/dependency issue"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:152
+msgid ""
+"Given the variety of dependencies involved in making LSP work, an "
+"incompatible or out of date version in your environment can result in "
+"error messages, incomplete results, or help/analysis not working at all."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:154
+msgid ""
+"To address this, first try updating Anaconda and Spyder as described in "
+":doc:`basic-first-aid`. If the issue still isn't resolved, update the "
+"various relevant dependencies with:"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:165
+msgid "Plugin Problems"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:168
+msgid "Plugin does not work at all"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:170
+msgid ""
+"If you have installed a Spyder plugin, but you can't see it, go to the "
+":guilabel:`Panes` submenu of the :guilabel:`View` menu and select the "
+"plugin's name, which should make its pane visible. If you don't see the "
+"plugin there, select the :guilabel:`Dependencies` item under the "
+":guilabel:`Help` menu and see if the plugin appears at the bottom."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:176
+msgid ""
+"If the plugin with the problem is not listed in the dependencies dialog, "
+"check that you installed it in the same environment as Spyder. If you "
+"have, then the problem may well be caused by a dependency issue. Test "
+"whether you can import the plug-in manually by opening a Python console "
+"in the same environment as Spyder and typing, for instance, ``import "
+"spyder_unittest`` to test the Spyder-Unittest` plug-in; this command "
+"should run without errors."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:180
+msgid ""
+"If none of this helps you to resolve the problem, then continue to the "
+"next section."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:184
+msgid "Other issues"
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:186
+msgid ""
+"If you get an error which mentions or involves a Spyder plugin, such as "
+"``spyder-unittest``, ``spyder-terminal`` or ``spyder-notebook``, or if "
+"you encounter any other problem with a Spyder plugin, then the first "
+"approach should be to update Spyder and the plugin to their latest "
+"versions."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:188
+msgid ""
+"If this doesn't fix the problem, you should check the plugin's website or"
+" repository to see if it is compatible with your version of Spyder."
+msgstr ""
+
+#: ../../troubleshooting/common-illnesses.rst:190
+msgid ""
+"Finally, if compatibility doesn't seem to be the problem, please check "
+"those repositories to see if an issue was already opened, and report it "
+"there if not."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:3
+msgid "Emergency CPR"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:5
+msgid ""
+"Is Spyder not launching at all? The steps on this section should "
+"hopefully get it back up and running in no time."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:12
+msgid "Common solutions"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:14
+msgid ""
+"Try :doc:`basic-first-aid` first, which usually resolves most Spyder "
+"install-related issues."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:16
+msgid ""
+"**Make sure Spyder isn't already running** and no Spyder related windows "
+"(*e.g.* :doc:`/panes/variableexplorer` dialogs) are left open, and check "
+"that the preference setting :menuselection:`Application --> Advanced "
+"Settings --> Use a single instance` isn't checked."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:21
+msgid ""
+"Try **starting Spyder via a different means**, such as from a shortcut, "
+"Anaconda navigator, or your command line (or Anaconda Prompt on Windows) "
+"by simply typing ``spyder`` then :kbd:`Enter`/:kbd:`Return`, and see if "
+"any of those work. If so, then something's wrong with your install, not "
+"Spyder itself, and so we recommend following :ref:`troubleshooting-"
+"reinstalling-spyder-ref` to uninstall and reinstall Anaconda."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:24
+msgid ""
+"**Disable any security software** you may be using, such as a firewall or"
+" antivirus, as these products can occasionally interfere with Spyder or "
+"its related packages. Make sure to re-enable it if it doesn't fix the "
+"problem, and if it does, add a rule or exception for Spyder or Python."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:27
+msgid ""
+"If it is currently installed \"for just you\", **try uninstalling and "
+"reinstalling Anaconda \"for all users\" instead**, and vice versa, as "
+"some systems can have issues with one or the other installation method."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:29
+msgid ""
+"**Check and repair/reset permissions**, your disk, and OS if all else "
+"fails."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:35
+msgid "Advanced tricks"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:37
+msgid ""
+"If none of the above solves the problem, you can try starting Spyder "
+"directly from its Python source files which may either get it running, or"
+" at least provide useful information to help debug the issue further."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:39
+msgid ""
+"This technique consists of starting Spyder from your terminal (or "
+"Anaconda Prompt on Windows) by manually running the Spyder startup "
+"routine ( :guilabel:`start.py` ) with a known good Python interpreter, "
+"and observing the results."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:41
+msgid "To do so, you'll need to:"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:43
+msgid ""
+"Find the path to the Spyder :file:`app` directory from the command line. "
+"For this, run:"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:50
+msgid "Go to the output path of the above command on your command line:"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:56
+msgid ""
+"Once inside the :file:`app` directory, run ``python start.py`` to launch "
+"Spyder."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:62
+msgid ""
+"#. If it doesn't start successfully, then you should see an error "
+"traceback printed; carefully copy that for future reference. Also run "
+"``python mainwindow.py``, and record your results as well."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:65
+msgid ""
+"(*Windows only*) In case the command window disappears immediately after "
+"the error, create a ``.bat`` file in the :file:`app` directory with the "
+"following content:"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:73
+msgid "Replace ``<PYTHON-PATH>`` with the output of:"
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:79
+msgid ""
+"Then, double click the batch file to run it, and you should see the error"
+" information you need."
+msgstr ""
+
+#: ../../troubleshooting/emergency-cpr.rst:81
+msgid ""
+"If reading the output (particularly the last line) doesn't help you solve"
+" the problem, then record all of it carefully, and post it as part of "
+"your bug report as described under the :doc:`submit-a-report` section."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:3
+msgid "First Steps"
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:5
+msgid ""
+"If Spyder crashes or you receive an error message, please read the "
+"following troubleshooting steps before opening a new issue. There's a "
+"good chance that someone else has already experienced the same problem, "
+"so checking for an existing solution will likely get Spyder working again"
+" for you as quickly as possible."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:9
+msgid ""
+"To make sure you're getting the most relevant help for your problem, "
+"please make sure the issue is actually related to Spyder:"
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:11
+msgid ""
+"If the problem appears to be a result of *your own code*, `Stack "
+"Overflow`_ is a better place to start."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:12
+msgid ""
+"If the bug also occurs in the *standard Python, IPython, or QtConsole* "
+"environments, or only with *a specific package*, it is unlikely to be "
+"something in Spyder, and you should report it to those sources instead."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:13
+msgid ""
+"If the problem lies with *your specific install*, uninstalling and clean-"
+"reinstalling the `Anaconda`_ distribution is strongly recommended. As the"
+" other methods of installing Spyder can result in tricky user-specific "
+"problems, we generally aren't able to give individual support for install"
+" issues."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:19
+msgid ""
+"Just like the programs you code in it, Spyder is written in Python, so "
+"you can often figure out many problems just by reading the last line of "
+"the traceback or error message. To view it, simply click :guilabel:`Show "
+"details` in the Spyder error dialog."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:25
+msgid ""
+"Often, that alone will tell you how to fix the problem on your own, but "
+"if not, we're here to help."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:31
+msgid "Where to go from here"
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:33
+msgid ""
+"If you check out our list of issue categories and problem descriptions "
+"and see a question, error message or traceback that looks familiar, the "
+"relevant sub-section will likely be of the most specific help solving "
+"your issue as quickly as possible."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:37
+msgid ""
+"As a first step to solving your issue, you can try some :doc:`basic-"
+"first-aid`."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:41
+msgid ""
+"If Spyder won't launch, check the :doc:`emergency-cpr` section and see if"
+" that clears it up."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:45
+msgid ""
+"If your problem is related to the kernel not starting, autocompletion or "
+"a plugin go to :doc:`common-illnesses` section."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:49
+msgid ""
+"If you still can't get it to work, and the problem is indeed Spyder-"
+"related, you should consult the the :doc:`call-for-help` section for "
+"other resources to explore."
+msgstr ""
+
+#: ../../troubleshooting/first-steps.rst:53
+msgid ""
+"Finally, if you couldn't solve your problem and want to submit an issue "
+"to our Github issue tracker, so the bug can hopefully be fixed for "
+"everyone, :doc:`submit-a-report`."
+msgstr ""
+
+#: ../../troubleshooting/index.rst:3
+msgid "Troubleshooting"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:3
+msgid "Submit a Report"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:5
+msgid ""
+"If you can't fix your issue with any of the troubleshooting steps, then "
+"you'll want to submit it to our issue tracker so our team can take a look"
+" at it for you. You'll need a `Github account`_ to do this, so make sure "
+"you have one before you begin (a good idea anyway)."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:13
+msgid ""
+"Before you submit an issue, make sure you've searched a description of "
+"the problem and a relevant portion of the error traceback, on both Google"
+" and Spyder's `issue tracker`_ to make sure it hasn't been submitted "
+"before. If that's the case, your issue will be closed as a duplicate."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:23
+msgid "Ways to submit an issue"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:25
+msgid ""
+"There are several ways to submit an issue, either from Spyder or GitHub "
+"directly. In order of preference and difficulty:"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:28
+msgid ""
+"**If Spyder presents an error dialog** you can submit an issue directly "
+"from it. You will have to fill out a title for your issue, specify the "
+"steps that lead to this problem and click :guilabel:`submit to Github`. "
+"This will prefill an error report with your environment details, key "
+"versions and dependencies and automatically insert the error/traceback "
+"for you."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:36
+msgid ""
+"**If Spyder opens and your issue does not involve an error dialog**, the "
+"best way to do so is to simply select :guilabel:`Report issue` from the "
+":guilabel:`Help` menu, which manually brings up the issue report form and"
+" fills in the key information about your Spyder installation. Describe "
+"the issue you're experiencing (including any error/traceback information)"
+" along with a descriptive title, and click :guilabel:`Submit to Github`."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:42
+msgid ""
+"**If Spyder won't launch**, you can submit a report manually at our "
+"issues page on `Github`_. Unlike the above, you'll need to manually "
+"provide the versions of everything (Spyder, Python, OS, Qt/PyQt, "
+"Anaconda, and Spyder's dependencies) as listed in the error report "
+"template; see below for more on that."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:50
+msgid ""
+"Once you submit your report, our team will try to get back to you as soon"
+" as possible, often within 24 hours or less, to try to help you fix it."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:55
+msgid "What to include in your report"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:57
+msgid ""
+"**Please include as much as possible of the following in your report** to"
+" maximize your chances of getting relevant help and our ability to "
+"diagnose, reproduce and solve your issue."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:59
+msgid "The key items, in order of priority:"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:61
+msgid ""
+"The full, **complete error message or traceback** copy/pasted or "
+"automatically entered exactly as displayed by Spyder:"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:63
+msgid ""
+"Auto-generated reports directly from the error dialog should include this"
+" automatically, but double check to make sure."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:64
+msgid ""
+"You can copy and paste this from the the :guilabel:`Show Details` section"
+" of the error dialog."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:65
+msgid ""
+"If not present, or a dialog is not displayed, you can also find it "
+"printed to Spyder's :guilabel:`Internal Console`, located under the "
+":guilabel:`View` menu at :menuselection:`Panes --> Internal Console`."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:66
+msgid ""
+"If you prefer, or if Spyder won't start, you can start Spyder from your "
+"command line (or Anaconda prompt on windows) with ``spyder`` and copy the"
+" output printed there."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:70
+msgid ""
+"If you are reporting a specific behavior rather than an error, or the "
+"message does not fully explain what occurs, please describe in detail "
+"what actually happened, and what you expected Spyder to do."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:72
+msgid ""
+"A **detailed, step by step description of exactly what you did** leading "
+"up to the error occurring, complete with sample code that triggers it, if"
+" applicable."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:74
+msgid ""
+"**Information about Spyder and its environment** as listed in the error "
+"report template, which you can find under :guilabel:`About Spyder` in the"
+" :guilabel:`Help` menu; along with its key dependencies, shown in the "
+"dialog under :menuselection:`Help --> Dependencies` (there's a button to "
+"copy-paste them)."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:79
+msgid ""
+"If Spyder won't launch, paste the output of ``conda list`` from your "
+"command line (or Anaconda prompt on Windows) in the "
+":guilabel:`Dependencies` section of the issue template."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:85
+msgid ""
+"**How you installed Spyder** and any other relevant packages, *e.g.* "
+"Anaconda, MacPorts or pip and **whether Spyder has worked before** since "
+"you installed it."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:87
+msgid ""
+"**What else you've tried to fix it**, *e.g.* from this guide or elsewhere"
+" on the web, and if you've **tried to reproduce it in standalone "
+"QtConsole, IPython, and/or the plain Python** interpreter."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:89
+msgid ""
+"**Whether the problem occurred consistently before** in similar "
+"situations or if this is the first time you've observed it."
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:91
+msgid ""
+"**Anything else special or unusual** about your system, environment, "
+"packages, or specific usage that might have anything to do with the "
+"problem"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:95
+msgid ""
+"If including block(s) of code in your report, be sure to precede and "
+"follow it with a line of three backticks \\`\\`\\` to get a code block "
+"like this:"
+msgstr ""
+
+#: ../../troubleshooting/submit-a-report.rst:101
+msgid ""
+"Otherwise, your code will likely contain random formatting or missing "
+"indentation, making it difficult to examine and run it to reproduce and "
+"fix your issue."
+msgstr ""
+

--- a/doc/locales/pot/videos.pot
+++ b/doc/locales/pot/videos.pot
@@ -1,0 +1,775 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../videos/first-steps-with-spyder.rst:3
+msgid "First Steps with Spyder"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:5
+msgid ""
+"The videos in this section provide a starting point for new users who "
+"have never opened Spyder before. You'll get familiar with opening Spyder "
+"in different ways, working with the four main panes and customizing the "
+"Spyder to your heart's content."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:12
+msgid "Getting started"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:14
+msgid ""
+"Discover the basics of using the Spyder interface and get an introduction"
+" to its four main panes, along with a quick look at the others."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:16
+msgid "Find out different ways to open Spyder"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:17
+msgid "Understand the key elements of Spyder’s interface"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:18
+msgid "Learn more about Spyder’s four core panes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:19
+msgid "Explore the other default panes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:33
+msgid ""
+"Hello everyone! I'm Juanita, and in this video I'm going to show you how "
+"to open Spyder and go over the basics of Spyder's interface. We will "
+"learn about Spyder's four panes that you'll likely be using most often, "
+"as well as briefly explore the others that are open by default. If you "
+"don't have Spyder installed and would like to follow along, you can "
+"`download it here`_."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:37
+msgid ""
+"The easiest way to open Spyder is by opening Anaconda Navigator and "
+"clicking on the Spyder application. In case you have an older version of "
+"Spyder in Anaconda, open the command line (or the Anaconda Prompt in the "
+"case of Windows) and type the commands:"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:44
+msgid ""
+"To launch Spyder without opening Navigator, open your command line and "
+"type ``spyder``. If you followed the :doc:`/installation`, you should "
+"have everything necessary to open Spyder 4."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:46
+msgid ""
+"This is what Spyder 4 looks like in its default configuration, though you"
+" can thoroughly customize it, which we'll get to in a later tutorial. You"
+" can see that it is divided into three sections showing three different "
+"panes: the Editor, the IPython Console and the Help viewer. These three, "
+"along with the Variable Explorer, are the four core panes you'll work "
+"with the most in Spyder."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:48
+msgid ""
+"On the left we have the Editor, where you can open, edit and run files. "
+"Bottom right is the IPython Console, which you can use both interactively"
+" and to run your code in the Editor. It shows you which version of Python"
+" you are using. Above it, you'll find the Help pane, where you can get "
+"more information and documentation for any object in the Editor or "
+"Console by pressing :kbd:`Ctrl-I` (or :kbd:`Cmd-I` on macOS). We'll see "
+"how to do this in our next video."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:50
+msgid ""
+"For the two sections on the right, you can switch tabs to see the other "
+"panes that are open by default when launching Spyder. In the top section,"
+" you can switch to the Variable Explorer, which shows you the name, type,"
+" size and value of the variables that you have previously defined in the "
+"Editor or the Console. You can also modify the value of these variables "
+"directly from this pane by double clicking them under the Value column. "
+"The Plots pane will show you the figures you generate with Matplotlib and"
+" other libraries, and the Files pane allows you to browse the files on "
+"your computer and open them in the Editor with just a click."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:52
+msgid ""
+"Finally, in the bottom section you can also access the History pane, "
+"which shows you the commands you have entered in the Console, including "
+"those from previous sessions."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:54
+msgid ""
+"I hope you're now familiar with the basics of using the Spyder interface."
+" In the next video, we will start working with Spyder's core panes."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:56
+msgid "Happy Spydering!"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:62
+msgid "Learning the basics"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:64
+msgid "Learn the basics of using Spyder’s four main panes."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:66
+msgid "Open and edit a file in Spyder’s Editor"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:67
+msgid "Run a script in the Editor and see the output in Spyder’s IPython Console"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:68
+msgid "Execute basic Python commands in the IPython Console"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:69
+msgid ""
+"Define variables in the Editor and modify their values in the IPython "
+"Console"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:70
+msgid "View and interact with the variables in Spyder’s Variable Explorer"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:71
+msgid "Get documentation in the Help pane in two different ways"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:84
+msgid ""
+"Hello everyone! I'm Juanita, and in this video I will show you how to "
+"start working with Spyder's four main panes. First, let's take a look at "
+"the Editor, which you can use to open, edit and run files from your "
+"computer. I will open a short \"Hello World\" program for this demo, "
+"which you can `download here`_. Once you have it open in your Editor, you"
+" can execute it by pressing the green run button. We can see the output "
+"in the Python Console [Show IPython console] as well as the path of the "
+"file that we are running and the working directory where this code was "
+"run."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:88
+msgid ""
+"We can also run any Python code that is entered directly in the IPython "
+"Console. For example, we can type ``print(\"Hello\")`` and see the "
+"output. Or, we can try some math operations and see the results here too."
+" Note that for implicitly printed output, there is a red indication that "
+"differs from the output of the ``print()`` function."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:90
+msgid ""
+"Now, let's start defining some variables. We can do this both from the "
+"editor or from the Console. If I define a variable ``a = 10`` and then "
+"run this code, I can see its value in the console just by typing its name"
+" ``a``. However, you can also assign any variable in the IPython console "
+"(``b = 20``) and its value will be stored too. In both cases, they can "
+"also be seen in the Variable Explorer pane, which shows the name, type, "
+"size and value of each of the objects previously defined. In this case, "
+"we see variables ``a`` and ``b``, both of type int and with size 1. We "
+"can also define a list ``l`` with ``l = [1, 2, 3]`` and see that the type"
+" of the variable is list and the size is 3."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:92
+msgid ""
+"We can change the values of the variables in the Variable Explorer too by"
+" double-clicking them and typing their new value. Now, we can check their"
+" new value in the console. In the case of a more complex type like a "
+"list, double-clicking it will open a viewer in which you can modify each "
+"of its values separately, along with other more complex operations which "
+"we'll demonstrate in a future video. We can remove a variable by right-"
+"clicking it and selecting the option Remove. After doing this, we can "
+"check in the IPython Console that the variable was actually deleted."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:94
+msgid ""
+"Finally, we are going to learn how to get help for objects in two "
+"different ways. First, we can press :kbd:`Ctrl-I` (or :kbd:`Cmd-I` on "
+"macOS) right after the name of an object written in the Editor or the "
+"Console, for example ``numpy.array``. You can see that we obtain its "
+"documentation in the Help pane if it is available. Second, if we change "
+"the Source dropdown option to Console, we can type its name in the object"
+" box in the Help pane. Now we can get help for Numpy arrays."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:96
+msgid ""
+"You should now be ready to start using Spyder's four main panes. Check "
+"out our next video to continue learning and as always, Happy Spydering!"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:102
+msgid "Customization"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:104
+msgid ""
+"Learn how to customize Spyder’s interface to match your workflow and "
+"development style."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:106
+msgid "Choose your preferred fonts"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:107
+msgid "Switch between different interface, icon and syntax themes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:108
+msgid "Show, hide, undock and rearrange Spyder panes"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:109
+msgid "Split, close and pop out Editor panels"
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:123
+msgid ""
+"Hello everyone, I'm Juanita! In this video, I will show you how to "
+"customize Spyder to match your workflow and development style."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:125
+msgid ""
+"First, we are going to learn how to change the font in the Editor, "
+"IPython Console and Help panes. To do this, go to Preferences, select the"
+" Appearance entry and scroll down to Fonts. You can change both the style"
+" and the size of the font for both plain and rich text. You can see how "
+"this affects the font in the Editor, Console and Help panes."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:127
+msgid ""
+"In this same dialog, you can easily change the syntax highlighting theme,"
+" for which you can see the preview at the right of the window. Note that "
+"Spyder's interface theme changes to match the highlighting theme because "
+"the Interface theme option is set to Automatic by default. However, you "
+"can change the theme for the entire Spyder interface, choosing between "
+"Light and Dark. After selecting this change, click Apply to restart "
+"Spyder to apply the new theme."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:129
+msgid ""
+"Beyond just Spyder's preferences, you can freely rearrange the panes in "
+"Spyder's main window. To show or hide panes, go to Panes under the View "
+"menu, and select which ones you want to see. For example, let's hide the "
+"Files pane and show the Profiler pane. You can also close a pane from its"
+" options menu, which will hide it from the main window."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:131
+msgid ""
+"By default, the panes and toolbars are locked so they can't be moved "
+"accidentally. However, unchecking the option Lock panes and toolbars in "
+"the View menu will allow you to move them freely anywhere on the window, "
+"by dragging them from the top and dropping them at any position you like."
+" You can also undock a pane, which will open a new window with it. You "
+"can have as many separate windows as you have panes, if you choose. This "
+"feature is very useful if you work with several monitors because you can "
+"undock the Editor and move it to a different monitor, while working with "
+"the rest of the panes in your main monitor."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:133
+msgid ""
+"Additionally, you can split the Editor pane vertically or horizontally in"
+" as many copies as you want, and open one or more panels in separate "
+"Spyder windows, complete with their own toolbar, outline and status bar."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:135
+msgid ""
+"Finally, each pane can be customized further under its respective options"
+" menu and Preferences panel."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:137
+msgid ""
+"With all these options, you can customize Spyder to your heart's content."
+" However, if you ever want to return to its default configuration, you "
+"can always reset the window layout under Window Layouts in the View menu,"
+" or your entire Spyder configuration with the Reset to Default button in "
+"the Preferences."
+msgstr ""
+
+#: ../../videos/first-steps-with-spyder.rst:139
+msgid "Enjoy your customized version of Spyder, and Happy Spydering!"
+msgstr ""
+
+#: ../../videos/index.rst:3
+msgid "Intro Videos"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:3
+msgid "Working with Spyder"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:5
+msgid ""
+"In this section, you will learn about Spyder's more advanced "
+"functionality, and explore most of the panes."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:11
+msgid "Beyond the main panes"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:13
+msgid ""
+"Explore how to take advantage of Spyder’s functionality beyond just the "
+"four core panes."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:15
+msgid "View, manage and save figures with the Plots pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:16
+msgid "Browse, interact with and open external programs in the in the Files pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:17
+msgid "Quickly navigate within and between files with the Outline pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:18
+msgid ""
+"Search for text or regular expressions across your entire project with "
+"the Find pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:19
+msgid "Discover and explore structured documentation in the Online Help pane"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:33
+msgid ""
+"Hello everyone! I'm Juanita, and I am going to show you how to use some "
+"of the remaining panes available in Spyder beyond just the four primary "
+"ones."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:35
+msgid ""
+"Let's start with the Plots pane, which is open by default when launching "
+"Spyder. To see how it works, let's open a file that will generate a "
+"couple plots from Matplotlib's documentation. You can view the generated "
+"plots in the Plots pane and browse between them using the arrows, or "
+"simply clicking them in the sidebar."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:37
+msgid ""
+"If you open the pane's options menu, you will see that Fit Plots to "
+"Window is enabled by default. Disabling it will allow you to zoom the "
+"plots in or out. You can also see that Mute inline plotting is enabled, "
+"which prevents the same figures from also appearing in the IPython "
+"Console. Note that every time that the code is run, new copies of the "
+"plots are generated in the pane, but you can remove any you don't want to"
+" keep around with the X button in the pane toolbar. Additionally, the "
+"pane automatically updates to show the plots generated by each console as"
+" you switch between them."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:39
+msgid ""
+"To use a plot in another document, click the Copy to Clipboard button and"
+" paste it wherever you want, such as a word processor. Additionally, you "
+"can save a plot as a PNG by clicking the save icon."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:41
+msgid ""
+"The Files pane, also open by default, lets you browse the contents of the"
+" directories on your computer, open them in the Editor, and perform a "
+"variety of other file operations. You can show or hide the size, kind and"
+" date of the files in the pane's options menu. As you change the top-"
+"level folder you're viewing in the pane, Spyder's working directory shown"
+" in the top right of the main toolbar will update, which will also be "
+"synchronized with the currently active console. Double-clicking a text "
+"file will open it in the Editor, and copying one or more files will allow"
+" you to paste them as automatically-formatted absolute or relative paths."
+" Right-clicking any item will offer an array of additional options for "
+"interacting with it."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:43
+msgid ""
+"You can also open a file in the system default external application, or "
+"set up a custom file association in the File Associations tab of the "
+"Files preferences pane. For example, we can add the ``.csv`` extension "
+"and associate it with LibreOffice Calc under associated applications. Now"
+" every time you click a file with this extension, it opens externally "
+"with this program."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:45
+msgid ""
+"Now, let's see how to use the Outline pane to navigate within a file. "
+"First, we have to open the pane under Panes in the View menu, since it "
+"isn't visible by default. As you can see, it shows you all the classes, "
+"methods and functions that are currently defined, and allows you to move "
+"between them with just a click. For a very large file like this one, it "
+"is very useful to switch between classes easily instead of scrolling "
+"through the four-thousand-plus lines of code. You can also browse the "
+"methods of a class by expanding it using the arrows, or the buttons in "
+"the Outline pane's toolbar. The Outline continuously updates to highlight"
+" the function, method or class corresponding to the cursor position in "
+"your code, so you can easily keep track of what object you are working "
+"on. Finally, by going to the pane options menu and activating Show all "
+"files, you can easily switch between the scripts and modules you have "
+"open, which is particularly important for navigating larger projects."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:47
+msgid ""
+"The Files pane is another useful tool for particularly larger projects. "
+"Like the Outline pane, it can be opened under Panes in the View menu. "
+"This allows you to view and navigate through all occurrences of text or "
+"regular expressions in any file in the working directory, project or "
+"another custom directory. We see, for example, in the ``mainwindow.py`` "
+"file we import the ``is_dark_font_color`` function. If we want to quickly"
+" find the file where it was defined, we can write this string in the "
+"search bar. With this search, we get 7 matches from 3 different files. "
+"When we click on any of these matches, the file is opened automatically "
+"in the Editor, right where this string appears."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:49
+msgid ""
+"Finally, we'll learn how to browse documentation using the Online Help "
+"pane. Once you open it, again under Panes in the View menu, you will see "
+"an index of modules from which documentation is available, including both"
+" those in the Python standard library and any third-party packages that "
+"may be installed in Spyder's environment. For example, we can find help "
+"for Numpy, Pandas and Matplotlib, which are all installed if you've "
+"downloaded Spyder with Anaconda. You can browse the contents in the "
+"built-in web browser provided by the pane, and click the hyperlinks "
+"within to navigate to different pages. You can also enter the name of the"
+" item you'd like documentation on in the Get field or in the space over "
+"the pane's toolbar, to load its information directly. If you're not sure "
+"of the object's name, use the Search field to view a list of results "
+"applicable to any keyword."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:51
+msgid ""
+"Now that you're familiar with a wider array of Spyder's panes and "
+"features, you can accomplish a variety of common programming tasks with "
+"ease. Stay tuned for our our next videos to further add to your "
+"scientific toolbox, and as always, Happy Spydering!"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:57
+msgid "Improving your code quality"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:59
+msgid "Learn how to improve the quality of your programs using code analysis."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:61
+msgid ""
+"Open and use Code Analysis to evaluate the quality and style of Python "
+"files"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:62
+msgid "Run analysis on a file in the Editor or anywhere on your computer"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:63
+msgid "Determine what an error, warning or message means and how to fix it"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:64
+msgid "Turn off messages on a line, in a file or globally"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:78
+msgid ""
+"Hello everyone! I'm Juanita, and in this video we will learn how to "
+"improve your code quality using the Code Analysis pane. To display it, we"
+" can click its name under Panes in the View menu."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:80
+msgid ""
+"This pane detects style issues, bad practices, potential bugs and other "
+"quality problems in your code, without having to execute it. There are "
+"three ways of running code analysis:"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:82
+msgid ""
+"To analyze a file that is open in the Editor, we can press the "
+"configurable shortcut, :kbd:`F8` by default, or select Source --> Run "
+"code analysis from the menu bar."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:84
+msgid ""
+"We can also select a file to analyze by browsing for it using the file "
+"button next to the path box. This will start the analysis automatically."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:86
+msgid ""
+"The third way is to manually enter the path of a file we'd like to check "
+"in the path entry box in the pane's toolbar, and click the Analyze button"
+" in the pane."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:88
+msgid ""
+"Based on these results, the code analysis shows an overall score of "
+"4.34/10, which allows us to track improvements in our code quality. We "
+"can also expand or collapse one or all the sections in the pane to be "
+"able to see the Pylint errors, warnings and messages identifying the "
+"issues with our code."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:90
+msgid ""
+"For example, the results tell us that there is a warning on line 20. To "
+"go directly to this line in the Editor, just click the message. Here, the"
+" code analysis says there is a ``bad-whitespace`` issue. To understand "
+"what this means, open the Pylint documentation. On the `Pylint docs "
+"page`_ , click on Pylint features and search for the code of the message."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:94
+msgid ""
+"We can see that the docs say that we used the wrong number of spaces "
+"around an operator."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:102
+msgid ""
+"We can fix the error by adding one space before and after the operator in"
+" this variable assignment. If we run the analysis again, we can see the "
+"error isn't shown any more on this line."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:104
+msgid ""
+"We can click the dropdown arrow in the filename field to view the list of"
+" previous analyses. Clicking one of them will show us the results."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:106
+msgid ""
+"Sometimes, it is useful to turn certain messages off. We can do that in "
+"three different ways."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:108
+msgid ""
+"We might want to silence warnings on only one line; for example, this "
+"\"unused\" import that is still necessary for the code execution. For "
+"this, type ``# pylint: disable=unused-import`` as a comment at the end of"
+" the line. Running the analysis again will show us that the error is no "
+"longer visible."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:110
+msgid ""
+"If we want to silence a message in the whole file, we can do it by "
+"writing the disable command at the beginning of the file. For example, we"
+" can disable the ``invalid-name`` warning that appears several times in "
+"this file. If we run the analysis again, all of these warnings are gone."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:112
+msgid ""
+"Finally, we can suppress specific messages for all files by editing the "
+"``.pylintrc`` configuration file in your user folder. If it doesn't "
+"exist, we can generate it by opening our terminal, or the Anaconda Prompt"
+" if you're using Windows, and running ``pylint --generate-rc > "
+".pylintrc`` in our user directory."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:114
+msgid ""
+"Now, we can go to the ``MESSAGE CONTROL`` section in this file and add "
+"the corresponding Pylint message name, for example ``no-name-in-module``."
+" If we run the analysis one more time, we see that the ``no-name-in-"
+"module`` warnings don't appear anymore."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:116
+msgid ""
+"We can see that the score of our file increased to 7.63/10, a big "
+"improvement over the previous 4.34."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:118
+msgid ""
+"Now that we've learned how to improve the quality of our code, you are "
+"ready to write cleaner and more correct programs using Spyder. Stay tuned"
+" for our next videos and as always, Happy Spydering!"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:124
+msgid "Optimizing your code"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:126
+msgid "Learn how to optimize your code using the Profiler."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:128
+msgid "Use the Profiler to find bottlenecks in your programs"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:129
+msgid "Run profiling on a file in the Editor or elsewhere on your machine"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:130
+msgid "Interpret the results to evaluate function and method performance"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:131
+msgid "Use the information to speed up the run time of your code"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:145
+msgid ""
+"Hello everyone! I'm Juanita, and in this video we will learn how to "
+"optimize your code using the profiler. To display it, click its name "
+"under Panes in the View menu."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:147
+msgid ""
+"The Profiler will determine the run time and number of calls for every "
+"function and method used in a file. There are three ways of profiling a "
+"file:"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:149
+msgid ""
+"We can browse for a file using the open button to the right of the "
+"Profiler's path box, which will run profiling over it automatically."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:151
+msgid ""
+"We can also manually enter the path in the pane's path box, and then run "
+"the analysis on the file by pressing the Profile button."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:153
+msgid ""
+"If we want to run the profiler for the file that is currently open in the"
+" Editor, we can click Run --> Profile... in the menu bar, or use the "
+"configurable shortcut :kbd:`F10`."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:155
+msgid ""
+"We see that the results in the pane show us the different functions and "
+"methods in our file, with each sub-function listed hierarchically under "
+"the item that called them. The columns show the total time taken by each "
+"function and everything it called, while the local time includes only the"
+" time spent in that particular function."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:157
+msgid ""
+"For example, the function ``values`` in this file calls a function "
+"``internal_values`` values took a total of 482 us to run, with 338 us of "
+"that spent executing internal_values inside of it. Therefore, the total "
+"time for values is 482 us, but its local time is only 144 us as the rest "
+"was spent inside ``internal_values``."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:159
+msgid ""
+"The Calls column displays the total number of times that function was "
+"called at that level. Finally, the numbers in the Diff columns for each "
+"of the three appear if a comparison is loaded, and indicate the change in"
+" runtime between the two measurements."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:161
+msgid ""
+"By double-clicking an item in the Profiler, we will be taken to the file "
+"and line in the Editor where it was called. If this function was not "
+"called in one of your open scripts, clicking it will open the file that "
+"contains it. We can click the down arrow button in the filename field to "
+"recall paths of previously profiled files."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:163
+msgid ""
+"Now that we know how to interpret the results of our profiling, let's "
+"optimize our code by finding the functions that take the longest time and"
+" making them faster. In this case, ``to_datetime`` takes 39 seconds to "
+"run. The reason for this is Pandas has to parse the non-standard "
+"timestamp format and is not told to try to use a faster parser than the "
+"default."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:165
+#, python-format
+msgid ""
+"We can reduce the time this function takes and compare it with the one "
+"before. For this, first we have to save the data as a ``.Result`` file "
+"with the save button in the pane. Now we have to figure out how to "
+"optimize the function, so let's search for it. We see that we can speed "
+"up this function by `manually specifying a datetime format`_. So, we add "
+"the appropriate argument, ``format=\"%Y-%m-%d %H:%M:%S.%f %z\"``, to our "
+"function call."
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:169
+msgid ""
+"Now, we run the profiling again to see how our script's performance has "
+"improved. If we want to see how much we lowered the time, we can load our"
+" previous result and take a look at the diff columns. Notice the "
+"difference is green because the time was reduced by three times, taking "
+"only 13 seconds instead of 39. Our code is now 26 seconds faster!"
+msgstr ""
+
+#: ../../videos/working-with-spyder.rst:171
+msgid ""
+"Now that you've learned how to analyze the execution time of your code, "
+"you are ready to write more efficient programs with Spyder's help. Stay "
+"tuned for our next videos and as always, Happy Spydering!"
+msgstr ""
+

--- a/doc/locales/pot/workshops.pot
+++ b/doc/locales/pot/workshops.pot
@@ -1,0 +1,4508 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C)  2009-2024 Spyder Doc Contributors; MIT License
+# This file is distributed under the same license as the Spyder package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Spyder 5\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-01-29 08:54-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: en <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../workshops/financial.rst:3
+msgid "Financial Data Analysis with Spyder"
+msgstr ""
+
+#: ../../workshops/financial.rst:5
+msgid ""
+"By the end of this workshop participants will be able to use Spyder "
+"effectively for  applying some normative financial theories and models to"
+" assemble a portfolio of assets in a way that maximizes the expected "
+"return for a given level of risk. In this way, statistically-based tools "
+"are used to construct investment portfolios."
+msgstr ""
+
+#: ../../workshops/financial.rst:11 ../../workshops/plugin-development.rst:15
+#: ../../workshops/scientific-computing.rst:11
+msgid "Prerequisites"
+msgstr ""
+
+#: ../../workshops/financial.rst:13
+msgid ""
+"To follow this workshop we recommend that you have a intermediate "
+"knowledge of Python. You can visit `The Python Tutorial`_ to learn the "
+"basics of this programming language or to refresh your knowledge of "
+"Python."
+msgstr ""
+
+#: ../../workshops/financial.rst:17
+msgid ""
+"You will also need to have `Anaconda "
+"<https://www.anaconda.com/products/individual>`_ (or `Miniconda "
+"<https://docs.conda.io/en/latest/miniconda.html>`_) and Spyder installed."
+" More information about Spyder installation in :doc:`installation "
+"guide<../installation>`."
+msgstr ""
+
+#: ../../workshops/financial.rst:21 ../../workshops/scientific-computing.rst:17
+msgid ""
+"Spyder now offers :ref:`install-standalone` for Windows and macOS, making"
+" it easier to get up and running with the application without having to "
+"download Anaconda or manually install it in your existing environment. "
+"While we still support Anaconda, we recommend this install method on "
+"those platforms to avoid most problems with package conflicts and other "
+"issues."
+msgstr ""
+
+#: ../../workshops/financial.rst:25 ../../workshops/plugin-development.rst:24
+#: ../../workshops/scientific-computing.rst:20
+msgid "It is also desirable to have the following prior knowledge:"
+msgstr ""
+
+#: ../../workshops/financial.rst:27
+msgid "Intermediate level of Python"
+msgstr ""
+
+#: ../../workshops/financial.rst:28
+msgid "Basic knowledge of Statistics"
+msgstr ""
+
+#: ../../workshops/financial.rst:29
+msgid "Some knowledge of Financial Econometrics is desirable"
+msgstr ""
+
+#: ../../workshops/financial.rst:34 ../../workshops/scientific-computing.rst:34
+msgid "Learning goals"
+msgstr ""
+
+#: ../../workshops/financial.rst:36 ../../workshops/scientific-computing.rst:36
+msgid "After completing this workshop, you should be able to:"
+msgstr ""
+
+#: ../../workshops/financial.rst:38
+msgid ""
+"Apply elementary statistical analysis to stock and cryptocurrency "
+"portfolios to measure their performance"
+msgstr ""
+
+#: ../../workshops/financial.rst:39
+msgid ""
+"Understand the advantages of programming with an IDE, such as inspecting "
+"variables using the Variable Explorer and interacting with plots "
+"leveraging the Plots Pane."
+msgstr ""
+
+#: ../../workshops/financial.rst:44 ../../workshops/scientific-computing.rst:45
+msgid "Learner profile"
+msgstr ""
+
+#: ../../workshops/financial.rst:46
+msgid ""
+"This workshop is intended for people interested in finance who want to "
+"take their first steps in Financial Analysis using Python and Spyder."
+msgstr ""
+
+#: ../../workshops/financial.rst:52 ../../workshops/scientific-computing.rst:53
+msgid "Intro"
+msgstr ""
+
+#: ../../workshops/financial.rst:54
+msgid ""
+"In this workshop we will obtain financial data in real-time from `Yahoo! "
+"Finance`_ API and explore financial portfolios using Econometrics and "
+"computational tools."
+msgstr ""
+
+#: ../../workshops/financial.rst:58
+msgid "Why use Python for financial analysis?"
+msgstr ""
+
+#: ../../workshops/financial.rst:60
+msgid ""
+"Real-time analysis of historical and current financial data is essential "
+"for those investing in financial instruments. Python has a number of "
+"features that make it ideal for financial tasks:"
+msgstr ""
+
+#: ../../workshops/financial.rst:62
+msgid ""
+"It is easy to learn for anyone, whether they have previous programming "
+"experience or not"
+msgstr ""
+
+#: ../../workshops/financial.rst:63
+msgid ""
+"It has a variety of specialized mathematical and statistical libraries "
+"(`SciPy <https://scipy.org>`_, `NumPy <https://numpy.org>`_, `Pandas "
+"<https://pandas.pydata.org>`_) that are commonly used for financial "
+"analysis"
+msgstr ""
+
+#: ../../workshops/financial.rst:64
+msgid "It can be connected to APIs for loading financial data in real time"
+msgstr ""
+
+#: ../../workshops/financial.rst:65
+msgid ""
+"It is the programming language with the most resources for machine "
+"learning (supervised learning, unsupervised learning, reinforcement "
+"learning), which is one of the most useful tools for Econometrics "
+"nowadays"
+msgstr ""
+
+#: ../../workshops/financial.rst:66 ../../workshops/scientific-computing.rst:68
+msgid "It has excellent libraries for plotting"
+msgstr ""
+
+#: ../../workshops/financial.rst:67
+msgid ""
+"You can use resources such as `Google Colab "
+"<https://colab.research.google.com>`_ or `Binder <https://mybinder.org>`_"
+" to do your analysis in the cloud."
+msgstr ""
+
+#: ../../workshops/financial.rst:71
+msgid "Why should I use an IDE?"
+msgstr ""
+
+#: ../../workshops/financial.rst:73
+msgid ""
+"Although you can use Python without an IDE (Integrated Development "
+"Environment), you will work much better with one. Spyder is a Scientific "
+"Integrated Development Environment written in Python, and designed by and"
+" for scientists, engineers, and data analysts. Spyder's capabilities and "
+"its integration with Python make it perfect for financial analysis."
+msgstr ""
+
+#: ../../workshops/financial.rst:77
+msgid "Introduction to financial analysis with Spyder"
+msgstr ""
+
+#: ../../workshops/financial.rst:79 ../../workshops/scientific-computing.rst:96
+msgid ""
+"If you're not familiar with Spyder, we recommend you start with our "
+":doc:`Quickstart<../quickstart>`. But if you want a  summary, here's a "
+"quick overview."
+msgstr ""
+
+#: ../../workshops/financial.rst:83
+msgid "If you already have experience with Spyder, you can skip this section."
+msgstr ""
+
+#: ../../workshops/financial.rst:87
+#: ../../workshops/scientific-computing.rst:104
+msgid "Editor"
+msgstr ""
+
+#: ../../workshops/financial.rst:89
+#: ../../workshops/scientific-computing.rst:106
+msgid ""
+"The :doc:`Editor<../panes/editor>` is the place where you write your code"
+" and save it as a file (script). It allows you to easily persist your "
+"work. This is where you write the code you want to keep from the data "
+"analysis you do in IPython Console. **Here you will also be able to read,"
+" edit and run the code from this workshop**."
+msgstr ""
+
+#: ../../workshops/financial.rst:93
+#: ../../workshops/scientific-computing.rst:110
+msgid "IPython Console"
+msgstr ""
+
+#: ../../workshops/financial.rst:95
+#: ../../workshops/scientific-computing.rst:112
+msgid ""
+"The :doc:`IPython Console<../panes/ipythonconsole>` is the Spyder's "
+"component where you write chunks of code that you want to experiment "
+"with. **In this workshop, we are going to give you pieces of code that "
+"you can copy and run in this console**."
+msgstr ""
+
+#: ../../workshops/financial.rst:97
+#: ../../workshops/scientific-computing.rst:114
+msgid ""
+"In essence, the IPython Console allows you to execute commands and "
+"interact with data using Python."
+msgstr ""
+
+#: ../../workshops/financial.rst:101
+#: ../../workshops/scientific-computing.rst:118
+msgid "Variable Explorer"
+msgstr ""
+
+#: ../../workshops/financial.rst:103
+#: ../../workshops/scientific-computing.rst:120
+msgid ""
+"The :doc:`Variable Explorer<../panes/variableexplorer>` is one of "
+"Spyder's best features. It allows you to interactively browse and manage "
+"the objects generated in the code of the currently selected "
+":doc:`../panes/ipythonconsole` session."
+msgstr ""
+
+#: ../../workshops/financial.rst:105
+msgid ""
+"The Variable Explorer is one of the most frequently used components in "
+"this workshop. **This is the pane where we will observe the data and most"
+" of the results of the analysis, except for the plots**."
+msgstr ""
+
+#: ../../workshops/financial.rst:109
+#: ../../workshops/scientific-computing.rst:126
+msgid "Plots pane"
+msgstr ""
+
+#: ../../workshops/financial.rst:111
+msgid ""
+"The :doc:`Plots pane <../panes/plots>` shows all the static graphs and "
+"images created in your IPython Console session. **All plots generated by "
+"the code will appear in this component**.  This pane also allows you to "
+"save each graphic in a local file or copy it to the clipboard to share it"
+" with other people."
+msgstr ""
+
+#: ../../workshops/financial.rst:117
+#: ../../workshops/scientific-computing.rst:140
+msgid "Preparation work"
+msgstr ""
+
+#: ../../workshops/financial.rst:119
+#: ../../workshops/scientific-computing.rst:142
+msgid ""
+"Before starting, you must have installed some packages and libraries "
+"needed to run the code. We recommend you to install these requirements in"
+" a virtual environment. Here we explain step by step how to do it."
+msgstr ""
+
+#: ../../workshops/financial.rst:123
+msgid "Set up Conda environment"
+msgstr ""
+
+#: ../../workshops/financial.rst:125
+#: ../../workshops/scientific-computing.rst:148
+msgid ""
+"If you would like to have Spyder in a dedicated environment to update it "
+"separately from your other packages and avoid any conflicts, you can."
+msgstr ""
+
+#: ../../workshops/financial.rst:127
+#: ../../workshops/scientific-computing.rst:150
+msgid "You can set up your environment in two different ways."
+msgstr ""
+
+#: ../../workshops/financial.rst:131
+msgid ""
+"We recommend creating the virtual environment with Anaconda (or "
+"Miniconda) as it integrates seamlessly with Spyder. You can find "
+"installation instructions in `Anaconda documentation`_."
+msgstr ""
+
+#: ../../workshops/financial.rst:137
+msgid "With commands"
+msgstr ""
+
+#: ../../workshops/financial.rst:139
+msgid ""
+"Just run the following command in your Anaconda Prompt (Windows) or "
+"terminal (other platforms), to create a new environment called "
+"``financial-analysis``:"
+msgstr ""
+
+#: ../../workshops/financial.rst:145
+msgid ""
+"To install Spyder's optional dependencies as well for full functionality,"
+" use the following command:"
+msgstr ""
+
+#: ../../workshops/financial.rst:156
+msgid ""
+"Spyder now offers :ref:`install-standalone` for Windows and macOS, making"
+" it easier to get up and running with the application without having to "
+"download Anaconda or manually install it in your existing environment."
+msgstr ""
+
+#: ../../workshops/financial.rst:160
+msgid "Download the datasets"
+msgstr ""
+
+#: ../../workshops/financial.rst:162
+msgid ""
+"Although during the workshop we will explain how to use some APIs to "
+"download up-to-date data, you can also download the datasets in csv "
+"format from `this link "
+"<https://figshare.com/articles/dataset/Historical_financial_datasets_for_Financial_Analysis_with_Spyder_workshop/14995215>`_."
+msgstr ""
+
+#: ../../workshops/financial.rst:164
+msgid ""
+"To follow this workshop you do not need to create a new directory. "
+"However, if you have downloaded the data and want to use it instead of "
+"the APIs, you must set the directory that has the downloaded data as the "
+"working directory. In order to do this, check that the working directory "
+"is correct. You should see in the upper right corner the path to the "
+"directory where you have the downloaded data. Something like this:"
+msgstr ""
+
+#: ../../workshops/financial.rst:171
+msgid "Setting up the virtual environment in Spyder"
+msgstr ""
+
+#: ../../workshops/financial.rst:173
+msgid ""
+"Let's check that the virtual environment we created is enabled in Spyder."
+" Go to :guilabel:`Preferences > Python interpreter`, and use the dropdown"
+" below :guilabel:`Use the following Python interpreter` to choose your "
+"virtual environment. You should see something like this:"
+msgstr ""
+
+#: ../../workshops/financial.rst:178
+#: ../../workshops/scientific-computing.rst:239
+msgid "Now, you have everything ready to proceed with the workshop."
+msgstr ""
+
+#: ../../workshops/financial.rst:182
+#: ../../workshops/scientific-computing.rst:243
+msgid "Download the code"
+msgstr ""
+
+#: ../../workshops/financial.rst:184
+msgid ""
+"Although the workshop is designed for you to write the code in the "
+"IPython Console, we have created a file that you can download "
+":download:`here <financial-analysis.py>`. This script provides all the "
+"code you will write in this workshop, and you can use it as a guide if "
+"you get lost."
+msgstr ""
+
+#: ../../workshops/financial.rst:190
+msgid "Obtain financial data"
+msgstr ""
+
+#: ../../workshops/financial.rst:192
+msgid ""
+"When it comes to finance, being up to date is very important. So we are "
+"going to use a Python library that allows us to get updated historical "
+"Stock Market records from `Yahoo! Finance`_ API. In this way, we will be "
+"able to download data in the period of time we are interested in "
+"analyzing."
+msgstr ""
+
+#: ../../workshops/financial.rst:197
+#: ../../workshops/scientific-computing.rst:261
+msgid ""
+"Remember to type and run all code for this workshop in the \"IPython "
+"Console\" at the bottom right of Spyder."
+msgstr ""
+
+#: ../../workshops/financial.rst:202
+msgid ""
+"You can also write your code in the Editor (the pane that occupies the "
+"entire left side of Spyder). If you use the Editor, you can run the code "
+"by selecting it and pressing the :guilabel:`Run selection or current "
+"line` button in the :guilabel:`Run toolbar` or by pressing the :kbd:`F9` "
+"key."
+msgstr ""
+
+#: ../../workshops/financial.rst:207
+#: ../../workshops/scientific-computing.rst:271
+msgid "To get started, import the libraries."
+msgstr ""
+
+#: ../../workshops/financial.rst:222
+msgid ""
+"The first group of imports is for basic operations. The second "
+"(``Historic_Crypto`` and ``yfinance``) imports the libraries that we will"
+" use to download financial data."
+msgstr ""
+
+#: ../../workshops/financial.rst:224
+msgid ""
+"Let's start exploring libraries with an example. We are going to get "
+"financial information about Netflix with one line of code:"
+msgstr ""
+
+#: ../../workshops/financial.rst:230
+msgid ""
+"We have used the ``Ticker`` class of the ``yfinance`` library to create a"
+" ``netflix`` object. This object contains attributes and methods that we "
+"can query to obtain various types of information."
+msgstr ""
+
+#: ../../workshops/financial.rst:234
+msgid "General stock information"
+msgstr ""
+
+#: ../../workshops/financial.rst:236
+msgid ""
+"If you want to know which methods and attributes you can query, you can "
+"do so with the built-in ``help()`` function."
+msgstr ""
+
+#: ../../workshops/financial.rst:238
+msgid ""
+"You can also type the name of the object (``netflix``) in the console, "
+"then type a period and hit the Tab key once. IPython suggestions will "
+"then appear to help you navigate the object:"
+msgstr ""
+
+#: ../../workshops/financial.rst:243
+msgid ""
+"For example, we can obtain general information with the ``info`` property"
+" of the object."
+msgstr ""
+
+#: ../../workshops/financial.rst:249
+msgid ""
+"We can observe the result in the Variable Explorer, in the "
+"``netflix_info`` variable."
+msgstr ""
+
+#: ../../workshops/financial.rst:254
+msgid ""
+"If we double-click on it, a new window with detailed information will be "
+"displayed."
+msgstr ""
+
+#: ../../workshops/financial.rst:259
+msgid ""
+"In that window we can see a Python dictionary in which each key has a "
+"value assigned to it. Each type of value is represented by a distinctive "
+"color. For example, we see that Netflix is an Entertainment industry, the"
+" summary of the business type, among other indicators. The Variable "
+"Explorer is a very convenient way to view these types of results. We can "
+"compare it to viewing them in the IPython Console with the ``pprint`` "
+"function:"
+msgstr ""
+
+#: ../../workshops/financial.rst:268
+msgid ""
+"Although ``pprint`` displays all the information, it is easier to view it"
+" in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:272
+msgid "Historical stock data"
+msgstr ""
+
+#: ../../workshops/financial.rst:274
+msgid ""
+"We can download in a dataset the history of a stock with the following "
+"line of code:"
+msgstr ""
+
+#: ../../workshops/financial.rst:280
+msgid ""
+"We can see a summary and more details of this dataset in the Variable "
+"Explorer. It appears as a DataFrame object, with 7 columns and thousands "
+"of rows. If we double-click on it we will see the historical records of "
+"Netflix stock organized by ascending dates."
+msgstr ""
+
+#: ../../workshops/financial.rst:285
+msgid ""
+"Throughout this workshop we will use this historical information to "
+"compare, with various normative financial theories, different types of "
+"financial portfolios."
+msgstr ""
+
+#: ../../workshops/financial.rst:291
+msgid "First portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:293
+msgid ""
+"Let's build our first stock investment portfolio! Say we are interested "
+"in investing in technology, and we want to know what performance can be "
+"obtained by putting money into some of the \"heavyweights\" in this "
+"industry."
+msgstr ""
+
+#: ../../workshops/financial.rst:295
+msgid ""
+"To measure the performance of our first portfolio we are going to use a "
+"classic theory in the world of finance: `mean-variance portfolio (MVP) "
+"theory`_. This model assumes that investors only care about expected "
+"returns and the variance of such returns. The analysis is based entirely "
+"on statistical measures based on a time series of share prices, such as "
+"periodic mean returns and the variances of those returns with the same "
+"periodicity."
+msgstr ""
+
+#: ../../workshops/financial.rst:301
+msgid "Prepare portfolio data"
+msgstr ""
+
+#: ../../workshops/financial.rst:303
+msgid ""
+"Before we start, let's run some lines of code to style the plots.  These "
+"lines are optional, but we recommend that you run them so that the "
+"graphics look like the screenshots we present in this workshop."
+msgstr ""
+
+#: ../../workshops/financial.rst:312
+msgid ""
+"Suppose we want to measure the performance of a portfolio consisting of "
+"Google, Apple, Microsoft, Netflix and Amazon stocks. Let's call this set "
+"``SYMBOLS_1``."
+msgstr ""
+
+#: ../../workshops/financial.rst:320
+msgid ""
+"If you search for ``SYMBOLS_1`` in Variable Explorer you will not find "
+"it: Python interprets this element not as a variable, but as a "
+"**constant**. This is because the name is written with uppercase letters "
+"(no letter is lowercase). By default, the Variable Explorer doesn't show "
+"this, but actually you can change the settings in the "
+":guilabel:`Preferences` to be able to see these constants."
+msgstr ""
+
+#: ../../workshops/financial.rst:322
+msgid ""
+"We are going to download the historical data for this portfolio. To do "
+"this, we are going to use the ``yfinance`` ``download()`` function, which"
+" takes as its first argument a string with the symbols (``SYMBOLS_1``) "
+"defined above. The rest of the arguments are the start date "
+"(``start=\"2012-01-01\"``), the end date (``end=\"2021-01-01\"``) and how"
+" the data will be grouped (``group_by=\"Ticker\"``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:328
+msgid ""
+"The last argument (``group_by=\"Ticker\"``) groups the information mainly"
+" by stock. Otherwise, the primary grouping is done by the type of "
+"information (e.g., opening price, closing price, volume traded) of the "
+"transactions. In the following image you can see the differences (above "
+"is the default organization and below is the grouping by \"Ticker\")."
+msgstr ""
+
+#: ../../workshops/financial.rst:334
+msgid ""
+"The historical data has been downloaded as a Pandas DataFrame. We can "
+"explore this data in the variable ``data_1`` in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:339
+msgid ""
+"Let's change the formatting of the data a bit so that the symbols appear "
+"as the column names, and the Ticker moves from columns to rows. We will "
+"do this with the ``stack()`` operation of the DataFrame."
+msgstr ""
+
+#: ../../workshops/financial.rst:348
+msgid ""
+"From the Ticker we are only interested in the daily closing price. So we "
+"will leave only the values for ``\"Close\"`` and eliminate the Ticker "
+"column afterwards."
+msgstr ""
+
+#: ../../workshops/financial.rst:354
+msgid ""
+"You will notice that there is a new DataFrame in the Variable Explorer "
+"called ``close_data_1`` with 2,265 rows and 5 columns."
+msgstr ""
+
+#: ../../workshops/financial.rst:358
+msgid "A first glance at the portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:360
+msgid ""
+"We want to see how our portfolio would have performed if we had invested "
+"in it from 2012 to early 2021. How could we obtain this measurement? "
+"Let's look at the monthly closing prices of each stock. To do this we "
+"will do an automatic resample of the data. And then we will calculate the"
+" change in relative frequencies (percentages)."
+msgstr ""
+
+#: ../../workshops/financial.rst:362
+msgid ""
+"The resampling will be performed with the ``resample(\"M\")`` method and "
+"the calculation of percentages with the ``pct_change()`` method. The "
+"result will be stored in the ``monthly_data_1`` variable."
+msgstr ""
+
+#: ../../workshops/financial.rst:368
+msgid ""
+"Since each stock is a column, we can use the ``mean()`` method on the "
+"DataFrame to see the results."
+msgstr ""
+
+#: ../../workshops/financial.rst:383
+msgid ""
+"Remember that this closing information represents the relative growth of "
+"each stock, not its closing price in any currency."
+msgstr ""
+
+#: ../../workshops/financial.rst:385
+msgid ""
+"As we can see, all the results are positive, so this portfolio has been "
+"profitable over the years. In relative terms, the biggest gains would "
+"come from Netflix (0.4 percent). These percentages show an average of the"
+" monthly variation of the stock price. But how stable have that prices "
+"been? To find this out, we can calculate the standard deviation of stock "
+"price growth:"
+msgstr ""
+
+#: ../../workshops/financial.rst:398
+msgid ""
+"The highest volatility is found in Netflix (0.1454), which indicates that"
+" its price, despite being the fastest growing, has also had a lot of "
+"variation during these years. The most stable price, on the other hand, "
+"has been Microsoft's (0.0583)."
+msgstr ""
+
+#: ../../workshops/financial.rst:400
+msgid ""
+"A good way to observe both growth and variability is to draw a time-"
+"series plot. To scale the values, we are going to divide the relative "
+"frequency of the closing price of the actions by the initial value it has"
+" in the dataframe ``close_data_1`` (these initial values can be found "
+"with ``close_data_1.iloc[0])``). The plot is drawn with the ``plot()`` "
+"method of the Pandas DataFrame (to which we pass as arguments the size of"
+" the plot and the plot title)."
+msgstr ""
+
+#: ../../workshops/financial.rst:411
+msgid ""
+"You will be able to see the graph in the Plots pane. On the left, you "
+"will see the plot in detail. On the right, a stack will be created with "
+"all the plots that are generated both in the Console and by running the "
+"code directly in the Editor. You can copy, delete or save the plot to "
+"disk by clicking on it with the right mouse button or trackpad."
+msgstr ""
+
+#: ../../workshops/financial.rst:413
+msgid ""
+"The above time-series plot clearly shows the growth of all stocks, "
+"particularly Netflix. The high volatility discussed above can also be "
+"seen. For example, it can be seen from the plots that, due to high "
+"volatility, investing in Netflix in the years 2014 and 2019 left "
+"virtually no profit (if shares were bought at the beginning of the year "
+"and sold right at the end)."
+msgstr ""
+
+#: ../../workshops/financial.rst:415
+msgid ""
+"We can also plot with the ``plot()`` method the DataFrame we already have"
+" with the monthly data. To do this, we will add 1 to all the values and "
+"calculate the accumulated product with the ``cumprod()`` method:"
+msgstr ""
+
+#: ../../workshops/financial.rst:424
+msgid ""
+"This plot of the monthly data is \"smoother\" than the plot of the daily "
+"data."
+msgstr ""
+
+#: ../../workshops/financial.rst:428
+msgid "Returns and volatility"
+msgstr ""
+
+#: ../../workshops/financial.rst:430
+msgid ""
+"Remember that in the *mean-variance portfolio theory* what matters are "
+"the expected returns and variances. To calculate these returns, we will "
+"divide the price of the stock on one day by the price of the same stock "
+"on the previous day. We will do this by dividing the ``close_data_1`` "
+"DataFrame by a version of itself in which we shift each record one date "
+"backwards (``shift(1)``). For example, if on the date 2012-01-03 a stock "
+"was valued at 1, and on the next day (2012-01-02), it was valued at 2, "
+"then in our shifted dataset, on the day 2012-01-03 the stock would be "
+"worth 1. In this way, we would divide 1 by 2. And so on with all the "
+"values of all the shares. We will also normalize the results by passing "
+"them to a logarithmic scale with ``np.log()``."
+msgstr ""
+
+#: ../../workshops/financial.rst:434
+msgid ""
+"Trend lines are more easily drawn in logarithmic scale because they tend "
+"to fit better to the minimums. In addition, the logarithmic scale gives a"
+" more realistic view of price movements."
+msgstr ""
+
+#: ../../workshops/financial.rst:440
+msgid ""
+"In the variable ``rets_1`` you can see the resulting DataFrame. If you "
+"double-click on the variable name in the Variable Explorer, you will see "
+"that there are positive values (the share price increased) and negative "
+"values (the price decreased at the time of closing)."
+msgstr ""
+
+#: ../../workshops/financial.rst:445
+msgid ""
+"In addition to the returns of each stock, we will need the specific "
+"weight of each stock in the portfolio, i.e., how many shares of each "
+"company are in the portfolio. In this workshop we will assume that there "
+"is one share of each company and, therefore, the weights will be "
+"distributed equally."
+msgstr ""
+
+#: ../../workshops/financial.rst:449
+msgid ""
+"A stock is a financial security that represents that you own a part of a "
+"company (whatever the size of this part). A share, on the other hand, is "
+"the smallest unit of denomination of a stock. A stock is composed of one "
+"or several shares."
+msgstr ""
+
+#: ../../workshops/financial.rst:451
+msgid ""
+"This weight will be a vector (Python list) composed of the relative "
+"weight (between 0 and 1) of each stock in the portfolio. The sum of these"
+" weights has to be 1. Since we will assume that each stock is a single "
+"share, the distribution will be equal: ``[0.2, 0.2, 0.2, 0.2, 0.2]``."
+msgstr ""
+
+#: ../../workshops/financial.rst:457
+msgid ""
+"With this information we can calculate the expected return of this "
+"portfolio. The math is simple: this is given by the dot product of the "
+"portfolio weights vector and the vector of expected returns. This result "
+"must be multiplied by the number of days for which the return is to be "
+"calculated (a year has approximately 252 stock price closings)."
+msgstr ""
+
+#: ../../workshops/financial.rst:459
+msgid "Let's put all this into a function:"
+msgstr ""
+
+#: ../../workshops/financial.rst:466
+msgid ""
+"Let's look at the expected return of this portfolio if we hold it for one"
+" year:"
+msgstr ""
+
+#: ../../workshops/financial.rst:474
+#, python-format
+msgid ""
+"An expected gain of almost 30% in one year. Not bad, right? But don't "
+"forget the other side of this coin: volatility. This calculation is a bit"
+" more complex. First, the dot product of the annualized covariance of the"
+" returns (this is multiplied by the number of trading days in a year) and"
+" the weights is calculated. Then the dot product of the weights and the "
+"previous result is obtained. Finally, the square root of this result is "
+"extracted. Let's implement this into a function as well."
+msgstr ""
+
+#: ../../workshops/financial.rst:481
+msgid "Let's see how our portfolio performs with respect to its volatility:"
+msgstr ""
+
+#: ../../workshops/financial.rst:489
+msgid ""
+"If high return is desirable, high volatility is undesirable. The risk of "
+"this portfolio is relatively large."
+msgstr ""
+
+#: ../../workshops/financial.rst:493
+msgid "Sharpe ratio"
+msgstr ""
+
+#: ../../workshops/financial.rst:495
+msgid ""
+"The `Sharpe`_ ratio or index is a measure of portfolio performance. It "
+"relates the portfolio's return to its volatility, comparing the "
+"expected/realized return with the expected/realized risk. It is "
+"calculated as the difference between the actual investment returns and "
+"the expected return in a zero-risk situation, divided by the volatility "
+"of the investment. **It provides a model of the additional amount of "
+"returns received for each additional unit of risk**."
+msgstr ""
+
+#: ../../workshops/financial.rst:499
+msgid "Let's formalize this in a function:"
+msgstr ""
+
+#: ../../workshops/financial.rst:506
+msgid "And let's apply this to our portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:516
+msgid ""
+"The Sharpe ratio measure is best understood in context: when comparing "
+"two or more portfolios, the one with the higher Sharpe ratio provides "
+"more profit for the same amount of risk."
+msgstr ""
+
+#: ../../workshops/financial.rst:518
+msgid ""
+"We can also use a `Monte Carlo "
+"<https://en.wikipedia.org/wiki/Monte_Carlo_method>`_ simulation to "
+"randomize the weights of each stock in the portfolio so that we can see "
+"the range over which the Sharpe ratio can vary. In this way we can plot "
+"some scenarios that together will give us a good insight of the "
+"relationship between expected returns and expected volatility."
+msgstr ""
+
+#: ../../workshops/financial.rst:520
+msgid ""
+"We are going to do this with a function that we will explain step by step"
+" in the `monte_carlo_sharpe function explained`_ section."
+msgstr ""
+
+#: ../../workshops/financial.rst:538
+msgid ""
+"You do not need to type the following code in the IPython Console. If you"
+" write the function above it will be enough. It is just a code "
+"presentation to explain what is inside the function."
+msgstr ""
+
+#: ../../workshops/financial.rst:542
+msgid "``monte_carlo_sharpe`` function explained"
+msgstr ""
+
+#: ../../workshops/financial.rst:544
+msgid ""
+"Let's now break the function down to understand what is happening. First,"
+" we create a numpy array of length 1,000 and width of the number of "
+"shares in the portfolio. Each row of the array has random weights that "
+"always add up to 1:"
+msgstr ""
+
+#: ../../workshops/financial.rst:552
+msgid ""
+"The next section calculates the volatility and returns for the new random"
+" weights using a list comprehension. The resulting list is transformed "
+"back into a numpy array:"
+msgstr ""
+
+#: ../../workshops/financial.rst:559
+msgid ""
+"Finally, we obtain the Sharpe ratio by dividing the index 1 "
+"(volatilities) by the index 0 (returns) of the numpy array:"
+msgstr ""
+
+#: ../../workshops/financial.rst:567
+msgid "Using the ``monte_carlo_sharpe`` function"
+msgstr ""
+
+#: ../../workshops/financial.rst:569
+msgid ""
+"We use the function to get the simulated returns and volatility of "
+"portfolio 1 (``port_1_vr``) and the related Sharpe ratios "
+"(``port_1_sr``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:571
+msgid "Enter the following code in the console."
+msgstr ""
+
+#: ../../workshops/financial.rst:579
+msgid ""
+"Remember that the weights are initialized randomly, so each time you run "
+"this code you will get different results."
+msgstr ""
+
+#: ../../workshops/financial.rst:581
+msgid ""
+"With this we obtain two arrays with 1,000 simulated cases for our "
+"portfolio. But the best way to explore this is with a plot."
+msgstr ""
+
+#: ../../workshops/financial.rst:593
+msgid "You should see in the Plots pane something like this:"
+msgstr ""
+
+#: ../../workshops/financial.rst:598
+msgid ""
+"A roughly linear relationship can be observed between returns and "
+"volatility: the higher the volatility, the higher the gains. And the "
+"Sharpe ratio shows an important amount of variability (it is noticeable "
+"in the \"width\" of the line drawn)."
+msgstr ""
+
+#: ../../workshops/financial.rst:600
+msgid ""
+"This seems to be a good portfolio because it has a good performance with "
+"a not very large variance."
+msgstr ""
+
+#: ../../workshops/financial.rst:604
+msgid "Optimal portfolio weights"
+msgstr ""
+
+#: ../../workshops/financial.rst:606
+msgid ""
+"Can we use the data obtained to calculate the optimal weights for the "
+"portfolio by year? Of course we can. Let's start by delimiting the "
+"previous years as variables."
+msgstr ""
+
+#: ../../workshops/financial.rst:612
+msgid "We will now write a function to calculate these optimal weights."
+msgstr ""
+
+#: ../../workshops/financial.rst:629
+msgid ""
+"Let's describe this function in broad strokes. ``bounds`` indicates the "
+"maximum and minimum weights for each stock in the portfolio. The lowest "
+"weight will be 0 and the highest weight will be 1 for each stock in the "
+"portfolio. ``constraints`` is a function that ensures that the sum of the"
+" weights of all actions always adds up to 1. Then a loop is initialized "
+"that will segment the data for each year. In the variable ``_rets`` the "
+"returns for the specified year are obtained. In ``_opt_w`` the "
+"``portfolio_shape()`` function is used to calculate the weights that "
+"maximize the Sharpe ratio. This is done with the ``minimize()`` function "
+"of SciPy (which takes as arguments the ``portfolio_shape`` function, the "
+"actual weights of our stocks in the portfolio, and the ``bounds`` and the"
+" ``constraints`` variables). Notice the ``-`` sign before "
+"``portfolio_sharpe``? It's because ``minimize()`` aims to find the "
+"minimum value of a function relative to a parameter, but we are "
+"interested in the maximum, so we make the result of ``portfolio_sharpe`` "
+"a negative one."
+msgstr ""
+
+#: ../../workshops/financial.rst:631
+msgid ""
+"We will use the function we just defined to calculate the optimal weights"
+" for each year, and we are going to save the result in a Pandas DataFrame"
+" to take advantage of the Variable Explorer display options."
+msgstr ""
+
+#: ../../workshops/financial.rst:639
+msgid ""
+"Double click on the ``port_1_ow`` variable in the Variable Explorer. In "
+"the table, you can specify the number of decimal places to display, by "
+"clicking the format button at the bottom left of the pane, as you can see"
+" in the following image:"
+msgstr ""
+
+#: ../../workshops/financial.rst:644
+msgid ""
+"We set the number of decimal places to 4 and uncheck the **Column "
+"min/max** checkbox to better appreciate the contrasts in the row values "
+"(years)."
+msgstr ""
+
+#: ../../workshops/financial.rst:646
+msgid ""
+"You can see, for example, how 2015 was a particularly good year for "
+"investing in Amazon and Netflix, while 2014 was the year of Apple. "
+"Despite Netflix's rapid growth over the years, its high volatility means "
+"that its Sharpe Ratio is not very remarkable in any year, especially (as "
+"we said above) in 2014 and 2019. In the same respect, Apple and Microsoft"
+" seem to be safer bets in the return/volatility ratio."
+msgstr ""
+
+#: ../../workshops/financial.rst:650
+msgid "Comparison of expected and realized returns"
+msgstr ""
+
+#: ../../workshops/financial.rst:652
+msgid ""
+"Finally, we will use the optimal weights to calculate the expected "
+"returns and compare them with the actual returns."
+msgstr ""
+
+#: ../../workshops/financial.rst:668
+msgid ""
+"In this function we compare year to year realized returns with "
+"theoretically expected returns. This is done by estimating:"
+msgstr ""
+
+#: ../../workshops/financial.rst:670
+msgid ""
+"The returns from applying the optimal weights of the previous year's "
+"stocks to the data for that same year (``expected_pr``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:671
+msgid ""
+"The returns from applying the optimal weights of the previous year's "
+"stocks to the following year's data (``realized_pr``)."
+msgstr ""
+
+#: ../../workshops/financial.rst:673
+msgid ""
+"We are going to apply this function to the data in portfolio 1 and store "
+"the results in a DataFrame that we can review in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:680
+msgid ""
+"The expected column shows the predicted values if the optimal portfolio "
+"composition had been used. The realized column, on the other hand, shows "
+"the actual profits that would have been obtained with those weights. It "
+"can be seen that there are notable differences in some years. Let's look "
+"at this in a plot."
+msgstr ""
+
+#: ../../workshops/financial.rst:689
+msgid ""
+"The most notable differences are seen in 2014 and 2016. In those years, "
+"the previous year's optimal portfolio weights (in blue in the above plot)"
+" are a lousy indicator of the following year's stock performance (in "
+"red). In 2013, our model estimated that Google and Netflix were excellent"
+" investments. But by 2014 their share price did not grow if we compare "
+"the price at the beginning and at the end of that year. And something "
+"similar happened in 2016, in which Amazon's growing trend of the previous"
+" year diminished, and the value of Microsoft and Apple shares grew."
+msgstr ""
+
+#: ../../workshops/financial.rst:691
+msgid "Let's summarize these numbers."
+msgstr ""
+
+#: ../../workshops/financial.rst:701
+msgid ""
+"Our optimal weight model offered us a profit of around 40%, but the "
+"profit we would have obtained, due to real market fluctuations, would "
+"have been almost 20%. Not bad, but the mean-variance portfolio model we "
+"have applied for annual calculations is not very accurate, is it?"
+msgstr ""
+
+#: ../../workshops/financial.rst:703
+msgid ""
+"And this result is less encouraging if we calculate the correlations "
+"between expected and realized profits."
+msgstr ""
+
+#: ../../workshops/financial.rst:713
+msgid ""
+"As we can see, the correlations are negative, which warns us that we "
+"should be cautious when using this type of modeling."
+msgstr ""
+
+#: ../../workshops/financial.rst:719
+msgid "Second portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:721
+msgid ""
+"We are now going to apply all the previous code with a portfolio of a "
+"different nature. Let's assume that instead of technology companies, we "
+"are now interested in pharmaceuticals. We will build a portfolio with "
+"stocks of Pfizer, Astra Zeneca, Johnson & Johnson."
+msgstr ""
+
+#: ../../workshops/financial.rst:725
+msgid "Download the data"
+msgstr ""
+
+#: ../../workshops/financial.rst:727
+msgid "Let's download the data and format it."
+msgstr ""
+
+#: ../../workshops/financial.rst:740
+msgid ""
+"If you do not want to use the yfinance API, you can download the "
+"``close_data_2.csv`` file containing the closing information for this "
+"portfolio. Copy this file to your working directory. Load the data with "
+"the following instruction:  ``>>> close_data_2 = "
+"pd.read_csv(\"close_data_2.csv\")``."
+msgstr ""
+
+#: ../../workshops/financial.rst:744
+msgid "Mean and standard deviation"
+msgstr ""
+
+#: ../../workshops/financial.rst:746
+msgid ""
+"We are going to put the data in a monthly format and observe the mean and"
+" standard deviation."
+msgstr ""
+
+#: ../../workshops/financial.rst:768
+msgid ""
+"As in portfolio 1, all means are positive. But its largest value (that of"
+" JNJ) barely reaches 1% per month, which is slower growth than that of "
+"portfolio 1. The variation is also smaller compared to that of the "
+"previous portfolio (here the largest deviation is 0.06) which makes it a "
+"lower risk investment."
+msgstr ""
+
+#: ../../workshops/financial.rst:772
+msgid "Daily and monthly timelines"
+msgstr ""
+
+#: ../../workshops/financial.rst:774
+msgid "Let's better visualize the above with a couple of charts."
+msgstr ""
+
+#: ../../workshops/financial.rst:791
+msgid ""
+"These two plots show a steady growth over the years, but also a high "
+"variability in each year. This seems to be a good portfolio only if taken"
+" as a long-term investment."
+msgstr ""
+
+#: ../../workshops/financial.rst:795
+msgid "Returns, volatility and Sharpe ratio"
+msgstr ""
+
+#: ../../workshops/financial.rst:797
+msgid ""
+"To confirm what was said in the previous section, let's calculate "
+"returns, volatility and Sharpe ratio."
+msgstr ""
+
+#: ../../workshops/financial.rst:811
+msgid ""
+"The return of this portfolio is significantly lower than that of the "
+"previous portfolio (0.0809 < 0.2859). Its volatility (0.1637 < 0.2370) is"
+" also lower, but to a lesser extent. This is reflected in a lower Sharpe "
+"ratio as well (0.4940 < 1.2062). This means, within the mean-variance "
+"theory approach, that the first portfolio is a better investment than the"
+" second one."
+msgstr ""
+
+#: ../../workshops/financial.rst:813
+msgid ""
+"The different behavior is clearly observed if we apply a Monte Carlo "
+"simulation and visualize it with a graph:"
+msgstr ""
+
+#: ../../workshops/financial.rst:830
+msgid ""
+"High volatility does not correspond in most cases with high returns. In "
+"fact, there are scenarios in the simulation in which higher expected "
+"returns are related to lower expected volatility."
+msgstr ""
+
+#: ../../workshops/financial.rst:834
+msgid "Optimal pharmaceutical stock weights"
+msgstr ""
+
+#: ../../workshops/financial.rst:836
+msgid ""
+"Let us now see what are the optimal weights for each stock using the "
+"``optimal_weights`` function."
+msgstr ""
+
+#: ../../workshops/financial.rst:849
+msgid ""
+"In addition, we can use these optimal weights to plot the expected and "
+"realized returns of this portfolio for each year."
+msgstr ""
+
+#: ../../workshops/financial.rst:861
+msgid ""
+"Due to the high volatility of this portfolio, our model has not been able"
+" to adequately forecast expected returns in several of the years. Higher "
+"than expected returns would have been realized in 2013 and 2017, but in "
+"2015 and 2018 using the model would have generated losses."
+msgstr ""
+
+#: ../../workshops/financial.rst:863
+msgid ""
+"Finally, let us look at the differences between the expected and realized"
+" means, and the linear correlation between the data."
+msgstr ""
+
+#: ../../workshops/financial.rst:881
+msgid ""
+"As we can see, the model with optimal weights predicted a return close to"
+" 15% per year, but the realized return would have barely reached 6%. And "
+"the negative correlations show, as with portfolio 1, that there does not "
+"seem to be any correspondence between these values."
+msgstr ""
+
+#: ../../workshops/financial.rst:883
+msgid ""
+"The comparison is then favorable for portfolio 1. But what if we compare "
+"portfolio 1 with a \"higher risk\" investment such as cryptocurrencies? "
+"Let's discuss it below."
+msgstr ""
+
+#: ../../workshops/financial.rst:889
+msgid "Third portfolio"
+msgstr ""
+
+#: ../../workshops/financial.rst:892
+msgid "Download cryptocurrencies data"
+msgstr ""
+
+#: ../../workshops/financial.rst:894
+msgid ""
+"Our third portfolio will consist of three cryptocurrencies: bitcoin "
+"(BTC), ethereum (ETH) and litecoin (LTC). To access historical data, we "
+"are going to use a library called **Historic-Crypto**."
+msgstr ""
+
+#: ../../workshops/financial.rst:898
+msgid ""
+"If you want to make use of the data without the Historic-Crypto library, "
+"you can `download the dataset "
+"<https://figshare.com/articles/dataset/Historical_financial_datasets_for_Financial_Analysis_with_Spyder_workshop/14995215>`_"
+" \"crypto_hist.csv\" in your working directory, and load it in memory "
+"with the instruction ``crypto_hist = pd.read_csv(\"crypto_hist.csv\")``, "
+"and skip to section `Monthly data`_."
+msgstr ""
+
+#: ../../workshops/financial.rst:900
+msgid "Import the libraries:"
+msgstr ""
+
+#: ../../workshops/financial.rst:907
+msgid ""
+"We are going to use the ``Cryptocurrencies`` class to obtain a list of "
+"available cryptocurrencies."
+msgstr ""
+
+#: ../../workshops/financial.rst:915
+msgid ""
+"If you want more information about the use of this library you can make a"
+" quick query using the Spyder Help panel (type in the console "
+"``Cryptocurrencies`` and use :kbd:`Ctrl-I` or :kbd:`Cmd-I` to display "
+"it). Or you can read the documentation in their `official repository "
+"<https://github.com/David-Woroniuk/Historic_Crypto>`_"
+msgstr ""
+
+#: ../../workshops/financial.rst:917
+msgid ""
+"A new variable has appeared in the Variable Explorer: ``crypto_list``. It"
+" is a Pandas DataFrame that has a basic description of the types of "
+"cryptocurrency transactions. For example, we can look up which token is "
+"the token for ethereum transactions in US dollars."
+msgstr ""
+
+#: ../../workshops/financial.rst:923
+msgid "In this case, we are interested in the symbol with ID 171: ETH-USD."
+msgstr ""
+
+#: ../../workshops/financial.rst:925
+msgid ""
+"We can use the HistoricalData class of Historic-Crypto to download the "
+"history of transactions done in the cryptocurrencies of our portfolio, in"
+" US dollars."
+msgstr ""
+
+#: ../../workshops/financial.rst:946
+msgid ""
+"Let's merge the resulting dataframes to have all the data in a single "
+"table."
+msgstr ""
+
+#: ../../workshops/financial.rst:953
+msgid ""
+"We will not present the procedures and code in this section, but only the"
+" results of the analysis. You can follow the steps in the previous "
+"sections to recreate these results."
+msgstr ""
+
+#: ../../workshops/financial.rst:957
+msgid ""
+"Use all this section on portfolio 3 to check your understanding of the "
+"concepts and code we have presented until now. If you have any questions,"
+" you can consult the :download:`code <financial-analysis.py>` code that "
+"accompanies this workshop. But we encourage you to try as much as "
+"possible to solve the code on your own."
+msgstr ""
+
+#: ../../workshops/financial.rst:961
+msgid "Monthly data"
+msgstr ""
+
+#: ../../workshops/financial.rst:963
+msgid "Let's take a look at the monthly history of cryptocurrency price growth."
+msgstr ""
+
+#: ../../workshops/financial.rst:968
+msgid ""
+"We can note that the scale here is much larger. And the proportion of ETH"
+" growth over the other two coins is quite remarkable."
+msgstr ""
+
+#: ../../workshops/financial.rst:972
+msgid "Return, volatility and Sharpe ratio"
+msgstr ""
+
+#: ../../workshops/financial.rst:974
+msgid "Let's consider the return, volatility and Sharpe ratio of this portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:976
+msgid "Return: 0.6203"
+msgstr ""
+
+#: ../../workshops/financial.rst:977
+msgid "Volatility: 0.7587"
+msgstr ""
+
+#: ../../workshops/financial.rst:978
+msgid "Sharpe: 0.8176"
+msgstr ""
+
+#: ../../workshops/financial.rst:980
+msgid ""
+"These numbers are higher than those obtained for portfolios 1 and 2, "
+"except for the Sharpe ratio. This is a very volatile portfolio (in fact "
+"three times more volatile than that of the technology companies), and "
+"that makes it ultimately not as profitable as portfolio 1. The returns "
+"are higher (almost double) but the risk may not compensate for it."
+msgstr ""
+
+#: ../../workshops/financial.rst:984
+msgid "Monte carlo simulation"
+msgstr ""
+
+#: ../../workshops/financial.rst:986
+msgid ""
+"The Monte Carlo simulation also shows the non-linear correlation between "
+"risk and returns (as you can see, sometimes high risk involves only "
+"modest profits):"
+msgstr ""
+
+#: ../../workshops/financial.rst:991
+msgid ""
+"As can be seen, there are points (bottom right) that show a very high "
+"volatility and yet have a very low expected return. In this sense, "
+"portfolio 1 represents a safer investment because the higher risk is "
+"consistently offset by higher returns."
+msgstr ""
+
+#: ../../workshops/financial.rst:995
+msgid "Optimal cryptocurrency weights"
+msgstr ""
+
+#: ../../workshops/financial.rst:1000
+msgid ""
+"The optimal portfolio weights, if calculated annually, suggest that our "
+"portfolio should have been quite polarized in some years: the "
+"recommendation is to have bought only bitcoins before the start of 2016 "
+"and 2019, and only ethereum in 2018. Starting 2017 and 2020, on the other"
+" hand, our weights recommended a more balanced investment between bitcoin"
+" and ethereum. Litecoin is not recommended by our model."
+msgstr ""
+
+#: ../../workshops/financial.rst:1004
+msgid "Expected and realized returns"
+msgstr ""
+
+#: ../../workshops/financial.rst:1009
+msgid ""
+"In this graph we can see that in 2017 and 2020 the earnings obtained "
+"would have exceeded the expected earnings (with our calculated weights). "
+"In 2019 our model predicted a sharp drop in the portfolio, but in reality"
+" the portfolio did not make either annualized gains or losses that year. "
+"In contrast, in 2018, our model would have brought us heavy losses, as "
+"the value of cryptocurrencies declined sharply that year."
+msgstr ""
+
+#: ../../workshops/financial.rst:1011
+msgid ""
+"The mean expected return for our portfolio is 0.6972, which is higher "
+"than the realized return of 0.4181 that we would have obtained. Having "
+"invested in this portfolio over the long term (from 2016 to the present) "
+"would have been a very good deal. Due to the high variability, investing "
+"in the short term would have been very risky. In terms of gross profits, "
+"the realized returns of this portfolio were more than double those of "
+"portfolio 1 (0.4181 > 0.1997)."
+msgstr ""
+
+#: ../../workshops/financial.rst:1017
+#: ../../workshops/plugin-development.rst:1394
+#: ../../workshops/scientific-computing.rst:751
+msgid "Final words"
+msgstr ""
+
+#: ../../workshops/financial.rst:1019
+msgid ""
+"The mean-variance portfolio (MVP) theory is one of the many tools "
+"available to financial analysis. In recent years, machine learning "
+"algorithms have even been used to predict the behavior of stock prices "
+"more accurately than can be achieved with any standard financial theory."
+msgstr ""
+
+#: ../../workshops/financial.rst:1021
+msgid ""
+"The examples given during this workshop are not intended to serve as "
+"guidelines for you to invest your money. It is only a first step towards "
+"learning financial analysis using Python and a scientific IDE."
+msgstr ""
+
+#: ../../workshops/financial.rst:1023
+#: ../../workshops/plugin-development.rst:1402
+#: ../../workshops/scientific-computing.rst:759
+msgid "In this workshop you have learned how to:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1025
+#: ../../workshops/scientific-computing.rst:761
+msgid "Set up a Conda environment."
+msgstr ""
+
+#: ../../workshops/financial.rst:1026
+msgid "Use the Spyder Editor to write and run code."
+msgstr ""
+
+#: ../../workshops/financial.rst:1027
+msgid "Write and test code with the IPython Console."
+msgstr ""
+
+#: ../../workshops/financial.rst:1028
+msgid "Obtain financial data using an API."
+msgstr ""
+
+#: ../../workshops/financial.rst:1029
+msgid "Graphing data."
+msgstr ""
+
+#: ../../workshops/financial.rst:1030
+#: ../../workshops/scientific-computing.rst:764
+msgid "Inspect objects in the Variable Explorer."
+msgstr ""
+
+#: ../../workshops/financial.rst:1031
+#: ../../workshops/scientific-computing.rst:766
+msgid "Browse between plots using the Plots pane."
+msgstr ""
+
+#: ../../workshops/financial.rst:1032
+#: ../../workshops/scientific-computing.rst:768
+msgid "Manipulate data in a Pandas DataFrame."
+msgstr ""
+
+#: ../../workshops/financial.rst:1033
+msgid "Build a financial portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:1034
+msgid "Calculate returns and volatility of a portfolio over time."
+msgstr ""
+
+#: ../../workshops/financial.rst:1035
+msgid "Obtain the optimal weights of the stocks in a portfolio."
+msgstr ""
+
+#: ../../workshops/financial.rst:1037
+msgid ""
+"With the skills learned here, you will be able to approach more complex "
+"topics of financial analysis such as those you will find in the "
+"references in the next section."
+msgstr ""
+
+#: ../../workshops/financial.rst:1039
+#: ../../workshops/scientific-computing.rst:774
+msgid ""
+"Thank you for reaching the end of this workshop! We hope you found it "
+"helpful and informative."
+msgstr ""
+
+#: ../../workshops/financial.rst:1041
+#: ../../workshops/plugin-development.rst:1422
+msgid ""
+"If you are interested in an introduction to scientific computing with "
+"Spyder, you can visit the workshop :doc:`Scientific Computing and "
+"Visualization with Spyder <../workshops/scientific-computing>`."
+msgstr ""
+
+#: ../../workshops/financial.rst:1045
+#: ../../workshops/plugin-development.rst:1429
+#: ../../workshops/scientific-computing.rst:780
+msgid "Homework"
+msgstr ""
+
+#: ../../workshops/financial.rst:1047
+msgid ""
+"If you want to check what you have learned, we suggest you try to obtain "
+"the results presented for the third portfolio. If you have any questions,"
+" you can consult the code that accompanies this workshop in our "
+"repository."
+msgstr ""
+
+#: ../../workshops/financial.rst:1053
+#: ../../workshops/plugin-development.rst:1436
+#: ../../workshops/scientific-computing.rst:788
+msgid "Further reading"
+msgstr ""
+
+#: ../../workshops/financial.rst:1055
+msgid ""
+"Much of the math used to apply MVP was the mathematics outlined in Yves "
+"Hilpisch's excellent book, which we recommend to you:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1057
+msgid "Yves Hilpisch, Y. (2020). *Artificial Intelligence in Finance*. O'Reilly.*"
+msgstr ""
+
+#: ../../workshops/financial.rst:1059
+msgid ""
+"A classic that has been with us for decades and is one of Warren "
+"Buffett's favorites:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1061
+msgid "Graham, B. (1949). *The Intelligent Investor*. HarperCollins."
+msgstr ""
+
+#: ../../workshops/financial.rst:1063
+msgid ""
+"Another good resource for financial analysis with Python is the following"
+" book by James Ma Weiming:"
+msgstr ""
+
+#: ../../workshops/financial.rst:1065
+msgid "Ma Weiming, J. (2019). *Mastering Python for Finance*. Packt"
+msgstr ""
+
+#: ../../workshops/index.rst:3
+msgid "Workshops"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:3
+msgid "Plugin Development with Spyder"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:5
+msgid ""
+"This workshop reviews the features and possibilities of the API offered "
+"by `Spyder`_ 5—the recently released version of our favorite IDE for "
+"scientific Python—for plugin development and to extend its functionality."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:7
+msgid ""
+"As a practical exercise, we will develop a simple plugin that "
+"incorporates a configurable pomodoro timer in the status bar and some "
+"toolbar buttons to interact with it."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:17
+#: ../../workshops/scientific-computing.rst:13
+msgid ""
+"You will need to have Spyder installed. Visit our :doc:`installation "
+"guide<../installation>` for more information."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:21
+msgid ""
+"Spyder now offers :ref:`install-standalone` for Windows and macOS, making"
+" it easier to get up and running with the application without having to "
+"download Anaconda or manually install it in your existing environment. "
+"However, readers of this workshop should install Spyder using Anaconda or"
+" Miniconda, as standalone installers currently do not allow to add extra "
+"packages like the plugin we are going to develop in this workshop."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:26
+#: ../../workshops/scientific-computing.rst:22
+msgid ""
+"Basic level of Python. You can visit `The Python Tutorial`_ to learn the "
+"basics of this programming language."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:27
+msgid ""
+"Know the basics of Qt application development using Python, either with "
+"`PyQT`_ or `PySide`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:29
+msgid ""
+"To quickly get started in desktop application development with Qt and "
+"Python here is a set of open access resources:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:31
+msgid "`Tutorials Point - PyQt tutorial`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:32
+msgid "`Real Python - PyQt entries`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:33
+msgid "`Guru99 - PyQt tutorial`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:34
+msgid "`Python GUIs - PyQt and PySide tutorials`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:46
+msgid "Learning Goals"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:48
+msgid "By the end of this workshop participants will know:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:50
+msgid ""
+"The basics to develop plugins for Spyder, and get a general idea of its "
+"inner workings."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:51
+msgid "What types of plugins can be developed with Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:52
+msgid ""
+"The structure of a plugin and the functionality of each component and how"
+" it connects to Spyder to extend its features."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:53
+msgid ""
+"How to package and publish our plugin so that it can be easily installed "
+"and used by others."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:59
+msgid "Spyder for developers"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:61
+msgid ""
+"The best place to find information about contributing to Spyder or "
+"developing for Spyder is its Github repository, in particular the "
+"`contribution guide`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:66
+msgid ""
+"The core of **Spyder** is `Spyder-IDE`_ , a desktop application developed"
+" in *Qt*, which requires for its operation two packages with it is "
+"closely related (and without which it cannot work): *spyder-kernels* and "
+"*python-lsp-server*."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:68
+msgid ""
+"`Qt`_ is an open source multiplatform widget toolkit for creating native "
+"graphical user interfaces. Qt is a very complete development framework "
+"that offers utilities for building applications, and has extensions for "
+"Networking, Bluetooth, Charts, 3D rendering, Navigation (as GPS), among "
+"others."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:70
+msgid ""
+"Spyder uses `qtpy`_ which is an abstraction layer that allows you to work"
+" with Qt from Python regardless of whether you use either of the two "
+"reference libraries: PyQt or PySide."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:72
+msgid ""
+"`spyder-kernels`_ provide Jupyter kernels to Spyder, for use within its "
+"consoles."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:76
+msgid ""
+"Spyder is currently developed in such a way that most of its features are"
+" implemented as plugins."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:89
+msgid "Types of plugins we can develop in Spyder"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:97
+msgid ""
+"A plugin is a component that adds functionality to an application, it can"
+" be a graphical component, for example, to display maps, or a non-"
+"graphical one that adds additional syntax coloring schemes."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:99
+msgid ""
+"Formally, plugins are instances of Qt classes that modify the behavior of"
+" Spyder. Aside from a few fundamental components, most of Spyder's "
+"functionality arises from the interaction of plugins of two types:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:104
+msgid "SpyderDockablePlugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:106
+msgid ""
+"It is a plugin that works as a `QDockWidget`_, this is a Qt class that "
+"provides a graphical control that can be docked inside a `QMainWindow`_ "
+"or floated as a top-level window on the desktop."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:113
+msgid "SpyderPluginV2"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:115
+msgid ""
+"``SpyderPluginV2`` is a plugin that does not create a new dock widget on "
+"Spyder's main window. In fact, ``SpyderPluginV2`` is the parent class of "
+"``SpyderDockablePlugin``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:120
+msgid "Discovering Spyder plugins"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:124
+msgid ""
+"If we look at the Spyder interface, we can find a number of different "
+"panes on the right side (with the default layout), such as *Help*, "
+"*Variable Explorer*, *Plots*, *Files* and *History*."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:126
+msgid ""
+"Each of these panes is a ``SpyderDockablePlugin`` that offers an *Undock*"
+" option by clicking the hamburger menu button in the upper right corner."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:128
+msgid ""
+"These plugins can also be hidden or shown via their entry in the *View > "
+"Panes* menu, or using its corresponding keyboard shortcut displayed "
+"there."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:132
+msgid ""
+"High-level interface elements that do not offer an undocking option are "
+"basically instances of ``SpyderPluginV2``. These are typically used to "
+"handle more abstract functionality."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:134
+msgid ""
+"Examples of this are the *appearance* and *layout* plugins that manage "
+"Spyder's code color schemes and window layouts respectively."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:136
+msgid ""
+"Other examples of this type of plugins are the *main menu* and keyboard "
+"*shortcuts*. Some graphical elements, such as the main toolbar and the "
+"status bar are also instances of the ``SpyderPluginV2`` class."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:142
+msgid "What will we do?"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:144
+msgid ""
+"Our practical work will consist in the implementation of the Pomodoro "
+"technique for time management in the Spyder interface."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:151
+msgid ""
+"The `Pomodoro Technique`_, designed by Francesco Cirillo, is a time "
+"management practice used to increase your focus and productivity when "
+"trying to complete assignments or meet deadlines. Choosing to use a "
+"Pomodoro Timer can help to give a task your full, undivided attention."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:154
+msgid ""
+"The typical process of the Pomodoro Technique consists of the following "
+"six steps:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:157
+msgid "Choose a task to be done."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:158
+msgid "Set the Pomodoro Timer (default is 25 minutes)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:159
+msgid "Work only on that task until the timer ends."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:160
+msgid ""
+"When the timer rings, put a checkmark on a piece of paper, this is called"
+" \"a pomodoro\"."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:161
+msgid ""
+"If you have less than 3 checkmarks take a short break (by default, 5 "
+"minutes), and return to step 2."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:162
+msgid ""
+"When you have completed four Pomodoro cycles, you deserve a longer break "
+"(our default is 15 minutes). Checkmarks are reset to zero, go back to "
+"step 1."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:168
+msgid "Steps"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:170
+msgid ""
+"These are the general steps that we will be following throughout this "
+"workshop:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:172
+msgid ""
+"Select the most suitable plugin type and create its initial structure "
+"using `cookiecutter`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:173
+msgid ""
+"Install the plugin in development mode in the virtual environment from "
+"which we run Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:174
+msgid ""
+"Implement the functionality of our plugin using the Spyder classes and "
+"following the guidelines indicated in the plugin structure."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:175
+msgid ""
+"Build a configuration page for our plugin, which would appear in Tools > "
+"Preferences."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:180
+msgid "Location of Spyder Pomodoro Timer widgets in Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:185
+msgid "Spyder Pomodoro Timer in the preferences window."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:189
+msgid "Features"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:191
+msgid "A minimal planning to organize ideas."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:193
+msgid "Pomodoro Timer"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:195
+msgid "Status bar widget: to display the time for the current pomodoro interval."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:196
+msgid ""
+"State: we have three activity states: *pomodoro*, *short-break* and "
+"*long-break*. We can show a message (with `QMessageBox`_) to tell users "
+"that the time to take a break has arrived."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:197
+msgid ""
+"Interactions: the user could use Start, Stop and Reset buttons to handle "
+"the Pomodoro Timer. This can be implemented adding `QAction`_ instances "
+"in a menu on the toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:199
+msgid ""
+"Tasks Logger - Counter: We need a variable to count the number of "
+"pomodoros completed."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:202
+msgid "Notifications"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:204
+msgid ""
+"Dialog: Each time a pomodoro or break interval is completed, a message "
+"should appear to prompt the user to start working on a task or take a "
+"break."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:206
+msgid ""
+"When working on a plugin for any system, we must check the data "
+"structures and functions available in that system that can facilitate our"
+" development. This involves spending considerable time understanding its "
+"inner workings."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:219
+msgid "Set up a development environment"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:221
+msgid ""
+"In principle, we could use any Spyder installed within a `conda "
+"environment`_ according to the instructions given in the `installation "
+"guide`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:223
+msgid ""
+"However, if you use a working environment that has other dependencies and"
+" you want to keep your plugin development independent of them, it is "
+"recommended to create a new environment which only has Spyder with the "
+"minimum dependencies needed for your plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:228
+msgid "We can install it in the following way:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:240
+msgid ""
+"`Anaconda Individual Edition`_ is a Python distribution for data science "
+"and machine learning to be used in a single machine."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:241
+msgid ""
+"`Conda`_ is an Anaconda tool that manages virtual environments and their "
+"packages."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:242
+msgid ""
+"Conda can work with *channels* that allow the use of packages that are "
+"not part of the official distribution. The most important channel is "
+"`conda-forge`_, where a more extensive and updated list of packages than "
+"those offered by Anaconda Individual Edition are maintained."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:243
+msgid ""
+"Finally, `mamba`_, is an optimized implementation of conda's package "
+"management features, that resolves dependencies and installs packages "
+"much faster than conda."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:256
+msgid "Create a repository"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:258
+msgid ""
+"Now that we have our local virtual environment, it is good practice to "
+"manage our source code with a version control system, and the most widely"
+" used web service for this purpose is currently Github. Here you can "
+"find, for example, the Spyder and Python repositories."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:263
+msgid "To create a git repository on Github, we need to follow these steps:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:265
+msgid "Log in to your Github account."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:266
+msgid ""
+"Click on the \"New repository\" option in the \"+\" menu at the top right"
+" next to your profile picture."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:267
+msgid ""
+"A dialog will appear where you can insert the repository name and some "
+"basic options, e.g. to initialize the repository with a README or license"
+" files."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:268
+msgid "Click the “Create repository” button."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:269
+msgid ""
+"In the main window of the recently created repository, click on the green"
+" \"Code\" button an copy the clone link."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:270
+msgid ""
+"In your local command line run ``$ git clone [repo-link]``. You must have"
+" git installed and configured on your computer. If you don't have "
+"experience using git we recommend The Carpentries workshop `Version "
+"control with git`_."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:272
+msgid ""
+"A detailed description of `repository creation`_ could be found in the "
+"official Github documentation, and a `hello world`_ tutorial with basic "
+"git operations from the Github interface."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:282
+msgid "Let's get started"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:284
+msgid ""
+"We already have a git repository and a virtual environment where Spyder 5"
+" is installed."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:286
+msgid ""
+"Let's activate our environment and go into the local folder of our "
+"repository."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:293
+msgid ""
+"Then we need to use ``cookiecutter`` to create the initial structure of "
+"our plugin. `cookiecutter`_ is a tool made in Python specifically "
+"designed to create project templates. We have developed one of these "
+"templates to generate the basic structure of a plugin, it can be found "
+"at: https://github.com/spyder-ide/spyder5-plugin-cookiecutter"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:301
+msgid "Let's run cookiecutter to generate our"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:331
+msgid "The plugin structure"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:334
+msgid ""
+"After ``cookicutter`` finishes its job, you'll get the following tree "
+"structure in your repository"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:356
+msgid "In the root folder you'll find two important files:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:358
+msgid "The Makefile, which has several useful commands:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:375
+msgid ""
+"``setup.py``, which helps you to install, package and distribute your "
+"plugin with ``setuptools``, the standard for distributing Python Modules."
+" On this file the ``entry_points`` parameter of ``setup`` is quite "
+"important, as it is the one that allows Spyder to identify this package "
+"as a plugin, and to know how to access its functionalities."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:380
+msgid ""
+"The ``spyder-pomodoro-timer`` folder has the name you introduced when "
+"running ``cookiecutter``. Inside this you'll see a folder called "
+"``spyder``, where we will place the code of our plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:382
+msgid "In the ``spyder`` directory you'll find the following files:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:384
+msgid ""
+"``api.py``: where the functionality of the plugin is exposed to the rest "
+"of Spyder. That would allow additional functionality to be added from "
+"other plugins."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:386
+msgid ""
+"``plugin.py``: is the core of the plugin. Depending on the type of plugin"
+" we created, here you'll see an instance of ``SpyderDockablePlugin`` or "
+"``SpyderPluginV2``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:388
+msgid ""
+"If it is a ``SpyderPluginV2`` you should set a constant class named "
+"``CONTAINER_CLASS`` with an instance of ``PluginMainContainer``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:389
+msgid ""
+"If it is a ``SpyderDockablePlugin`` you should set a constant class named"
+" ``WIDGET_CLASS`` with an instance of ``PluginMainWidget``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:391
+msgid ""
+"``container.py``: only used for ``SpyderPluginV2`` plugins. This file "
+"contains an instance of ``PluginMainContainer`` that holds a reference to"
+" all graphical elements (or widgets) that the plugin is going to add to "
+"the interface. This is necessary because Qt requires widgets to be "
+"children of other widgets before using them (otherwise they appear as "
+"floating windows). Since ``SpyderPluginV2`` is not a widget, we need a "
+"data structure (i.e. the container) that is a widget for that."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:393
+msgid ""
+"``widgets.py``: in this file we will add the graphical components of our "
+"plugin. If it is of type ``SpyderPluginV2`` and it does not have widgets,"
+" then it is not necessary. We can also place here the instance of "
+"``PluginMainWidget`` necessary for ``SpyderDockablePlugin``, if we are "
+"developing that kind of plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:396
+msgid ""
+"``confpage.py``: this is where you specify the configuration page that "
+"will be displayed in ``Preferences``, so that the user can adjust the "
+"options of our plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:402
+msgid "Building our first plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:404
+msgid ""
+"From now on we will be building the plugin step by step. In the `spyder "
+"pomodoro timer repository`_ you will find the final version of the code "
+"for you to take a look at it, in case we are missing any detail."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:409
+#: ../../workshops/qt_fundamentals.rst:45
+msgid "Widgets"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:411
+msgid ""
+"The best way to start building our plugin is by implementing its "
+"graphical components first in ``widgets.py``"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:413
+msgid ""
+"Let's call the initial version, without any editing ``INITIAL``. In "
+"`INITIAL`_, widgets.py is as follows:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:431
+msgid ""
+"The preset imports are a guide to what we will need in our plugin. The "
+"``on_conf_change`` decorator will allow us to propagate the changes in "
+"configuration. ``get_translation`` helps us to generate translation "
+"strings for the plugin and ``SpyderWidgetMixin`` adds to any widget the "
+"attributes and methods needed to integrate it with Spyder (icon, style, "
+"translation, actions and extra options)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:433
+msgid ""
+"When taking a look at the Spyder ``api`` module, we can find that in "
+"Spyder there are two types of predefined components for the status bar:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:435
+msgid ""
+"``StatusBarWidget``, a class derived from ``QWidget`` and "
+"``SpyderWidgetMixin``, which contains an icon, a label and a spinner (to "
+"show the plugin loading)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:436
+msgid ""
+"``BaseTimerStatus``, a class derived from ``StatusBarWidget`` with an "
+"internal ``QTimer`` to periodically update its content."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:440
+msgid ""
+"Below, we will be indicating links in github with the diffs between the "
+"tags, this as an aid to check the progressive changes that will be made "
+"in the code."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:442
+msgid ""
+"The first version that we are going to reach after the first editions "
+"will be called ``HELLO WORLD``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:444
+msgid "`INITIAL -> HELLO WORLD widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:448
+msgid ""
+"Since we want a widget that shows the pomodoro countdown and is "
+"periodically updated, we will use a ``BaseTimerStatus`` instance."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:450
+msgid "So, we can substitute"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:456
+msgid "with"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:463
+msgid "Add an initial import:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:470
+msgid "With that, we can write our first widget like this"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:493
+msgid ""
+"Spyder needs ``ID`` to be defined for ``BaseTimerStatus``. Its "
+"constructor calls the parent class constructor and initializes the label "
+"with ``value``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:495
+msgid ""
+"We add a tooltip to verify the presence of our widget. Since Spyder uses "
+"``qtawesome`` (another of our projects that eases the incorporation of "
+"iconic fonts into PyQt applications), we can select an appropriate icon "
+"by running the ``qta-browser`` command on a terminal."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:501
+msgid "From here we can select and copy the name of the icon of our preference."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:506
+msgid ""
+"To finish the implementation of our widget, we need to add the following "
+"method:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:516
+msgid ""
+"``BaseTimerStatus`` requires this method to be implemented to update its "
+"content every time it is requested by the internal timer."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:520
+msgid "The container"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:522
+msgid ""
+"The next step in the development of our plugin is to create an instance "
+"of the widget we wrote above, so we can add it to Spyder's status bar. "
+"For that, we need to use a container. Due to Qt specifics, we need an "
+"instance of ``QWidget`` (the container) to be the parent of all other "
+"widgets part of our plugin (as mentioned above)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:524
+msgid "Thus, the `COOKIECUTTER`_ version of ``container.py`` is:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:547
+msgid "`INITIAL -> HELLO WORLD container.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:551
+msgid ""
+"In this case ``SpyderPomodoroTimerContainer`` is already defined, and we "
+"must implement the ``setup`` and ``update_actions`` methods."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:553
+msgid ""
+"Now we are going to add the widget created earlier to the container. To "
+"do so, first we need to import the widget."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:560
+msgid "Then we edit the ``setup`` method to add an instance of our widget."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:570
+msgid "Plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:572
+msgid ""
+"Finally, we define our plugin so that it is registered within Spyder. The"
+" `INITIAL`_ version (i.e. the one created by cookiecutter)  for "
+"``plugin.py`` is:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:575
+msgid "Imports:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:592
+msgid "Plugin class:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:633
+msgid "`INITIAL -> HELLO WORLD plugin.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:637
+msgid ""
+"First, we need to declare the dependencies of our plugin, by defining the"
+" ``REQUIRES`` class constant. Since we're going to add a status bar "
+"widget, we require the ``StatusBar`` plugin, as shown below."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:643
+msgid "Then we need to set the icon for our plugin. For that, we substitute"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:651
+#: ../../workshops/plugin-development.rst:668
+msgid "and"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:658
+#: ../../workshops/plugin-development.rst:871
+msgid "by"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:676
+msgid ""
+"Due to recent changes to the Spyder API, we need to add to the spyder "
+"imports"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:683
+msgid "And add the following after the ``on_initialize`` method:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:693
+msgid ""
+"With these changes, Spyder will be aware of the presence of our plugin, "
+"and that this plugin adds a new widget to the status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:695
+msgid "Finally, we add the following method to our plugin:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:704
+msgid ""
+"In this way, ``SpyderPomodoroTimer`` can access ``pomodoro_timer_status``"
+" of ``SpyderPomodoroTimerContainer`` as if it were its own property."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:706
+msgid "In summary, we did the following:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:711
+msgid ""
+"We created a widget, then we added it to the container, which is "
+"registered in the plugin through the ``CONTAINER_CLASS`` constant. In the"
+" plugin, we accessed the instance of that widget and added it to the "
+"status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:717
+msgid "How to test our plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:719
+msgid "Now it is time to see how our plugin looks in the Spyder interface."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:721
+msgid ""
+"**From the root folder of our plugin**, we activate the environment where"
+" Spyder is installed, and run:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:729
+msgid "Now we can see two outputs. The first one is shown in the command line:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:736
+msgid ""
+"And in Spyder you'll see our plugin in the status bar with the tooltip "
+"\"I am the Pomodoro tooltip\"."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:741
+msgid ""
+"Keep in mind that every time we make a change to our code, it is "
+"necessary to restart Spyder so that the plugin is reloaded and we can "
+"check the changes."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:747
+msgid "Enhancing our plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:749
+msgid ""
+"From now on we are going to go into details of how things are implemented"
+" in Qt. So in case you have any doubts, the Qt documentation will be your"
+" best guide. We created an annex to this workshop that quickly explains "
+"way the fundamental concepts of Qt for those in a hurry: :ref:`qt-"
+"fundamentals`"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:754
+msgid "Timer updates"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:756
+msgid ""
+"The first problem with our plugin is that its pomodoro timer is not being"
+" updated. To activate it we can use the ``QTimer`` in "
+"``PomodoroTimerStatus``, which is present because it's an instance of "
+"``BaseTimerStatus``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:758
+msgid ""
+"The second version where the value in the status bar is updated is called"
+" ``TIMER``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:760
+msgid ""
+"Let's go back to ``widgets.py`` and add this constant below the import "
+"lines (line 22)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:762
+msgid "`HELLO WORLD -> TIMER widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:774
+msgid ""
+"``POMODORO_DEFAULT`` is to set the pomodoro time limit in milliseconds, "
+"and ``INTERVAL`` to the timer update rate."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:776
+msgid "Now, in the ``__init__`` method of ``PomodoroTimerStatus`` we need to add:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:788
+msgid ""
+"Up to this point, we created a default value (``POMODORO_DEFAULT``) for "
+"the timer duration during pomodoros; we added it to the "
+"``pomodoro_limit`` attribute to be able to configure it; and with that "
+"value we initialized the ``countdown`` attribute that will be modified "
+"over time. As for the update interval of the timer, we set it to to the "
+"value of ``INTERVAL``, which corresponds to 1 second (one thousand "
+"milliseconds)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:791
+msgid ""
+"The function of ``self.timer`` is to update our timer periodically. This "
+"is done through the method ``timeout.connect()``, to which we pass as "
+"parameter the reference to the ``update_timer`` function that will "
+"perform the required adjustments."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:793
+msgid "Now let's implement ``update_timer`` at the end of the file:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:813
+msgid ""
+"Here we rely on the ``display_time`` method that converts the current "
+"``countdown`` value, which is measured in milliseconds, into a human-"
+"readable format. And ``update_timer`` simply keeps updating the countdown"
+" until it reaches zero."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:815
+msgid "If we run Spyder again we will find that our timer has come to life."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:824
+msgid "Timer controls"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:826
+msgid ""
+"Now we need a way to control our timer. We can achieve this by adding "
+"some buttons to Spyder's toolbar, which will be useful to learn how to "
+"work with toolbars, menus and actions in Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:830
+msgid "PomodoroTimerToolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:832
+msgid ""
+"The next version where actions are added to the toolbar is called "
+"``ACTIONS``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:834
+msgid "`TIMER -> ACTIONS widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:838
+msgid ""
+"Let's go back to ``widgets.py`` and import the Spyder application toolbar"
+" class:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:844
+msgid ""
+"And create an instance of it by adding the following code before the "
+"definition of ``PomodoroTimerStatus``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:853
+msgid ""
+"As you can see, this statement is very simple. It only needs to declare "
+"an ``ID``, that serves to identify our toolabr among the rest."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:855
+msgid ""
+"It is possible to include other Qt widgets in our toolbar, but in this "
+"case it's better to use the appropriate Spyder methods for that in order "
+"to maintain their relationship with the rest of the application. In other"
+" words, as long as the widget you need exists in ``spyder.api.widgets``, "
+"use it!"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:858
+msgid ""
+"Next, we need to declare a boolean variable in our status widget to "
+"indicate if the countdown is paused or not. For that, let's add the "
+"following inside the ``__init__`` method of ``PomodoroTimerStatus``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:864
+msgid "And inside the ``update_timer`` method, substitute"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:880
+msgid "Create the Pomodoro Toolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:882
+msgid ""
+"Now we are going to create a new section in our toolbar and associate "
+"some functionality to it by means of actions. This particular information"
+" is recommended to be included in the ``api.py`` file because this way we"
+" can offer endpoints to the rest of Spyder and new plugins for tweaking "
+"the behavior of our plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:884
+msgid "`TIMER -> ACTIONS api.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:888
+msgid "Let's add the following to the end of ``api.py``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:904
+msgid ""
+"With these we are telling the rest of Spyder, and our own plugin, that we"
+" are going to have a new toolbar section called \"pomodoro_timer\". This "
+"section will consist of a button containing a menu (with a single section"
+" \"main_section\") and actions identified as \"start_timer\", "
+"\"pause_timer\" and \"stop_timer\", to start, pause and stop (resetting) "
+"our timer, respectively."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:906
+msgid ""
+"Note that these are simple class definitions with class constants, to "
+"ease the encapsulation and exchange of this information in a simple way."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:909
+msgid "Add actions to the toolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:911
+msgid "`TIMER -> ACTIONS container.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:915
+msgid ""
+"Now let's go to ``container.py``, where we are going to implement the "
+"behavior of our new toolbar and its actions. In this case, we are not "
+"going to specify the internal behavior of our plugin, but the "
+"relationship between its widgets and other areas of Spyder, so it is more"
+" convenient to do it in the container."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:918
+msgid ""
+"As we did with ``PomodoroTimerStatus``, we are going to use ``qtawesome``"
+" icons for our actions. For this purpose, let's add at the beginning of "
+"our imports:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:926
+msgid ""
+"We also imported ``QToolButton`` because it will be used to set the "
+"button that we will add in our toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:928
+msgid "At the end of the Spyder imports we also need:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:934
+msgid ""
+"Now, let's include ``PomodoroTimerToolbar`` and the actions and sections "
+"we just declared in ``api.py`` in our local imports:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:948
+msgid ""
+"Next, we need to do following things in the ``setup`` method of "
+"``SpyderPomodoroTimerContainer``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:950
+msgid ""
+"The first one is to create an instance of the toolbar class we declared "
+"earlier:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:957
+msgid ""
+"The second one is to create the actions corresponding to Start, Pause and"
+" Stop our pomodoro timer:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:986
+msgid ""
+"The third one is to create the menu that will contain our actions and add"
+" them to it."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1004
+msgid ""
+"The fourth one is to create a button that will contain the menu and "
+"configure it as ``PopupMode``, so that it is displayed when clicked."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1017
+msgid "And finally, the fifth one is to add the button to our toolbar:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1028
+msgid ""
+"When creating the actions, we indicate by means of the ``triggered`` "
+"parameter the methods to be executed when they are activated, i.e. when "
+"the corresponding buttons on the toolbar are clicked."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1030
+msgid ""
+"We can insert these methods at the end of the "
+"``SpyderPomodoroTimerContainer`` declaration, in the section that our "
+"cookiecutter template indicates as ``# --- Public API``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1050
+msgid ""
+"These methods simply manipulate the ``pause`` field of "
+"``pomodoro_timer_status``, and in the case of ``stop_pomodoro_timer`` the"
+" countdown is restarted."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1053
+msgid "Register the toolbar"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1055
+msgid "`TIMER -> ACTIONS plugin.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1059
+msgid ""
+"A final mandatory step is to go to ``plugin.py`` and register this new "
+"toolbar component."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1061
+msgid "To do this, add ``Plugins.Toolbar`` to the plugin requirements:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1067
+msgid ""
+"And use this plugin's API to add the toolbar we have created in the "
+"container to Spyder's toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1078
+msgid "Review the changes"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1080
+msgid ""
+"The first thing we can notice is that we already have the corresponding "
+"buttons in the toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1085
+msgid ""
+"The strings that were entered as the ``tip`` parameter in the creation of"
+" the actions are shown here as the buttons' tooltips."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1087
+msgid ""
+"Also, if we check the menu \"View > Toolbars\", we find that there is a "
+"new entry there corresponding to our toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1093
+msgid ""
+"Finally, let's check how the new Pomodoro Timer control buttons in the "
+"toolbar interact with the component in the status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1102
+msgid "Add a Configuration Page"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1104
+msgid ""
+"Another feature of Spyder plugins is that they can have configurable "
+"options that appear in Spyder's Preferences window."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1107
+msgid "Configuration defaults"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1109
+msgid ""
+"The final version in which we add a configurable parameter will be called"
+" ``CONFPAGE``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1111
+msgid ""
+"The first step is to define what options we want to offer to our users. "
+"For this we must create a new file, which we can call ``conf.py``. In "
+"this file we will write the following:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1113
+msgid "`ACTIONS -> CONFPAGE config.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1138
+msgid ""
+"We must highlight the declaration of ``CONF_SECTION``, which is the "
+"internal name of the section in Preferences corresponding to our plugin; "
+"and the dictionary keys associated with ``CONF_DEFAULTS``. In this case, "
+"we are indicating that ``pomodoro_limit`` is a configurable parameter "
+"within the ``spyder_pomodoro_timer`` section."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1140
+msgid ""
+"At the end of this file it is necessary to set another important "
+"constant, ``CONF_VERSION``, which must be updated when adding, removing "
+"or renaming configurable parameters in successive versions of the plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1153
+msgid ""
+"Note that we are moving the definition of ``POMODORO_DEFAULT`` from "
+"``widgets.py`` to ``conf.py``, since we now have a dedicated place for "
+"default configuration values."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1156
+msgid "Configuration page"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1158
+msgid ""
+"Now, we need to build the page that will appear in the Preferences "
+"window. For this, we edit the ``confpage.py`` file generated by "
+"cokkiecutter as follows:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1160
+msgid "`ACTIONS -> CONFPAGE confpage.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1206
+msgid ""
+"This mostly corresponds to the regular code for user interfaces based on "
+"Qt widgets. In this case, our options section corresponds to a "
+"``QGroupBox``, where the parameters are organized vertically using a "
+"``QVBoxLayout``, and each parameter corresponds to a ``QGridLayout`` "
+"where labels and inputs are distributed (in this case a ``QSpinBox``)."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1208
+msgid ""
+"Configuration pages in Spyder provide some helper methods to facilitate "
+"this work. For instance, ``create_spinbox`` allows to instantiate and "
+"initialize in a single step the widgets corresponding prefix an suffix "
+"labels together with the spinbox."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1211
+msgid "Propagate configuration changes"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1213
+msgid ""
+"Since we moved all the configuration information to ``conf.py``, now we "
+"have to import it from there into ``widgets.py``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1215
+msgid "`ACTIONS -> CONFPAGE widgets.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1228
+msgid ""
+"Now we can access the configuration options from anywhere in our plugin "
+"using the ``get_conf`` method. In this case we use it to access the value"
+" of ``pomodoro_limit`` from the configuration instead of the constant "
+"``POMODORO_DEFAULT``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1236
+msgid ""
+"Now we can add a method that updates our configurable parameter "
+"``pomodoro_limit``. The ``@on_conf_change`` decorator is the one in "
+"charge of capturing the signal that is generated when applying the change"
+" of a specific option."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1247
+msgid "Registering preferences"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1249
+msgid ""
+"Finally, it is necessary to activate the use of preferences in "
+"``plugin.py``, by requiring the Preferences plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1251
+msgid "`ACTIONS -> CONFPAGE plugin.py diff`_"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1262
+msgid ""
+"and registering our plugin in a method with the decorator "
+"``@on_plugin_available``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1271
+msgid ""
+"Now we can access the Preferences window either from the toolbar or from "
+"the \"Tools > Preferences\" menu. There we will find a section called "
+"*Spyder Pomodoro Timer* and inside it is the *Pomodoro timer limit* "
+"parameter. If we change that value, we will see how the corresponding "
+"label in the status bar changes."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1276
+msgid "Now your plugin is in an initial version ready to publish..."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1282
+msgid "Publishing your plugin"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1284
+msgid ""
+"Since the recommended way to install Spyder is through conda, the obvious"
+" choice would be to publish our plugin through a channel like conda-"
+"forge, but this is a task that is beyond the scope of this workshop due "
+"to its complexity."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1286
+msgid ""
+"However, the tools used to publish packages in conda are usually based on"
+" the packages published in PyPI. So let's see how to publish our plugin "
+"there."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1293
+msgid "PyPI and TestPyPI"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1295
+msgid ""
+"The first thing we have to do is to create an account on the `PyPI`_ and "
+"`TestPyPI`_ websites. Although our package will be finally published in "
+"PyPI, it is advisable to use TestPyPI to test that our package can be "
+"published properly without generating additional load to the PyPI servers"
+" or affecting their logs."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1297
+msgid ""
+"Next, we need edit the ``setup.py`` file at the root of our project with "
+"our own data. Fortunately, cookiecutter created one for us."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1299
+msgid ""
+"To upload our package to PyPI we have to use a tool called `Twine`_ that "
+"makes this task much easier. And we can install it in our conda "
+"environment using:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1306
+msgid "Build and check the package"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1308
+msgid ""
+"Before publishing our plugin we must package it. To do it we must write "
+"the following from the root folder of our project (where ``setup.py`` is "
+"placed):"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1314
+msgid ""
+"After that we will see that the following files are generated in the "
+"``dist`` folder:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1323
+msgid ""
+"On Linux and macOS we can check that the newly built distribution "
+"packages contain the expected files by inspecting the contents of the "
+"``tar`` file:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1329
+msgid ""
+"You can also use ``twine`` to run a check on the created files in "
+"``dist``:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1338
+msgid "Upload to PyPI"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1340
+msgid ""
+"Now we can use twine to upload the distribution packages we have built. "
+"First, we will upload them to TestPyPI to make sure everything works:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1346
+msgid ""
+"This command will prompt you for the username and password with which you"
+" registered in TestPyPI."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1348
+msgid ""
+"If we open https://test.pypi.org/project/spyder-pomodoro-timer/ in the "
+"browser we will be able to see the package we have just published."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1350
+msgid ""
+"There we'll see that some details are missing, like the package "
+"description, and that our package is marked as ``Development Status "
+"5-Stable``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1352
+msgid ""
+"To fix the first one, we can follow the instructions in `Making a PyPI-"
+"friendly README`_. Since we already have a README file, we simply add the"
+" following lines to the beginning of our ``setup.py`` file:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1368
+msgid ""
+"We can also change the classifiers of our package using the following "
+"site as a guide: https://pypi.org/classifiers. Here we can simply copy "
+"the classifiers we consider appropriate and then paste them into our "
+"code. Specifically in ``setup.py``, within the list that enters as the "
+"``classifier`` argument in the call to function ``setup``."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1371
+msgid ""
+"With these changes, and by bumping our plugin's version in the "
+"``__init__.py`` file inside the ``spyder_pomodoro_timer`` folder, we can "
+"repeat the cycle of building a new version of our package, loading it "
+"into TestPyPI for checking, and finally loading it into PyPI by using:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1377
+msgid "And check the result in https://pypi.org/project/spyder-pomodoro-timer/"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1379
+msgid ""
+"Once this is done, anyone can install our plugin in their environments "
+"simply by running:"
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1396
+msgid ""
+"The possibility of making a tool extensible through plugins, extensions "
+"or addons, as they are usually called, is a fundamental feature that "
+"allows taking advantage of the talent of third-party developers to "
+"respond to needs and enhancements that are beyond the scope of the "
+"application's core development team."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1398
+msgid ""
+"Similarly, a plugin-based system makes the application much easier to "
+"maintain. Eventually, the ability to enable and disable plugins makes it "
+"more adaptable to different use cases. For instance, at present it would "
+"be inconceivable to think of a web browser that does not have extensions "
+"to block advertising or organize links, even if those features don't come"
+" by default on them."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1400
+msgid ""
+"In Spyder we have put special interest in consolidating an API that "
+"allows the development of plugins in a consistent way. The main focus of "
+"the development effort between versions 4 and 5 was in this direction and"
+" we are at a key moment where we expect to capitalize on all this work."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1404
+msgid "Identify the basic building blocks in Spyder development."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1405
+msgid "Identify the different types of plugins that can be implemented in Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1406
+msgid "Recognize the types of plugins that are part of Spyder."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1407
+msgid "Plan the development of a new Spyder plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1408
+msgid "Build a development environment for Spyder plugin development."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1409
+msgid "Generate the basic structure of a Spyder plugin using Cookiecutter."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1410
+msgid "Understand the file structure of a Spyder plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1411
+msgid "Add and register Qt widgets in the Spyder status bar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1412
+msgid "Add and register Qt widgets in the Spyder toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1413
+msgid "Add a menu with actions in the toolbar."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1414
+msgid ""
+"Add configuration options to our plugin and display them appear in the "
+"Preferences window."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1415
+msgid ""
+"Edit the description and classifiers of the installable package of our "
+"plugin."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1416
+msgid "Publish our plugin to TestPyPI and PyPI."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1418
+msgid ""
+"With these skills we hope to ease the way for you to develop your own "
+"Spyder plugins."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1420
+msgid ""
+"If you have ideas for plugin development feel free to contact us through "
+"the `Spyder-IDE`_ Github organization space."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1424
+#: ../../workshops/scientific-computing.rst:776
+msgid ""
+"If you are interested in an introduction to financial analysis with "
+"Spyder, you can visit the workshop :doc:`Financial Data Analysis with "
+"Spyder<../workshops/financial>`."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1431
+msgid ""
+"As you may have noticed, there were some features left to implement such "
+"as notifications when pomodoros are completed. Try to implement them and "
+"do not hesitate to contact us if you have any doubts."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1438
+msgid ""
+"In the `plugin-examples`_ repository you can find additional examples "
+"that will surely be useful for you to further understand Spyder plugin "
+"development."
+msgstr ""
+
+#: ../../workshops/plugin-development.rst:1440
+msgid ""
+"A more in-depth review of the Spyder repository itself, especially its "
+"simpler plugins, such as History, Plots or Working directory, may help "
+"you understand it better. As well as a review of the various helper "
+"functions, widgets and mixins present in ``spyder.api``."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:5
+msgid "Qt Fundamentals"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:9
+msgid ""
+"**Qt** is a multiplatform widget toolkit for creating native graphical "
+"user interfaces. Qt is also a very complete development framework that "
+"offers utilities for building applications, and libraries of extensions "
+"for Networking, Bluetooth, Charts, 3D rendering, Navigation (as GPS), "
+"among others."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:14
+msgid "Basic Qt Components"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:16
+msgid ""
+"As mentioned before, Spyder's plugin development consists of extending "
+"the functionality of its Qt-based graphical interface."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:18
+msgid ""
+"To develop a GUI we will add graphical elements of interaction known as "
+"widgets, arrange them using layouts. Then, we interconnect those widgets "
+"using customized procedures implemented as functions or methods, allowing"
+" to trigger behavior from user interaction. In the following, we will "
+"develop these ideas in more detail."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:20
+msgid ""
+"Each type of Qt component is a class starting with the letter ``Q`` "
+"followed by a name related to its functionality."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:22
+msgid ""
+"The core component of Qt is the ``QApplication`` class. Every Qt "
+"application needs a single instance of this class as the base, from where"
+" the Qt *event loop* is controlled. Spyder itself is an instance of "
+"``QApplication``, its starting point is in the following two lines of "
+"code (spyder/spyder/app/mainwindow.py):"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:30
+msgid ""
+"``QMainWindow`` is a pre-built widget that provides many standard window "
+"features as toolbars, menus, a status bar, dockable widgets and more, "
+"which serves as the basis for the application."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:34
+msgid "Signals & Slots"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:36
+msgid ""
+"**Signals** are notifications emitted by widgets when something happens. "
+"That something could be different things, from pressing a button, to "
+"changing text in an input box, to changing text in the window. Many "
+"signals are initiated by user action, but this is not a rule."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:39
+msgid ""
+"**Slots** are signal receivers. Functions or methods could be used as "
+"slots, by connecting a signal to them. If a signal sends data, the "
+"receiver callable will also receive it. Many Qt widgets also have their "
+"own built-in slots, so the corresponding widgets are notified "
+"automatically."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:47
+msgid ""
+"In computer science a *Widget* is a shortened form of “window gadget”. A "
+"widget is an element of interaction, such as a button, or a container for"
+" other widgets, as panels or tabs. The ``QWidget`` class is the "
+"fundamental class for creating interfaces in Qt, it receives events from "
+"the window system, and renders its representation on the screen. A widget"
+" can provide a container for grouping other widgets, and if it is not "
+"embedded in a parent widget, it becomes a window."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:52
+msgid "Layouts"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:54
+msgid ""
+"Interfaces are built by embedding widgets inside widgets, and since they "
+"are visual components they are visually organized by means of *layouts*. "
+"A layout indicates how the widgets fill their container, either as "
+"columns, rows, cells in a matrix or stacked so that only one is visible "
+"at a time. Those are the 4 basic layouts available in Qt: "
+"``QHBoxLayout``, ``QVBoxLayout``, ``QGridLayout``, and "
+"``QStackedLayout``."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:61
+msgid "Actions, Toolbars & Menus"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:63
+msgid ""
+"User interfaces of desktop applications usually use ``QToolbar`` and "
+"``QMenu``. Since these are alternative ways to access the same "
+"functionality, Qt provides ``QAction`` as a way to avoid duplication of "
+"functions. Thus, each time a menu option or a toolbar button gives access"
+" to the same function, they point to the same action."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:67
+msgid "Dialogs"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:69
+msgid ""
+"A *Dialog* is a GUI component that communicates with the user. Dialogs "
+"are commonly used for functions that do not fit into the main interface. "
+"In Qt, by design ``QDialog`` is a modal (or blocking) window that show in"
+" front of the main Window until it is dismissed."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:72
+msgid ""
+"Qt provides some *special dialogs* for the most common use-cases as *file"
+" Open/Save*, *font selection*, *error messages*, *color choosing*, "
+"*printing*, among others."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:76
+msgid "Windows"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:78
+msgid ""
+"If an application requires additional windows that do not block the main "
+"window, these are generated as non-parent ``QWidget`` instances. These "
+"are used for tasks that happen in parallel over long-running processes "
+"such as displaying graphs or document editing."
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:83
+msgid "Events"
+msgstr ""
+
+#: ../../workshops/qt_fundamentals.rst:85
+msgid ""
+"An *Event* denote every interaction the user has with a Qt application. "
+"There are several types of events designed to address different types of "
+"interactions. In Qt they are represented by ``QEvent`` instances that "
+"contain information about what prompted them, and are passed to specific "
+"handlers that are responsible for triggering further actions."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:3
+msgid "Scientific Computing and Visualization with Spyder"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:5
+msgid ""
+"This workshop allows you to explore some of Spyder's features that make "
+"Spyder an ideal IDE for using the scientific tools offered by Python. "
+"Throughout the workshop, we will apply the scientific method to answer "
+"some questions related to our preferences and cognitive abilities. By the"
+" end of this workshop participants will be able to use Spyder to explore "
+"data, analyze it with some statistical tools and plot the relationship "
+"between variables."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:23
+msgid ""
+"Some knowledge of Statistics (`hypothesis testing`_ , `ANOVA`_, "
+"`p-value`_)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:38
+msgid ""
+"Apply the scientific method to answer questions related to psychometric "
+"variables"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:39
+msgid "Understand how to use Spyder's built-in scientific computing tools"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:47
+msgid ""
+"This workshop is intended for people who want to learn how to answer "
+"questions scientifically from a dataset. We have also designed it to "
+"serve as a tutorial for learning how to use Spyder as a research tool."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:55
+msgid ""
+"In this workshop we will explore a data set and use it to answer some "
+"questions using the scientific method."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:59
+msgid "Why do scientific research with Python?"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:61
+msgid ""
+"Python is a mature programming language that has been chosen by much of "
+"the scientific community to support the research process. There are a few"
+" reasons for this:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:63
+msgid "It is versatile and easy to learn and use"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:64
+msgid ""
+"It allows for multiple ways to handle inputs and outputs. No matter what "
+"format your data is in, in Python there is always a way to import it (and"
+" export it in the format of your choice)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:65
+msgid ""
+"It is interpreted. You don't have to write code from start to finish to "
+"see partial results. This makes it especially easy and fast to explore "
+"data"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:66
+msgid ""
+"It has built-in support for scientific computing tasks: `SciPy "
+"<https://scipy.org>`_, `NumPy <https://numpy.org>`_, `Pandas "
+"<https://pandas.pydata.org>`_, and a vast number of other libraries "
+"created by and for scientists"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:67
+msgid ""
+"It is the most widely used programming language for Machine Learning "
+"(including Keras and TensorFlow)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:69
+msgid ""
+"It can be integrated with `Jupyter Notebooks <https://jupyter.org>`_ and "
+"implementations of these in the cloud (`Google Colab "
+"<https://colab.research.google.com>`_ or `Binder "
+"<https://mybinder.org>`_)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:73
+msgid "How can Spyder help me in my scientific research?"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:75
+msgid ""
+"Spyder is a Scientific Integrated Development Environment written in "
+"Python, and designed by and for scientists, engineers, and data analysts."
+" It features a unique combination of the advanced editing, analysis, "
+"debugging, and profiling functionality of a comprehensive development "
+"tool with the data exploration, interactive execution, deep inspection, "
+"and beautiful visualization capabilities of a scientific package. "
+"Together with Python, it provides a very complete set of tools for "
+"scientific computing."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:79
+msgid "The basic steps of the scientific method"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:81
+msgid ""
+"The `scientific method "
+"<https://en.wikipedia.org/wiki/Scientific_method>`_ is a set of good "
+"practices used to achieve new knowledge in a valid way. Broadly speaking,"
+" the stages of the scientific method are as follows:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:83
+msgid "Observation: first find something that needs an explanation"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:84
+msgid ""
+"Search/generate theory: say a thing or two about the state of the world "
+"or how it works (an abstract thought about a phenomenon)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:85
+msgid "Hypothesis: identify variables and make predictions"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:86
+msgid ""
+"Testing/Experiment/More observation: measure relationship between "
+"variables"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:87
+msgid "Analysis: fit a model/graph data"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:88
+msgid "Reporting: share new findings"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:90
+msgid ""
+"Throughout this workshop, we will be developing each of these steps in a "
+"practical way. We will use Spyder as a research tool and psychometric "
+"data from an online dating site to make it easy and fun."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:94
+msgid "Introduction to scientific research with Spyder"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:100
+msgid ""
+"If you already have experience with Spyder, you can skip to `Preparation "
+"work`_ section."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:122
+msgid ""
+"The Variable Explorer is one of the most frequently used components in "
+"this workshop. **This is the pane where we will observe the data and most"
+" of the results of the scientific analysis, except for the plots**."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:128
+msgid ""
+"The :doc:`Plots pane <../panes/plots>` shows all the static graphs and "
+"images created in your IPython Console session. **All plots generated by "
+"the code will appear in this component**. You will also be able to save "
+"each graphic in a local file or copy it to the clipboard to share it with"
+" other researchers."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:132
+msgid "Code Analysis (share a stylish code!)"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:134
+msgid ""
+"Wouldn't it be great to have a tool to be able to detect code errors, "
+"stylistic problems, bad practices, inconsistencies and other issues? This"
+" is precisely the task of the  :doc:`Code Analysis<../panes/pylint>`. "
+"Your code can run, but if you are going to share it with other "
+"researchers it would be great if it is both readable and neat as well."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:146
+msgid "Setting up the Conda environment"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:154
+msgid ""
+"We recommend creating the virtual environment with `Anaconda "
+"<https://www.anaconda.com/products/individual>`_ (or `Miniconda "
+"<https://docs.conda.io/en/latest/miniconda.html>`_) as it integrates "
+"seamlessly with Spyder. You can find installation instructions in "
+"`Anaconda documentation`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:160
+msgid "1. With commands"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:162
+msgid ""
+"Just run the following command in your Anaconda Prompt (Windows) or "
+"terminal (other platforms), for a minimal install of Spyder into a new "
+"environment called ``scientific-computing``:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:168
+msgid ""
+"To install Spyder's optional dependencies as well for full functionality,"
+" use the following command instead:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:176
+msgid ""
+"Spyder now offers :ref:`install-standalone` for Windows and macOS, making"
+" it easier to get up and running with the application without having to "
+"download Anaconda or manually install it in your existing environment. If"
+" you use the standalone installer, there is no need to install "
+"``spyder=5`` with conda."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:180
+msgid "2. From an environment.yml file"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:182
+msgid ""
+"You can also install the virtual environment easily using the environment"
+" file (``scientific-computing.yml``) that we share with you. Just run the"
+" following command in the terminal (you must have the environment file in"
+" the current directory):"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:190
+msgid "Activate environment"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:192
+msgid "You can now enter the newly created virtual environment in this way:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:200
+msgid "Downloading the dataset"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:202
+msgid ""
+"We are going to work with a public dataset called OKCupid, collected by "
+"Kirkegaard and Bjerrekaer. The dataset is composed of 68,371 records and "
+"2,626 variables."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:204
+msgid "Download the `OKCupid dataset`_ to a directory of your choice."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:210
+msgid "Setting up the working directory"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:212
+msgid ""
+"The virtual environment and the data file are now ready. The only thing "
+"that remains is to create a directory to work in. In your operating "
+"system, create a new directory with the name of your choice. Then copy "
+"and unzip the dataset file there."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:214
+msgid "Here is an example (on Linux or macOS):"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:221
+msgid ""
+"Keep in mind that in this new directory you must have the data file "
+"unzipped."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:223
+msgid "Launch Spyder:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:229
+msgid ""
+"Let's make sure Spyder is ready. First, check that the working directory "
+"is correct. You should see in the upper right corner the path to the "
+"directory where you have the dataset. Something like this:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:234
+msgid ""
+"Second, let's check that the virtual environment we created is enabled in"
+" Spyder. Go to :guilabel:`Preferences` > :guilabel:`Python interpreter`, "
+"and use the dropdown under :guilabel:`Use the following Python "
+"interpreter` to select the path to your virtual environment. You should "
+"see something like this:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:245
+msgid ""
+"Although the workshop is designed for you to write the code in the "
+"IPython Console, we have created a file that you can :download:`download "
+"<scientific-computing.py>`. This script provides all the code you will "
+"write in this workshop, and you can use it as a guide if you get lost."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:251
+msgid "The dataset"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:253
+msgid ""
+"OKCupid is a dataset that gathers information obtained from the online "
+"dating site OKCupid. It consists of 68,371 records collected "
+"automatically employing a scraper that extracted public information."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:255
+msgid ""
+"The dataset contains demographic data (e.g., gender, sexual orientation "
+"and age). It also includes answers to general questions used by the "
+"website's algorithm to calculate some personality indicators to help find"
+" compatible matches."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:257
+msgid ""
+"If you want more information about how this dataset was collected and "
+"what kind of information it contains you can get it in this paper: `The "
+"OKCupid dataset`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:266
+msgid ""
+"You can also write your code or in the Editor (the pane that occupies the"
+" entire left side of Spyder). If you use the Editor, you can run the code"
+" by selecting it and pressing the :guilabel:`Run selection or current "
+"line` button in the :guilabel:`Run toolbar` or by pressing the F9 button."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:280
+msgid ""
+"The data you downloaded earlier is in `parquet "
+"<https://arrow.apache.org/docs/python/parquet.html>`_ format. This format"
+" is very convenient because it is smaller and faster than CSV or JSON "
+"files."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:282
+msgid "Load data:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:288
+msgid ""
+"You should now be able to see the data you have imported in the Variable "
+"Explorer."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:293
+msgid ""
+"You can see that the object is of type DataFrame and the number of rows "
+"and columns of the object."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:299
+msgid "Explore the dataset"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:303
+msgid "Age"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:305
+msgid ""
+"Now, let's explore one of the variables, in this case, the numeric "
+"variable age (``d_age``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:309
+msgid ""
+"In the OKCupid dataset, all demographic variables are prefixed with "
+"\"d\\_\" and profile variables with \"p\\_\"."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:318
+msgid ""
+"What happened? We called the ``data`` object and used Python's dot "
+"notation to pick the ``d_age`` column. This has a `Pandas Series "
+"<https://pandas.pydata.org/pandas-"
+"docs/stable/reference/api/pandas.Series.html>`_ type object. To this "
+"object we pass the ``describe()`` method that shows a summary of some "
+"indicators: count of values, mean, standard deviation, maximum value, "
+"minimum value, among others. With these figures we can see that the "
+"sample is mainly constituted of young people (the average is 31.65 years "
+"old)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:320
+msgid ""
+"The return of a function, method or the attribute of an object can be "
+"stored as a variable to have it at hand in the Variable Explorer:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:330
+msgid ""
+"The values are floats. The lowest age is 18.0 years and the highest is "
+"100.0 years."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:334
+msgid ""
+"Notice also that each type of variable has a different color to quickly "
+"distinguish them."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:336
+msgid ""
+"We already know the minimum and maximum age, and that the mean is around "
+"32 years old. A good way to further explore this variable is to plot a "
+"histogram, a type of graph that shows the frequency distributions. In "
+"this way we can see if the groups of young people on the platform are "
+"more numerous than the older ones."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:338
+msgid ""
+"We can plot a histogram directly from the dataframe. To do this we select"
+" the variable (as we did with the ``.describe()``) and invoke the "
+"``.plot.hist()`` method. In this method we will pass as arguments the "
+"number of bins and the transparency of the plot (``alpha``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:348
+msgid ""
+"Another way to generate a simple histogram in Spyder is to use a context "
+"menu on an array in the Variable Explorer. But first we must store these "
+"values in a list and call that variable ``age``."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:360
+msgid ""
+"Frequency distributions come in different sizes and shapes. The shape of "
+"a histogram reveals very interesting things about the data. A "
+"symmetrical, bell-shaped histogram might indicate that the distribution "
+"is normal (most of the scores are close to the center of the "
+"distribution). In the age histogram, you can see that it has a \"tail\" "
+"to the right (towards the older ages). Technically this is called "
+"\"positively `skewed`_\". It is also noticeable that it is somewhat "
+"pointy (positive `kurtosis`_ or leptokurtic). These two things could "
+"suggest that age is not a random variable."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:365
+msgid ""
+"Although we can create the histogram directly from the dataframe, we are "
+"going to use a Python library called Seaborn to do the same, because this"
+" library will allow us to do more interesting things later."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:372
+msgid ""
+"We call ``sns.histplot()`` with three arguments. The first one "
+"(``data.d_age``) is a Pandas Series with the **quantitative** variable we"
+" want to plot. The second (``kde=True``) adds a curve showing an ideal "
+"model of the age distribution (using a method called *Kernel Density "
+"Estimator*). And the third one (``bins=25``) indicates that we want 25 "
+"bins in the graph."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:377
+msgid ""
+"The second line (``plt.show()``) is intended to show all the figures not "
+"displayed so far. If you have any doubts about how to utilize an object, "
+"method or function, you can use the ``help()`` tool in the console. For "
+"example:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:383
+msgid ""
+"Or you can also take advantage of the Help pane included in Spyder to get"
+" on-screen help:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:388
+msgid ""
+"With Seaborn, we can add a line representing the mean of the histogram. "
+"To do this we will use the ``axvline()`` method and add a text with the "
+"value of the mean where ``text()``, ``min_ylim`` and ``max_ylim`` are "
+"used to mark the position of the text."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:405
+msgid "Religion seriosity"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:407
+msgid ""
+"We know the extent of the dataframe and we have seen how to explore a "
+"quantitative variable. Now let's move on to a qualitative variable. The "
+"``columns`` attribute shows a list of column names in the dataframe. We "
+"also know that demographic variables are prefixed with \"d\\_\", so we "
+"can look for variable names that correspond to this prefix."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:413
+msgid ""
+"In the Variable Explorer you will see a new variable ``demograph``. If "
+"you double click on it you will see a list of the demographic variables "
+"in the dataset. At the end of the list you will see a value "
+"``d_religion_seriosity``. If you right click on it, several options will "
+"appear on the screen. You can rename the column, delete it or insert a "
+"new one. Let's click on :guilabel:`Copy` to copy the column name into "
+"memory."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:415
+msgid ""
+"In the IPython Console, type ``data.`` and then copy the column name. "
+"Type a period at the end (no spaces) and hit tab. You should see "
+"something like the following:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:420
+msgid ""
+"You can then see a list of all relevant methods and attributes of the "
+"class. Right at the end you will see ``value_counts`` that could be used "
+"to summarize the variable. It is a method so it must end in parentheses:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:432
+msgid ""
+"In addition to demographic and profile variables, the dataset includes "
+"responses to questions on a variety of topics. These questions are coded "
+"with a prefix \"q\" followed by an integer. The text of the questions is "
+"stored in a file called :file:`question_data.csv` (which you can download"
+" as part of the `OKCupid dataset`_)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:434
+msgid "We can examine this file in the Variable Explorer:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:440
+msgid ""
+"Double click on \"question_data\" in the Variable Explorer to display "
+"each question aligned with its code (\"q\" + number)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:442
+msgid ""
+"Now that we have learned how to explore the data we can ask interesting "
+"questions and try to answer them with the help of the dataset and Spyder."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:448
+msgid "Think of a theory and write a hypothesis"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:450
+msgid ""
+"A theory is nothing more than an explanation of something. For example, "
+"we could get involved in the eternal conflict between cats and dogs. I, "
+"as a dog person, might have a theory (unscientific, of course) that those"
+" who prefer to have the companionship of a dog are smarter people than "
+"those who prefer a wicked (but lovable) kitty. To test the support of a "
+"theory, one can make a prediction based on it and see how this prediction"
+" behaves in an experiment or a concrete situation. We call this "
+"prediction a hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:452
+msgid ""
+"A hypothesis is a statement that can be tested employing the scientific "
+"method. They must be verifiable using empirical evidence or data. For "
+"example, *green is the best color* is not a hypothesis since it cannot be"
+" proven or disproven."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:454
+msgid ""
+"Concerning the above theory of a person's pet preferences, to explore it "
+"we should find two variables to relate. The first variable would be "
+"related to a **self-identification as a cat person or dog person**. The "
+"second variable would be related to a person's **ability to solve "
+"problems and situations**."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:456
+msgid ""
+"The OKCupid dataset has useful variables that we can use to investigate "
+"this theory. For example, question **q997** (*Are you a cat person or a "
+"dog person?* ) provides information about a person's pet preferences. The"
+" second variable is slightly more difficult to come up with, as it is "
+"somewhat more complex. Fortunately, the researchers who collected the "
+"dataset have also selected 14 questions that can serve as a proxy for a "
+"cognitive ability test. This selection of questions can be found in the "
+"file :file:`test_items.csv` in the `OKCupid dataset`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:462
+msgid ""
+"So, let's try to see if there is any evidence in the OKCupid dataset to "
+"support the following hypothesis:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:464
+msgid ""
+"*People who prefer dogs to cats would score higher on tests of cognitive "
+"ability*."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:468
+msgid ""
+"SPOILER ALERT: If you are a cat person, and feel you should immediately "
+"leave this workshop, I suggest you stay. If you're not a cat person, stay"
+" too."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:474
+msgid "Build the test"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:476
+msgid ""
+"We already know which questions will be part of the cognitive ability "
+"test. Now we are going to process this data to obtain the scores for each"
+" person."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:478
+msgid "First, we make a copy of the original dataset:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:484
+msgid ""
+"Then, we find the correct answer to each test question (these answers are"
+" in ``test_items``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:493
+msgid "The correct answers have been stored in the ``test_items`` dataframe."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:495
+msgid ""
+"Next, we will indicate, in the ``ca_test`` dataframe, whether the person "
+"answered correctly to each question selected in the cognitive ability "
+"test. These answers will be entered as a boolean in new variables with "
+"the prefix \"resp\\_\" followed by the corresponding question code. The "
+"Boolean is calculated with the function ``lambda row: row[q] == a, "
+"axis=1``."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:510
+msgid ""
+"Some ``test_items`` questions are not in the data but don't worry about "
+"that. We use a ``try... except`` block to ignore these errors. Answering "
+"these questions was optional, so many OkCupid site users did not answer "
+"all of them. So we have removed from the records the users who did not "
+"answer the 14 questions we have chosen for the cognitive ability test. "
+"This reduced the sample size considerably. There are other ways to avoid "
+"this reduction, but they are outside the scope of this workshop."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:512
+msgid ""
+"We want to sum the correct answers for each person, but some integer "
+"results were stored as strings, so let's fix that:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:524
+msgid ""
+"Now that we have the correct answer for each test question, let's add up "
+"each correct answer for each person. There are 14 questions, so the "
+"maximum score will also be 14:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:531
+msgid ""
+"How do we add up these responses? Remember that each answer was stored as"
+" a boolean (True or False) with the prefix \"resp\\_\". So we search in "
+"the ``ca_test`` dataframe for the answers of each column starting with "
+"\"resp\" (we use the regular expression ``regex=\"^resp\"`` and the "
+"method ``filter``) and sum the True values of each row with "
+"``sum(axis=1)``. Then we store these results in the \"cognitive_score\" "
+"column of the ``ca_test`` dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:533
+msgid ""
+"You can see the results of these operations by typing in the IPython "
+"Console ``ca_test.cognitive_score.describe()``. If you do so, in *count* "
+"you will see that the new number of records has been reduced to 479 (the "
+"rest of the 68,371 users did not answer all of these questions)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:537
+msgid "Cognitive ability distribution"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:539
+msgid "Let's draw a histogram of this variable to see the frequency distribution."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:549
+msgid ""
+"As you can see, in this case, the distribution is not symmetrical but has"
+" a long \"tail\" on the left (negatively skewed). This means that most of"
+" the users who answered all the questions did quite well and that only a "
+"few users answered most of the questions in the wrong way."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:553
+msgid ""
+"The values we have calculated in this section were already in the data "
+"(``data.CA_items``). However, we have chosen to obtain these results "
+"again using code because it is a good way to learn how to use the tools "
+"provided by Python and Pandas for data manipulation."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:559
+msgid "Relate variables"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:561
+msgid ""
+"Remember that the hypothesis relates two variables: which pet do you "
+"prefer and cognitive ability. The measurement of pet preferences will be "
+"made from question **q997** (categorical or qualitative variable) and "
+"cognitive ability will be measured from the sum of the correct answers on"
+" the test (quantitative interval variable). With this type of variable we"
+" can make some box plots to see if there are differences between the "
+"means."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:563
+msgid ""
+"But first, let's change the standard Seaborn palette, to get prettier "
+"plots."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:573
+msgid ""
+"Seaborn allows you to choose from different styles of graphics and color "
+"palettes. More information is available at "
+"https://seaborn.pydata.org/tutorial/color_palettes.html"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:575
+msgid ""
+"Now, we are going to create box plots to observe the relationship between"
+" variables. To do this, we will use the ``catplot`` class of Seaborn. The"
+" first argument will be the x-axis, which in this case will be the "
+"qualitative variable (question **q997**). The second argument will be the"
+" y-axis, where we will place the quantitative variable (cognitive score)."
+" With the parameter ``kind`` we indicate that it is a box plot. The "
+"parameters ``height`` and ``aspect`` regulate the appearance of the "
+"graph. The last parameter, ``data``, indicates where the data comes from."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:586
+#, python-format
+msgid ""
+"Box plots or box-whisker diagrams display, near the center of the box, "
+"the **mean** of the data as a horizontal line. The lines bordering the "
+"box represent **50% of the observations** (*interquartile range* ). "
+"Outside the box, upwards and downwards, we find two whiskers: the lower "
+"one represents the **mean of the values in the lower part of the "
+"dataset**, and the upper one represents the **mean of the values in the "
+"upper part of the dataset**. The points beyond the whiskers are "
+"**outliers**."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:590
+msgid ""
+"An outlier is a value that is very different from the rest of the data "
+"values. They must be taken into account because they can often create a "
+"bias in the model we are trying to fit to the data."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:592
+msgid ""
+"The graph shows four boxes measuring cognitive ability for the following "
+"groups:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:594
+msgid "Those who prefer dogs"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:595
+msgid "Those who define themselves as cat people and dog people indistinctly."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:596
+msgid "Those who prefer cats"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:597
+msgid "Those who like neither cats nor dogs."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:599
+msgid ""
+"The lowest mean is that of those who prefer dogs only, but by very "
+"little. The box (and boundaries) representing dog lovers is also "
+"\"wider,\" implying a larger variability in the individual test results "
+"for this group. But this is not a very different dispersion from that of "
+"those who prefer cats. All the means are within the limits of the other "
+"boxes (interquartiles), which seems to indicate that, in fact, there are "
+"not really important differences in the intelligence test scores for "
+"these groups. This seems to undermine support for the initial hypothesis "
+"we posed above."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:603
+msgid ""
+"If you want to see the figures, enter ``dog_or_cat = "
+"ca_test.groupby(\"q997\")[\"cognitive_score\"].describe()`` in the "
+"IPython Console and look at the results in the Variable Explorer. This "
+"way you can see how many people prefer cats or dogs, and the means and "
+"standard deviation of the cognitive ability test results for each group."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:605
+msgid ""
+"To appreciate in context the real difference in the averages, let's "
+"create some bar charts. We are now going to use Seaborn's barplot class. "
+"On the x-axis we put again the qualitative variable (**q997**) and on the"
+" y-axis the quantitative variable (cognitive_score). The data parameter "
+"takes as argument the entire dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:620
+msgid ""
+"If the box plots indicated that the means did not show significant "
+"differences (possibly due to chance), the bar plot confirms that these "
+"differences are, in proportion, quite modest."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:626
+msgid "ANOVA test"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:628
+msgid ""
+"To make sure that the differences between the means are statistically "
+"significant, we will perform an ANOVA (analysis of variance) because we "
+"are going to compare the means of more than two groups."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:630
+msgid ""
+"How does ANOVA work? This analysis tells us whether three or more means "
+"are equal. If so, this would support the null hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:634
+msgid ""
+"The *null hypothesis* is an alternative prediction to the one we have "
+"stated in our hypothesis. The null hypothesis simply states that the "
+"observed differences in means are due to random variations that occur "
+"when samples are collected."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:636
+msgid ""
+"An ANOVA produces an *F-ratio* (also called F-statistic) that compares "
+"the amount of systematic variation in the data (variation that can be "
+"explained by the model or hypothesis) with the amount of unsystematic "
+"variance (variation that cannot be explained by our hypothesis or model)."
+" This means that F is the ratio of the model to its error. ANOVA also "
+"produces a *p-value* that indicates the probability that the variation "
+"can be attributed to the null hypothesis. The smaller the p-value, the "
+"less likely it is that the observed variation is due to chance."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:640
+msgid "Formatting the data"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:642
+msgid ""
+"To perform an ANOVA, let's start by pivoting the dataset with the "
+"cognitive ability test results. The pet preferences values will now be "
+"the column names, and each row will represent a person."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:646
+msgid ""
+"To perform an ANOVA, certain requirements or assumptions must be met. For"
+" example, the distributions of the residuals must be normal. This is not "
+"the case here. There are more appropriate statistical tests for this "
+"example, and the possibility of performing certain transformations on the"
+" data in order to apply ANOVA in this case. However, we use ANOVA because"
+" it is a fairly popular test, and because the purpose of this workshop is"
+" to serve as an introduction to scientific computing with Spyder. We do "
+"not intend here to obtain scientific results for publication."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:652
+msgid ""
+"You will see that one of the columns includes the answers to the test "
+"made by people who did not specify their preferences towards pets. Let's "
+"delete that column."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:661
+msgid ""
+"Now let's rename the column names (for simplicity) and remove the records"
+" that have missing values (with ``dropna``). The argument "
+"``inplace=True`` allows you to directly modify a dataframe without having"
+" to create a new one."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:671
+msgid ""
+"In the variable ``dog_or_cat_col_names`` we have stored the names of the "
+"values in order. This implies that: A = Both, B = Cats, C = Dogs, and D ="
+" Neither."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:673
+msgid ""
+"To perform ANOVA, we are going to use a Python library called \"stats\", "
+"in particular the ``f_oneway`` function. You can find more information "
+"about this library by typing ``stats`` in the Help Pane or learn more "
+"about the function by typing ``stats.f_oneway``."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:678
+msgid ""
+"The help notes that this function requires an array-like with the "
+"measurements for each group as an input (in our case, one sample for A, "
+"one for B, one for C, and one for D). Since we have empty cells in each "
+"column, let's remove them from each column (the ``f_oneway`` function "
+"does not support missing values)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:684
+msgid ""
+"In the above line of code we are creating a list with 4 elements: the "
+"test results of each column A, B, C, and D, without the missing values "
+"(they are removed with ``dropna()``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:688
+msgid "Run ANOVA"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:690
+msgid ""
+"Now, let's run ANOVA and store the output in two variables: ``f_value`` "
+"and ``p_value``. Notice that since ``dog_or_cat_samples`` is a list, we "
+"must pass the argument with an asterisk (``*dog_or_cat_samples``)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:696
+msgid ""
+"With the help of ``stats.f_oneway`` in the Help Pane you can read a "
+"description of the output of this function, some interesting notes about "
+"the test, and some references that you can use to better understand the "
+"nature of this analysis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:700
+msgid ""
+"In the Help pane you will read that ANOVA requires certain assumptions to"
+" be satisfied. In this workshop we have not checked those assumptions "
+"because our goal is merely to show some Spyder functions that make the "
+"research work easier. Thus, the results obtained in this example with "
+"ANOVA should not be taken too rigorously."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:702
+msgid ""
+"In the Variable Explorer you can find these two new variables: "
+"``f_value`` and ``p_value``. ``p_value`` (0.6275) is well over 0.05, "
+"which gives support to the null hypothesis (detracting support from our "
+"hypothesis). To know if the F value obtained is greater than the "
+"theoretically expected value, a **F critical value** must be calculated. "
+"This can be estimated using the ``stats`` library, a significance level "
+"(*q* ), and the degrees of freedom (*df* ) for the number of groups and "
+"the number of observations:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:713
+msgid ""
+"The value of ``f_critical`` (2.6241) is larger than that of ``f_value`` "
+"(0.5813). This means that the variance between the means of these groups "
+"is not significantly different. Since the *p* value indicates that we "
+"cannot rule out random variations, then we have to discard our "
+"hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:715
+msgid ""
+"What is the conclusion of all this? There seems to be little or no "
+"evidence in our data to think that there is indeed a correlation between "
+"a person's pet preferences and his or her ability to solve practical or "
+"abstract problems. Cat and dog owners, rejoice!"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:721
+msgid "Report and share"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:723
+msgid ""
+"In science, sharing results, good and bad, is critical. Today, in "
+"scientific computing, it is also crucial to share data, and the code used"
+" to process and analyze it. To help with this, we will use Spyder's Code "
+"Analysis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:727
+msgid "Code Analysis"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:729
+msgid ""
+"When you share code, you want it to be readable, clean, and not overly "
+"complex. The Code Analysis component can help us detect these issues and "
+"even bugs that can affect the performance of our code."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:731
+msgid ""
+"To see an example, you can open the :download:`scientific-computing-"
+"astro.py <scientific-computing-astro.py>` file and run the "
+":guilabel:`Code Analysis` (open the file in the pane and click on the "
+"green triangular button in the upper right corner)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:736
+msgid "You can see four categories that can help you improve your code:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:738
+msgid "Convention: programming standard violations"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:739
+msgid "Refactor: refactoring related checks"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:740
+msgid "Warning: Python-specific problems"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:741
+msgid "Error: probable bugs in the code"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:743
+msgid ""
+"Each of these categories indicates the type of alert and the line on "
+"which the potential issue occurs. For example, it tells us that line 129 "
+"is too long, or that we imported numpy but did not use it at all in the "
+"code."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:745
+msgid ""
+"These suggestions can contribute to sharing clean code. We recommend "
+"using this panel to polish your code before publishing it."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:753
+msgid ""
+"In this workshop we have taken the first steps to use Spyder for "
+"scientific computing. We have seen how from a question or doubt a "
+"hypothesis is raised. This question can also emerge from the exploration "
+"of some data, which can be done by calculating some measures (such as "
+"mean, median, standard deviation) or by drawing some plots."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:755
+msgid ""
+"Often, in order to answer the question, we must process some data (for "
+"example, for the construction of a cognitive ability test)."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:757
+msgid ""
+"Finally, we try to establish a relationship between variables with some "
+"statistical tests. The results of these tests will support or not our "
+"initial hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:762
+msgid "Write and test code with the IPython Console and Editor."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:763
+msgid "Download a dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:765
+msgid "Graphically explore a dataset."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:767
+msgid "Explore data and relate it to a hypothesis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:769
+msgid "Perform a statistical test with a specialized library on the data."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:770
+msgid "Improve code readability with Code Analysis."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:772
+msgid ""
+"Spyder has many features that can help you do data analysis. You can find"
+" more information in our `official documentation <https://docs.spyder-"
+"ide.org/5/index.html>`_."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:782
+msgid ""
+"If you want to check what you have learned, we suggest you analyze the "
+"data to try to answer the following question: *Do the different zodiac "
+"signs influence the results of a cognitive ability test?,* you can check "
+"the Python script :download:`scientific-computing-astro.py <scientific-"
+"computing-astro.py>` if you have any doubts."
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:790
+msgid ""
+"For a description of the dataset used, see the following `paper "
+"<https://openpsych.net/paper/46/>`__:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:792
+msgid ""
+"Kirkegaard, E. O. W., & Bjerrekær, J. D. (2016). *The OKCupid dataset: A "
+"very large public dataset of dating site users*. Open Differential "
+"Psychology. doi:10.26775/odp.2016.11.03*"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:794
+msgid "A very fun book for learning statistics with R is the following:"
+msgstr ""
+
+#: ../../workshops/scientific-computing.rst:796
+msgid ""
+"Field, A., Miles, J., & Field, Z. (2012). *Discovering statistics using "
+"R*. SAGE Publications."
+msgstr ""
+


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

As a followup to #377 and #379 , add the actual infrastructure and automation tooling for translating the Spyder documentation, and the translations themselves.

Specifically, this adds:
* The actual pot and po files with the translations, pulled from the versions in Crowdin
* Commands for generating and updating the translation files
* Commands for building the docs with multiple translations
* CI support for the same
* Crowdin configuration for future automatated pulls and pushes of translation updates

The site is now built into the translated versions; to view this, add `LANGCODE/` to the URL after the version, currently either `en/` or `es/`. There is not yet a GUI switcher for translations; the current translations can be switched by manually editing the URL. Additionally, the translations need some additional work to translate untranslated texts (overview, FAQ titles, captions, etc) and update the translation to be generated with the current documentation rather than one several months old. Therefore, it will remain beta for now.


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
