### PR TITLE
Fix Sphinx Lint for Spanish translations

### DIFF
--- a/doc/locales/es/LC_MESSAGES/panes.po
+++ b/doc/locales/es/LC_MESSAGES/panes.po
@@ -32,7 +32,7 @@ msgstr "Depurando con ipdb"
 
 #: ../../panes/debugging.rst:17
 msgid "You can fully control debugger execution from the :guilabel:`Debug` menu, :guilabel:`Debug toolbar` and via configurable keyboard shortcuts, along with the standard ``ipdb`` `console commands`_."
-msgstr "Puedes controlar completamente la ejecución del depurador desde el menú `Depurar` de la :guilabel:`Barra de herramientas de depuración` y a través de atajos de teclado configurables, junto con el estándar ``ipdb`` `comandos de consola`_."
+msgstr "Puedes controlar completamente la ejecución del depurador desde el menú :guilabel:`Depurar` de la :guilabel:`Barra de herramientas de depuración` y a través de atajos de teclado configurables, junto con el estándar ``ipdb`` `comandos de consola`_."
 
 #: ../../panes/debugging.rst:22
 msgid "Additionally, the  :doc:`editor` shows the line of code the debugger is currently stopped on with an arrow."
@@ -246,7 +246,7 @@ msgstr "Para mejorar la legibilidad de tu código, Spyder tiene una función de 
 
 #: ../../panes/editor.rst:93
 msgid "You can configure and preview syntax highlighting themes and fonts under :menuselection:`Preferences --> Appearance`. The :guilabel:`Syntax highlighting theme` section allows you to change the color and style of the syntax elements and background to match your preferences. You can switch between available themes in the drop-down menu, modify the selected theme, create a new theme, and more. The :guilabel:`Fonts` section lets you change the text font and size."
-msgstr "Puedes configurar y previsualizar los temas y fuentes de resaltado de sintaxis bajo :menuselection:`Preferencias --> Apariencia`. La sección :guilabel:'Tema de coloreado de sintaxis' te permite cambiar el color y el estilo de los elementos de sintaxis y el fondo para que coincida con tus preferencias. Puedes cambiar entre los temas disponibles en el menú desplegable, modificar el tema seleccionado, crear un nuevo tema y más. La sección :guilabel:`Tipo de letra` te permite cambiar el tamaño y la fuente de texto."
+msgstr "Puedes configurar y previsualizar los temas y fuentes de resaltado de sintaxis bajo :menuselection:`Preferencias --> Apariencia`. La sección :guilabel:`Tema de coloreado de sintaxis` te permite cambiar el color y el estilo de los elementos de sintaxis y el fondo para que coincida con tus preferencias. Puedes cambiar entre los temas disponibles en el menú desplegable, modificar el tema seleccionado, crear un nuevo tema y más. La sección :guilabel:`Tipo de letra` te permite cambiar el tamaño y la fuente de texto."
 
 #: ../../panes/editor.rst:101
 msgid "Changes made to the syntax highlighting theme and font settings are common to all source files, regardless of their language."
@@ -540,7 +540,7 @@ msgstr "Asociaciones de archivos"
 
 #: ../../panes/fileexplorer.rst:83
 msgid ":guilabel:`Files` allows you to associate different external applications with specific file extensions they can open. Under the :guilabel:`File associations` tab of the :guilabel:`Files` preferences pane, you can add file types and set the external program used to open each of them by default."
-msgstr ":guilabel:`Archivos` te permite asociar diferentes aplicaciones externas con extensiones específicas de archivo que pueden abrir. Bajo la pestaña :guilabel:'Asociaciones de archivos' del panel de preferencias :guilabel:'Archivos', puedes añadir tipos de archivo y establecer el programa externo usado para abrir cada uno de ellos por defecto."
+msgstr ":guilabel:`Archivos` te permite asociar diferentes aplicaciones externas con extensiones específicas de archivo que pueden abrir. Bajo la pestaña :guilabel:`Asociaciones de archivos` del panel de preferencias :guilabel:`Archivos`, puedes añadir tipos de archivo y establecer el programa externo usado para abrir cada uno de ellos por defecto."
 
 #: ../../panes/fileexplorer.rst:89
 msgid "Once you've set this up, files will automatically launch in the associated application when opened from Spyder's :guilabel:`Files` pane. Additionally, when you right-click a file, you will find an :guilabel:`Open with...` option that will allow you to select from the applications associated with this extension."
@@ -1093,7 +1093,7 @@ msgstr "Haciendo clic en el menú desplegable o pulsando la tecla :kbd:`Flecha a
 
 #: ../../panes/profiler.rst:47
 msgid "Finally, you can save the data for a given run to disk as a file with the ``.Result`` extension using the :guilabel:`Save data` button. This can be loaded to compare with a previous run of the same file using the :guilabel:`Load data` button. To remove the loaded data, click the :guilabel:`Clear comparison` button."
-msgstr "Finalmente, puedes guardar los datos para una ejecución dada en el disco como un archivo con el ``.Result`` usando el botón :guilabel:`Guardar información de perfilado`. Esto se puede cargar para comparar con una ejecución anterior del mismo archivo usando el botón 'Cargar datos' de :guilabel:. Para eliminar los datos cargados, haga clic en el botón :guilabel:'Limpiar comparación'."
+msgstr "Finalmente, puedes guardar los datos para una ejecución dada en el disco como un archivo con el ``.Result`` usando el botón :guilabel:`Guardar información de perfilado`. Esto se puede cargar para comparar con una ejecución anterior del mismo archivo usando el botón :guilabel:`Cargar datos`. Para eliminar los datos cargados, haga clic en el botón :guilabel:`Limpiar comparación`."
 
 #: ../../panes/profiler.rst:58
 msgid "Interpreting the results"

