### PR TITLE
Update custom styles to avoid an image corner artifact

### DIFF
--- a/doc/_static/css/custom_styles.css
+++ b/doc/_static/css/custom_styles.css
@@ -345,3 +345,9 @@ a.dropdown-link:focus {
 html[data-theme="dark"] img {
   filter: none !important;
 }
+
+/* Override image background color to avoid corner artifact */
+
+html[data-theme="dark"] .bd-content img:not(.only-dark, .dark-light) {
+  background-color: transparent;
+}


### PR DESCRIPTION
# Pull Request

<!--- Before submitting your pull request, --->
<!--- please complete as much as possible of the following checklist: --->


## Pull Request Checklist

* [x] Read and followed this repo's [Contributing Guidelines](https://github.com/spyder-ide/spyder-docs/blob/master/CONTRIBUTING.md)
* [x] Based your PR on the latest version of the ``master`` branch
* [x] Checked your writing carefully for correct English spelling, grammar, etc
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

<!--- Describe what you've changed and why. --->

Theme style gives images a background color which creates an artifact in images with rounded corners in dark mode. Solved by removing the background color on content images for dark mode. 

Before: 

<img width="41" height="47" alt="imagen" src="https://github.com/user-attachments/assets/08be35a8-c672-44cf-bba9-97b33e5d4143" />

After: 

<img width="41" height="47" alt="imagen" src="https://github.com/user-attachments/assets/32481813-f669-4926-875a-82cfb05e987c" />

