### PR TITLE
Fix bug in language switcher due to lack of trailing slash in base URL

### DIFF
--- a/doc/_static/js/language-switcher.js
+++ b/doc/_static/js/language-switcher.js
@@ -1002,12 +1002,12 @@ async function fetchAndUseLanguages() {
         "language": "en",
         "name": "English",
         "preferred": true,
-        "url": "https://docs.spyder-ide.org/5/en"
+        "url": "https://docs.spyder-ide.org/5/en/"
       },
       {
         "language": "es",
         "name": "Español",
-        "url": "https://docs.spyder-ide.org/5/es"
+        "url": "https://docs.spyder-ide.org/5/es/"
       }
     ]
 


### PR DESCRIPTION
# Pull Request

<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->


## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below


## Description of Changes

<!--- Describe what you've changed and why. --->

During real-world deployed web testing, we discovered a bug in the language switcher URLs on subpages that was not caught in local filesystem testing: a missing trailing slash in the base URL, leading to the main page being displayed instead of subpages. This PR fixes it.


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