--- a/doc/locales/es/LC_MESSAGES/troubleshooting.po
+++ b/doc/locales/es/LC_MESSAGES/troubleshooting.po
@@ -300,7 +300,7 @@ msgstr "Spyder-Kernels no está instalado o es incompatible"
 
 #: ../../troubleshooting/common-illnesses.rst:24
 msgid "Spyder requires a supported version of the ``spyder-kernels`` package to be present in the working environment you want to run your console in."
-msgstr "Spyder requiere que una versión compatible del paquete``spyder-kernels`` esté presente en el entorno de trabajo en el que deseas ejecutar tu consola."
+msgstr "Spyder requiere que una versión compatible del paquete ``spyder-kernels`` esté presente en el entorno de trabajo en el que deseas ejecutar tu consola."
 
 #: ../../troubleshooting/common-illnesses.rst:29
 msgid "It is included by default with Anaconda, but if you want to run your code in another Python environment or installation, you'll need to make sure it's installed and updated to the latest version."
@@ -600,7 +600,7 @@ msgstr "Para hacerlo, necesitarás:"
 
 #: ../../troubleshooting/emergency-cpr.rst:43
 msgid "Find the path to the Spyder :file:`app` directory from the command line. For this, run:"
-msgstr "Encuentra la ruta al directorio `:file:`app` de Spyder desde la línea de comandos. Para esto, ejecuta:"
+msgstr "Encuentra la ruta al directorio :file:`app` de Spyder desde la línea de comandos. Para esto, ejecuta:"
 
 #: ../../troubleshooting/emergency-cpr.rst:50
 msgid "Go to the output path of the above command on your command line:"


### PR DESCRIPTION
<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->

# Pull Request

## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

<!--- Describe what you've changed and why. --->

Sphinx Lint's own CI runs on some "friend projects", including this one, and has started failing:

```
E         + sphinx-lint/tests/fixtures/friends/spyder-docs/doc/locales/es/LC_MESSAGES/troubleshooting.po:301: found an unbalanced inline literal markup. (unbalanced-inline-literals-delimiters)
E         + sphinx-lint/tests/fixtures/friends/spyder-docs/doc/locales/es/LC_MESSAGES/troubleshooting.po:301: found an unbalanced inline literal markup. (unbalanced-inline-literals-delimiters)
E         + sphinx-lint/tests/fixtures/friends/spyder-docs/doc/locales/es/LC_MESSAGES/troubleshooting.po:601: default role used (hint: for inline literals, use double backticks) (default-role)
E         + sphinx-lint/tests/fixtures/friends/spyder-docs/doc/locales/es/LC_MESSAGES/troubleshooting.po:301: missing space before default role: 'ete``spyder-kernels``'. (missing-space-before-default-role)
E         + sphinx-lint/tests/fixtures/friends/spyder-docs/doc/locales/es/LC_MESSAGES/troubleshooting.po:601: superfluous backtick in front of role (backtick-before-role)
E         + sphinx-lint/tests/fixtures/friends/spyder-docs/doc/locales/es/LC_MESSAGES/panes.po:33: default role used (hint: for inline literals, use double backticks) (default-role)
E         + sphinx-lint/tests/fixtures/friends/spyder-docs/doc/locales/es/LC_MESSAGES/panes.po:247: role with no backticks: " :guilabel:'Tema " (role-without-backticks)
E         + sphinx-lint/tests/fixtures/friends/spyder-docs/doc/locales/es/LC_MESSAGES/panes.po:541: role with no backticks: " :guilabel:'Asociaciones " (role-without-backticks)
E         + sphinx-lint/tests/fixtures/friends/spyder-docs/doc/locales/es/LC_MESSAGES/panes.po:1094: role with no backticks: ' :guilabel:. ' (role-without-backticks)
```

https://github.com/hugovk/sphinx-lint/actions/runs/10919403051/job/30306982773

I've not checked why the spyder-docs CI didn't find these, maybe they don't run on `.po` files?


Most of these changes are straightforward mechanical fixes, but I don't speak Spanish so please check this one where I deleted a "de":

```diff
-msgstr "Finalmente, puedes guardar los datos para una ejecución dada en el disco como un archivo con el ``.Result`` usando el botón :guilabel:`Guardar información de perfilado`. Esto se puede cargar para comparar con una ejecución anterior del mismo archivo usando el botón 'Cargar datos' de :guilabel:. Para eliminar los datos cargados, haga clic en el botón :guilabel:'Limpiar comparación'."
+msgstr "Finalmente, puedes guardar los datos para una ejecución dada en el disco como un archivo con el ``.Result`` usando el botón :guilabel:`Guardar información de perfilado`. Esto se puede cargar para comparar con una ejecución anterior del mismo archivo usando el botón :guilabel:`Cargar datos`. Para eliminar los datos cargados, haga clic en el botón :guilabel:`Limpiar comparación`."
```

### Issue(s) Resolved

<!--- Pull requests should typically resolve at least one—preferably only one— --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line. --->
<!--- However, smaller fixes, maintenance or trivial changes don't need one. --->

n/a


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
