### PR TITLE
Remove np.log preprocessing from individual return series

### DIFF
--- a/doc/workshops/financial-analysis.py
+++ b/doc/workshops/financial-analysis.py
@@ -87,7 +87,7 @@ print(monthly_data_1.std())
 
 
 # %% Returns per day
-rets_1 = np.log(close_data_1/close_data_1.shift(1)).dropna()
+rets_1 = (close_data_1/close_data_1.shift(1)).dropna()
 weights_1 = [0.2, 0.2, 0.2, 0.2, 0.2]
 
 
@@ -224,7 +224,7 @@ print(monthly_data_2.std())
 
 
 # %% Plot daily timeline
-rets_2 = np.log(close_data_2[SYMBOLS_2] /
+rets_2 = (close_data_2[SYMBOLS_2] /
                 close_data_2[SYMBOLS_2].shift(1)).dropna()
 
 (close_data_2[SYMBOLS_2] /
@@ -342,7 +342,7 @@ monthly_data_3 = crypto_hist.resample("M").ffill().pct_change()
 
 
 # %% Returns per day
-rets_3 = np.log(crypto_hist[SYMBOLS_3] /
+rets_3 = (crypto_hist[SYMBOLS_3] /
                 crypto_hist[SYMBOLS_3].shift(1)).dropna()
 
 


### PR DESCRIPTION



# Pull Request

<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->


## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the correct branch (master or 4.x)
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

<!--- Describe what you've changed and why. --->
This commit strips out the np.log transformation on rets_1, rets_2, and rets_3,
switching them to raw arithmetic returns via `.pct_change().dropna()` in line
with conventional portfolio return, volatility, and Sharpe ratio calculations.
No downstream functions were altered—they will now consume raw returns directly.

Note: log‐returns are still valuable for their multiplicative additivity. In
future updates, np.log should only be applied once to the AGGREGATED portfolio
return (i.e. after the dot‐product of weights and raw returns) to avoid
nonlinear distortions at the per‐asset level.



### Issue(s) Resolved

<!--- Pull requests should typically resolve at least one—preferably only one— --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line. --->
<!--- However, smaller fixes, maintenance or trivial changes don't need one. --->




Fixes #393


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
