### PR TITLE
Display active player controls below the video, not on top

### DIFF
--- a/doc/_static/css/video_player.css
+++ b/doc/_static/css/video_player.css
@@ -27,6 +27,14 @@
   visibility: visible;
 }
 
+.bd-article .sphinx-contrib-video-container .vjs-controls-enabled.vjs-has-started {
+  margin-bottom: 3em;
+}
+
+.bd-article .sphinx-contrib-video-container .video-js .vjs-control-bar {
+  bottom: -3em;
+}
+
 .bd-article .sphinx-contrib-video-container + p,
 .bd-article .sphinx-contrib-video-container + img {
   margin-top: 1rem;


### PR DESCRIPTION
# Pull Request

<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->


## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the ``master`` branch
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

<!--- Describe what you've changed and why. --->

This PR adds a couple CSS rules to display the video controls below the playing video, and not over the bottom, as it was before.


### Issue(s) Resolved

<!--- Pull requests should typically resolve at least one—preferably only one— --->
<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line. --->
<!--- However, smaller fixes, maintenance or trivial changes don't need one. --->

Video controls now appear below the playing video.


<!--- Thanks for your help making Spyder --->
<!--- and its documentation better for everyone! --->
